### PR TITLE
fixes sur les formulaires de création de site et de projet

### DIFF
--- a/apps/web/src/features/create-project/domain/project.types.ts
+++ b/apps/web/src/features/create-project/domain/project.types.ts
@@ -120,7 +120,7 @@ const getPrevisionalEnrSocioEconomicImpactPerHectare = (
     case RenewableEnergyType.GEOTHERMAL:
       return 10000;
     case RenewableEnergyType.PHOTOVOLTAIC:
-      return -10000;
+      return 10000;
   }
 };
 

--- a/apps/web/src/features/create-project/views/costs/photovoltaic-panels-installation-costs/PhotoVoltaicPanelsInstallationCostsForm.tsx
+++ b/apps/web/src/features/create-project/views/costs/photovoltaic-panels-installation-costs/PhotoVoltaicPanelsInstallationCostsForm.tsx
@@ -32,18 +32,36 @@ const PhotovoltaicPanelsInstallationCostsForm = ({ onSubmit }: Props) => {
           label="Travaux"
           hintText="€"
           name="worksAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Études et honoraires techniques"
           hintText="€"
           name="technicalStudyAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Frais divers"
           hintText="€"
           name="otherAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <p>
           <strong>

--- a/apps/web/src/features/create-project/views/costs/reinstatement-costs/ReinstatementCostsForm.tsx
+++ b/apps/web/src/features/create-project/views/costs/reinstatement-costs/ReinstatementCostsForm.tsx
@@ -40,36 +40,72 @@ const ReinstatementsCostsForm = ({ onSubmit }: Props) => {
           label="Enlèvement des déchets"
           hintText="€"
           name="wasteCollectionAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Désamiantage"
           hintText="€"
           name="asbestosRemovalAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Déconstruction"
           hintText="€"
           name="demolitionAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Dépollution"
           hintText="€"
           name="remediationAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Désimperméabilisation"
           hintText="€"
           name="deimpermeabilizationAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Restauration écologique des sols"
           hintText="€"
           name="sustainableSoilsReinstatementAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <p>
           <strong>

--- a/apps/web/src/features/create-project/views/costs/yearly-projected-costs/YearlyProjectedCostsForm.tsx
+++ b/apps/web/src/features/create-project/views/costs/yearly-projected-costs/YearlyProjectedCostsForm.tsx
@@ -33,24 +33,48 @@ const YearlyProjectedCostsForm = ({ onSubmit }: Props) => {
           label="Loyer"
           hintText="€"
           name="rentAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Maintenance"
           hintText="€"
           name="maintenanceAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Taxes et impôts"
           hintText="€"
           name="taxesAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Autres dépenses"
           hintText="€"
           name="otherAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <p>
           <strong>

--- a/apps/web/src/features/create-project/views/revenue/financial-assistance/ProjectFinancialAssistanceRevenueForm.tsx
+++ b/apps/web/src/features/create-project/views/revenue/financial-assistance/ProjectFinancialAssistanceRevenueForm.tsx
@@ -32,18 +32,36 @@ const ProjectFinancialAssistanceRevenueForm = ({ onSubmit }: Props) => {
           label="Participation des collectivités"
           hintText="€"
           name="localOrRegionalAuthorityAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Subvention publiques"
           hintText="€"
           name="publicSubsidiesAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Autres ressources"
           hintText="€"
           name="otherAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <p>
           <strong>

--- a/apps/web/src/features/create-project/views/revenue/yearly-projected-revenue/ProjectYearlyProjectedRevenueForm.tsx
+++ b/apps/web/src/features/create-project/views/revenue/yearly-projected-revenue/ProjectYearlyProjectedRevenueForm.tsx
@@ -31,12 +31,24 @@ const ProjectYearlyProjectedRevenueForm = ({ onSubmit }: Props) => {
           label="Recettes d'exploitation"
           hintText="€ / an"
           name="operationsAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <NumericInput
           control={control}
           label="Autres recettes"
           hintText="€ / an"
           name="otherAmount"
+          rules={{
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <p>
           <strong>

--- a/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
+++ b/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
@@ -158,7 +158,8 @@ function SoilsSurfaceAreasForm({
         <p>
           Les <strong>sols minéraux</strong> devraient faire au minimum{" "}
           {formatNumberFr(minAdvisedSoilSurfacesByType[SoilType.MINERAL_SOIL])}{" "}
-          m2. C’est la superficie requise <strong>les pistes d’accès</strong>.
+          m2. C’est la superficie requise pour{" "}
+          <strong>les pistes d’accès</strong>.
         </p>
       )}
 

--- a/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
+++ b/apps/web/src/features/create-project/views/soils-surface-areas/SoilsSurfaceAreasForm.tsx
@@ -43,37 +43,6 @@ const computeDefaultValues = (
   return siteSoilsAsArray as SoilsSurfaceAreas[];
 };
 
-const getHintTextAndMarks = ({
-  existingSurface,
-  minAdvisedSurface,
-}: {
-  existingSurface?: number;
-  minAdvisedSurface?: number;
-}) => {
-  const marks = [];
-
-  const hintSurfaceText = `Actuellement : ${formatNumberFr(
-    existingSurface ?? 0,
-  )} m²`;
-  let hintAdvisedSurfaceText = "";
-
-  if (minAdvisedSurface) {
-    hintAdvisedSurfaceText = ` - Minimum conseillé : ${formatNumberFr(
-      minAdvisedSurface,
-    )} m²`;
-    marks.push([minAdvisedSurface, `${formatNumberFr(minAdvisedSurface)} m²`]);
-  }
-
-  if (existingSurface) {
-    marks.push([existingSurface, `${formatNumberFr(existingSurface)} m²`]);
-  }
-
-  return {
-    hintText: `${hintSurfaceText}${hintAdvisedSurfaceText}`,
-    marks: Object.fromEntries(marks) as Record<number, string>,
-  };
-};
-
 const getTotalSurface = (soilsSurfaceAreas: SoilsSurfaceAreas[]) =>
   soilsSurfaceAreas.reduce((total, { surface }) => total + surface, 0);
 const getTotalFlatSurface = (soilsSurfaceAreas: SoilsSurfaceAreas[]) =>
@@ -172,10 +141,7 @@ function SoilsSurfaceAreasForm({
 
       <form onSubmit={handleSubmit(onSubmit)}>
         {controlledSoilsFields.map(({ soilType, surface, id }, index) => {
-          const { hintText, marks } = getHintTextAndMarks({
-            existingSurface: siteSoils[soilType],
-            minAdvisedSurface: minAdvisedSoilSurfacesByType[soilType],
-          });
+          const minAdvisedSurface = minAdvisedSoilSurfacesByType[soilType];
           return (
             <SliderNumericInput
               key={id}
@@ -183,11 +149,29 @@ function SoilsSurfaceAreasForm({
               name={`soilsSurfaceAreas.${index}.surface`}
               label={getLabelForSoilType(soilType)}
               maxValue={freeSurface + surface}
-              hintText={hintText}
+              hintText={`Actuellement : ${formatNumberFr(
+                siteSoils[soilType] ?? 0,
+              )} m²${
+                minAdvisedSurface
+                  ? ` - Minimum conseillé : ${formatNumberFr(
+                      minAdvisedSurface,
+                    )} m²`
+                  : ""
+              }`}
               sliderStartValue={0}
               sliderEndValue={totalSurfaceArea}
               sliderProps={{
-                marks,
+                marks: {
+                  0: "0",
+                  [totalSurfaceArea]: formatNumberFr(totalSurfaceArea),
+                  ...(minAdvisedSurface
+                    ? {
+                        [minAdvisedSurface]: `${formatNumberFr(
+                          minAdvisedSurface,
+                        )} m²`,
+                      }
+                    : {}),
+                },
                 ...SLIDER_PROPS,
               }}
             />

--- a/apps/web/src/features/create-project/views/stakeholders/conversion-full-time-jobs-involved/ConversionFullTimeJobsInvolvedForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/conversion-full-time-jobs-involved/ConversionFullTimeJobsInvolvedForm.tsx
@@ -32,14 +32,26 @@ function ConversionFullTimeJobsInvolvedForm({
             control={control}
             name="reinstatementFullTimeJobsInvolved"
             label="Remise en état de la friche"
-            rules={{ required: "Ce champ est requis" }}
+            rules={{
+              required: "Ce champ est requis",
+              min: {
+                value: 0,
+                message: "Veuillez sélectionner un montant valide",
+              },
+            }}
           />
         )}
         <NumericInput
           control={control}
           name="fullTimeJobs"
           label="Installation des panneaux photovoltaïques"
-          rules={{ required: "Ce champ est requis" }}
+          rules={{
+            required: "Ce champ est requis",
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <ButtonsGroup
           buttonsEquisized

--- a/apps/web/src/features/create-project/views/stakeholders/operations-full-time-jobs-involved/OperationsFullTimeJobsInvolvedForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/operations-full-time-jobs-involved/OperationsFullTimeJobsInvolvedForm.tsx
@@ -25,7 +25,13 @@ function OperationsFullTimeJobsInvolvedForm({ onSubmit }: Props) {
           control={control}
           name="fullTimeJobs"
           label="Maintenance des panneaux photovoltaïques"
-          rules={{ required: "Ce champ est requis" }}
+          rules={{
+            required: "Ce champ est requis",
+            min: {
+              value: 0,
+              message: "Veuillez sélectionner un montant valide",
+            },
+          }}
         />
         <ButtonsGroup
           buttonsEquisized

--- a/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/SiteReinstatementContractOwnerForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/SiteReinstatementContractOwnerForm.tsx
@@ -93,7 +93,7 @@ function SiteReinstatementContractOwnerForm({
         ?
       </h2>
       <p>
-        Les travaux de remise en état incluent la désimperméabimisation des
+        Les travaux de remise en état incluent la désimperméabilisation des
         sols, la dépollution, l’enlèvement des déchets, la déconstruction, etc.
       </p>
       <form onSubmit={handleSubmit(onSubmit)}>

--- a/apps/web/src/features/create-site/application/createSite.actions.ts
+++ b/apps/web/src/features/create-site/application/createSite.actions.ts
@@ -26,7 +26,7 @@ const createSiteSchema = z.object({
   contaminatedSoilSurface: z.number().nonnegative().optional(),
   fricheActivity: z.nativeEnum(FricheActivity).optional(),
   // management
-  fullTimeJobsInvolved: z.number().nonnegative(),
+  fullTimeJobsInvolved: z.number().nonnegative().optional(),
   owner: z.object({
     structureType: z.string(),
     name: z.string().optional(),


### PR DESCRIPTION
- fix de typos
- empêcher les valeurs négatives sur les champs numériques du parcours projet
- J’ai ajouté le `optional` dans le schéma de validation du site pour `fullTimeJobsInvolved` pour résoudre l’incohérence avec le form (je validerai mercredi avec Chloë et si c’était l’inverse, je fixerais)
- j’ai changé la valeur d’impacts prévisionnel sur photovoltaïque pour éviter de montrer un impact négatif pour le test
- Correction d’un bug sur l’input associé au slider de surfaces 
- Ajout de marker pour le min et le max sur le slider, pour qu’il soit plus agréable à utiliser si on veut rapidement mettre à 0 ou au max

