### PR TITLE
feat: implement slider on create site form

### DIFF
--- a/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
+++ b/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
@@ -120,11 +120,11 @@ function SoilsSurfaceAreasForm({
     ...watchSoils[index],
   }));
 
-  const totalAllowedSurface = useMemo(
+  const totalAllocatedSurface = useMemo(
     () => getTotalSurface(controlledSoilsFields),
     [controlledSoilsFields],
   );
-  const remainingSurface = totalSurfaceArea - totalAllowedSurface;
+  const freeSurface = totalSurfaceArea - totalAllocatedSurface;
   const totalFlatSurface = useMemo(
     () => getTotalFlatSurface(controlledSoilsFields),
     [controlledSoilsFields],
@@ -175,7 +175,7 @@ function SoilsSurfaceAreasForm({
               control={control}
               name={`soilsSurfaceAreas.${index}.surface`}
               label={getLabelForSoilType(soilType)}
-              maxAllowed={remainingSurface + surface}
+              maxAllowed={freeSurface + surface}
               hintText={hintText}
               sliderProps={{
                 min: 0,
@@ -231,13 +231,13 @@ function SoilsSurfaceAreasForm({
           label="Total de toutes les surfaces allouées"
           hintText="en m²"
           nativeInputProps={{
-            value: totalAllowedSurface,
+            value: totalAllocatedSurface,
             max: totalSurfaceArea,
           }}
           disabled
-          state={totalAllowedSurface < totalSurfaceArea ? "error" : "default"}
+          state={totalAllocatedSurface < totalSurfaceArea ? "error" : "default"}
           stateRelatedMessage={`- ${formatNumberFr(
-            totalSurfaceArea - totalAllowedSurface,
+            totalSurfaceArea - totalAllocatedSurface,
           )} m²`}
         />
         <Button nativeButtonProps={{ type: "submit" }}>Suivant</Button>

--- a/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
+++ b/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
@@ -87,6 +87,12 @@ const getAvailableSoilTypes = (soilsSurfaceAreas: SoilsSurfaceAreas[]) => {
   return SOIL_TYPES.filter((soilType) => !selectedSoilTypes.includes(soilType));
 };
 
+const SLIDER_PROPS = {
+  tooltip: {
+    formatter: (value?: number) => value && `${formatNumberFr(value)} m²`,
+  },
+};
+
 function SoilsSurfaceAreasForm({
   onSubmit,
   totalSurfaceArea,
@@ -175,16 +181,13 @@ function SoilsSurfaceAreasForm({
               control={control}
               name={`soilsSurfaceAreas.${index}.surface`}
               label={getLabelForSoilType(soilType)}
-              maxAllowed={freeSurface + surface}
+              maxValue={freeSurface + surface}
               hintText={hintText}
+              sliderStartValue={0}
+              sliderEndValue={totalSurfaceArea}
               sliderProps={{
-                min: 0,
                 marks,
-                max: totalSurfaceArea,
-                tooltip: {
-                  formatter: (value?: number) =>
-                    value && `${formatNumberFr(value)} m²`,
-                },
+                ...SLIDER_PROPS,
               }}
             />
           );

--- a/apps/web/src/features/create-site/views/soil-contamination/SoilContaminationForm.tsx
+++ b/apps/web/src/features/create-site/views/soil-contamination/SoilContaminationForm.tsx
@@ -1,11 +1,13 @@
 import { useForm } from "react-hook-form";
 import Button from "@codegouvfr/react-dsfr/Button";
 
-import NumericInput from "@/shared/views/components/form/NumericInput/NumericInput";
+import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
+import SliderNumericInput from "@/shared/views/components/form/NumericInput/SliderNumericInput";
 import RadioButtons from "@/shared/views/components/RadioButtons/RadioButtons";
 
 type Props = {
   onSubmit: (data: FormValues) => void;
+  surfaceArea: number;
 };
 
 type HasContaminatedSoilsString = "yes" | "no";
@@ -18,7 +20,7 @@ type FormValues = {
 const requiredMessage =
   "Ce champ est nécessaire pour déterminer les questions suivantes";
 
-function SoilContaminationForm({ onSubmit }: Props) {
+function SoilContaminationForm({ onSubmit, surfaceArea }: Props) {
   const { register, control, handleSubmit, formState, watch } =
     useForm<FormValues>({
       shouldUnregister: true,
@@ -55,13 +57,24 @@ function SoilContaminationForm({ onSubmit }: Props) {
           error={hasContaminatedSoilsError}
         />
         {watch("hasContaminatedSoils") === "yes" && (
-          <NumericInput
-            name="contaminatedSurface"
-            label="Superficie polluée"
-            hintText="en m2"
-            rules={{ required: "Ce champ est requis" }}
-            control={control}
-          />
+          <div className="fr-pb-7v">
+            <SliderNumericInput
+              control={control}
+              name="contaminatedSurface"
+              label="Superficie polluée"
+              hintText="en m2"
+              required="Ce champ est requis"
+              minValue={5}
+              sliderStartValue={0}
+              sliderEndValue={surfaceArea}
+              sliderProps={{
+                tooltip: {
+                  formatter: (value?: number) =>
+                    value && `${formatNumberFr(value)} m²`,
+                },
+              }}
+            />
+          </div>
         )}
         <Button nativeButtonProps={{ type: "submit" }}>Suivant</Button>
       </form>

--- a/apps/web/src/features/create-site/views/soil-contamination/index.tsx
+++ b/apps/web/src/features/create-site/views/soil-contamination/index.tsx
@@ -5,11 +5,15 @@ import {
   setContaminatedSoilSurface,
   SiteCreationStep,
 } from "@/features/create-site/application/createSite.reducer";
-import { useAppDispatch } from "@/shared/views/hooks/store.hooks";
+import {
+  useAppDispatch,
+  useAppSelector,
+} from "@/shared/views/hooks/store.hooks";
 import { AppDispatch } from "@/store";
 
-const mapProps = (dispatch: AppDispatch) => {
+const mapProps = (dispatch: AppDispatch, surfaceArea: number) => {
   return {
+    surfaceArea,
     onSubmit: (data: { contaminatedSurface: number }) => {
       dispatch(setContaminatedSoilSurface(data.contaminatedSurface ?? 0));
       dispatch(goToStep(SiteCreationStep.MANAGEMENT_INTRODUCTION));
@@ -19,8 +23,11 @@ const mapProps = (dispatch: AppDispatch) => {
 
 function SoilContaminationFormController() {
   const dispatch = useAppDispatch();
+  const surfaceArea = useAppSelector(
+    (state) => state.siteCreation.siteData.surfaceArea ?? 0,
+  );
 
-  return <SoilContaminationForm {...mapProps(dispatch)} />;
+  return <SoilContaminationForm {...mapProps(dispatch, surfaceArea)} />;
 }
 
 export default SoilContaminationFormController;

--- a/apps/web/src/features/create-site/views/soils/soils-surface-areas/SoilsSurfaceAreasForm.tsx
+++ b/apps/web/src/features/create-site/views/soils/soils-surface-areas/SoilsSurfaceAreasForm.tsx
@@ -27,6 +27,12 @@ const getInitialSurfacesFormSoilTypes = (soils: SoilType[]) =>
     {},
   );
 
+const SLIDER_PROPS = {
+  tooltip: {
+    formatter: (value?: number) => value && `${formatNumberFr(value)} m²`,
+  },
+};
+
 function SiteSoilsSurfaceAreasForm({
   soils,
   totalSurfaceArea,
@@ -66,21 +72,13 @@ function SiteSoilsSurfaceAreasForm({
             name={soilType}
             label={getLabelForSoilType(soilType)}
             hintText="en m2"
-            maxAllowed={freeSurface + soilsValues[soilType]}
-            sliderProps={{
-              min: 0,
-              max: totalSurfaceArea,
-              tooltip: {
-                formatter: (value?: number) =>
-                  value && `${formatNumberFr(value)} m²`,
-              },
-            }}
+            sliderStartValue={0}
+            sliderEndValue={totalSurfaceArea}
+            maxValue={freeSurface + soilsValues[soilType]}
+            sliderProps={SLIDER_PROPS}
           />
         ))}
-        <div
-          className="fr-py-7v"
-          style={{ display: "flex", justifyContent: "space-between" }}
-        >
+        <div className="fr-py-7v">
           <Button
             onClick={() => reset(defaultValues)}
             priority="secondary"


### PR DESCRIPTION
- Ajout du composant SliderNumericInput sur les pages soil-contamination `SoilContaminationForm` et `SoilsSurfaceAreasForm` dans le formulaire de création de site
- Renommage de certaines variables dans `SoilsSurfaceAreasForm` de `create-project` pour clarifier et aligner sur celui de `create-site`
- Refacto des props de `SliderNumericInput` pour clarifier la différence entre les min et max qui représente les extrémités du slider et les min et max qui représente les valeurs max et min que l’on peut atteindre sur le slider.