### PR TITLE
fix: use carbon storage per square meters instead of superficie in Carbon Storage graph

### DIFF
--- a/apps/api/src/carbon-storage/adapters/primary/carbonStorage.controller.integration-spec.ts
+++ b/apps/api/src/carbon-storage/adapters/primary/carbonStorage.controller.integration-spec.ts
@@ -76,9 +76,11 @@ describe("CarbonStorage controller", () => {
             type: SoilCategoryType.CULTIVATION,
             surfaceArea: 1500,
             carbonStorage: 8.25,
+            carbonStorageInTonPerSquareMeters: 0.0055,
           },
           {
             type: SoilCategoryType.FOREST_DECIDUOUS,
+            carbonStorageInTonPerSquareMeters: 0.021887,
             surfaceArea: 3000,
             carbonStorage: 65.661,
           },

--- a/apps/api/src/carbon-storage/domain/models/carbonStorage.ts
+++ b/apps/api/src/carbon-storage/domain/models/carbonStorage.ts
@@ -41,7 +41,7 @@ export enum LocalisationCategoryType {
 export type CarbonStorageProps = {
   reservoir: ReservoirType;
   soil_category: RepositorySoilCategoryType;
-  stock_tC_by_ha: number;
+  stock_tC_by_ha: string;
   localisation_category: LocalisationCategoryType;
   localisation_code: string;
 };
@@ -65,7 +65,7 @@ export class CarbonStorage {
     return new CarbonStorage(
       reservoir,
       soil_category,
-      stock_tC_by_ha,
+      parseFloat(stock_tC_by_ha),
       localisation_category,
       localisation_code,
     );
@@ -75,7 +75,7 @@ export class CarbonStorage {
     return {
       reservoir: this.reservoir,
       soil_category: this.soilCategory,
-      stock_tC_by_ha: this.carbonStorageInTonByHectare,
+      stock_tC_by_ha: this.carbonStorageInTonByHectare.toString(),
       localisation_category: this.localisationCategory,
       localisation_code: this.localisationCode,
     };

--- a/apps/api/src/carbon-storage/domain/usecases/getCityCarbonStoragePerSoilsCategory.spec.ts
+++ b/apps/api/src/carbon-storage/domain/usecases/getCityCarbonStoragePerSoilsCategory.spec.ts
@@ -98,11 +98,13 @@ describe("GetTownCarbonStocksPerSoilsCategoryUseCase", () => {
           type: SoilCategoryType.CULTIVATION,
           surfaceArea: 15000,
           carbonStorage: 75,
+          carbonStorageInTonPerSquareMeters: 0.005,
         },
         {
           type: SoilCategoryType.FOREST_DECIDUOUS,
           surfaceArea: 30000,
           carbonStorage: 557.61,
+          carbonStorageInTonPerSquareMeters: 0.018587,
         },
       ],
     });
@@ -137,16 +139,19 @@ describe("GetTownCarbonStocksPerSoilsCategoryUseCase", () => {
           type: SoilCategoryType.IMPERMEABLE_SOILS,
           surfaceArea: 15000,
           carbonStorage: CARBON_STORAGE_BY_HECTARE_FOR_IMPERMEABLE_SOILS * 1.5,
+          carbonStorageInTonPerSquareMeters: 0.003,
         },
         {
           type: SoilCategoryType.BUILDINGS,
           surfaceArea: 30000,
           carbonStorage: CARBON_STORAGE_BY_HECTARE_FOR_IMPERMEABLE_SOILS * 3,
+          carbonStorageInTonPerSquareMeters: 0.003,
         },
         {
           type: SoilCategoryType.MINERAL_SOIL,
           surfaceArea: 20000,
           carbonStorage: CARBON_STORAGE_BY_HECTARE_FOR_IMPERMEABLE_SOILS * 2,
+          carbonStorageInTonPerSquareMeters: 0.003,
         },
       ],
     });
@@ -171,6 +176,7 @@ describe("GetTownCarbonStocksPerSoilsCategoryUseCase", () => {
           type: SoilCategoryType.WATER,
           surfaceArea: 15000,
           carbonStorage: 0,
+          carbonStorageInTonPerSquareMeters: 0,
         },
       ],
     });

--- a/apps/api/src/carbon-storage/domain/usecases/getCityCarbonStoragePerSoilsCategory.ts
+++ b/apps/api/src/carbon-storage/domain/usecases/getCityCarbonStoragePerSoilsCategory.ts
@@ -14,8 +14,9 @@ type Request = {
 type Response = {
   totalCarbonStorage: number;
   soilsCarbonStorage: {
-    surfaceArea: SurfaceAreaType;
-    carbonStorage: number; // m2
+    surfaceArea: SurfaceAreaType; // m²
+    carbonStorage: number;
+    carbonStorageInTonPerSquareMeters: number;
     type: SoilCategoryType;
   }[];
 };
@@ -33,15 +34,17 @@ export class GetCityCarbonStoragePerSoilsCategoryUseCase implements UseCase<Requ
       const entriesForCategory = carbonStorage.filter(
         ({ soilCategory }) => soilCategory === type.getRepositorySoilCategory(),
       );
-      const totalForCategory = entriesForCategory.reduce(
-        (total, { carbonStorageInTonByHectare }) =>
-          total + carbonStorageInTonByHectare * surfaceArea.getInHectares(),
+      const totalCarbonStoragePerHectare = entriesForCategory.reduce(
+        (total, { carbonStorageInTonByHectare }) => total + carbonStorageInTonByHectare,
         0,
       );
+      const carbonStorageInTonPerSquareMeters = totalCarbonStoragePerHectare / 10000;
+      const totalForCategory = carbonStorageInTonPerSquareMeters * surfaceArea.getInSquareMeters();
       return {
         type: type.getValue(),
         surfaceArea: surfaceArea.getInSquareMeters(),
         carbonStorage: totalForCategory,
+        carbonStorageInTonPerSquareMeters,
       };
     });
 

--- a/apps/api/src/shared-kernel/adapters/sql-knex/seeds/carbonStorage.ts
+++ b/apps/api/src/shared-kernel/adapters/sql-knex/seeds/carbonStorage.ts
@@ -19,26 +19,21 @@ const readCsvData = async () => {
       if (line === HEADER) {
         return;
       }
-      const [
-        reservoir,
-        soilCategory,
-        carbonStorageInTonByHectare,
-        localisationCategory,
-        localisationCode,
-      ] = line.split(",") as [
-        CarbonStorage["reservoir"],
-        CarbonStorage["soilCategory"],
-        CarbonStorage["carbonStorageInTonByHectare"],
-        CarbonStorage["localisationCategory"],
-        CarbonStorage["localisationCode"],
-      ];
+      const [reservoir, soil_category, stock_tC_by_ha, localisation_category, localisation_code] =
+        line.split(",") as [
+          CarbonStorageProps["reservoir"],
+          CarbonStorageProps["soil_category"],
+          CarbonStorageProps["stock_tC_by_ha"],
+          CarbonStorageProps["localisation_category"],
+          CarbonStorageProps["localisation_code"],
+        ];
       data.push(
         CarbonStorage.create({
           reservoir,
-          soil_category: soilCategory,
-          stock_tC_by_ha: carbonStorageInTonByHectare,
-          localisation_category: localisationCategory,
-          localisation_code: localisationCode,
+          soil_category,
+          stock_tC_by_ha,
+          localisation_category,
+          localisation_code,
         }).toDatabaseFormat(),
       );
     });

--- a/apps/web/src/features/create-project/application/soilsCarbonStorage.actions.ts
+++ b/apps/web/src/features/create-project/application/soilsCarbonStorage.actions.ts
@@ -7,6 +7,7 @@ export type SoilsCarbonStorageResult = {
     type: SoilType;
     surfaceArea: number;
     carbonStorage: number;
+    carbonStorageInTonPerSquareMeters: number;
   }[];
 };
 

--- a/apps/web/src/features/create-project/application/soilsCarbonStorage.reducer.spec.ts
+++ b/apps/web/src/features/create-project/application/soilsCarbonStorage.reducer.spec.ts
@@ -13,8 +13,18 @@ import { getTestAppDependencies } from "@/test/testAppDependencies";
 const SOILS_STORAGE_API_MOCKED_RESULT = {
   totalCarbonStorage: 350,
   soilsStorage: [
-    { type: SoilType.BUILDINGS, carbonStorage: 30, surfaceArea: 1400 },
-    { type: SoilType.MINERAL_SOIL, carbonStorage: 320, surfaceArea: 5000 },
+    {
+      type: SoilType.BUILDINGS,
+      carbonStorage: 30,
+      surfaceArea: 1400,
+      carbonStorageInTonPerSquareMeters: 0.021,
+    },
+    {
+      type: SoilType.MINERAL_SOIL,
+      carbonStorage: 320,
+      surfaceArea: 5000,
+      carbonStorageInTonPerSquareMeters: 0.064,
+    },
   ],
 };
 

--- a/apps/web/src/features/create-site/application/siteSoilsCarbonStorage.actions.ts
+++ b/apps/web/src/features/create-site/application/siteSoilsCarbonStorage.actions.ts
@@ -14,6 +14,7 @@ export type SiteSoilsCarbonStorageResult = {
     type: SoilType;
     surfaceArea: number;
     carbonStorage: number;
+    carbonStorageInTonPerSquareMeters: number;
   }[];
 };
 

--- a/apps/web/src/features/create-site/application/siteSoilsCarbonStorage.reducer.spec.ts
+++ b/apps/web/src/features/create-site/application/siteSoilsCarbonStorage.reducer.spec.ts
@@ -10,8 +10,18 @@ describe("Site carbon sequestration reducer", () => {
     const mockedResult = {
       totalCarbonStorage: 350,
       soilsStorage: [
-        { type: SoilType.BUILDINGS, carbonStorage: 30, surfaceArea: 1400 },
-        { type: SoilType.MINERAL_SOIL, carbonStorage: 320, surfaceArea: 5000 },
+        {
+          type: SoilType.BUILDINGS,
+          carbonStorage: 30,
+          surfaceArea: 1400,
+          carbonStorageInTonPerSquareMeters: 0.021,
+        },
+        {
+          type: SoilType.MINERAL_SOIL,
+          carbonStorage: 320,
+          surfaceArea: 5000,
+          carbonStorageInTonPerSquareMeters: 0.064,
+        },
       ],
     };
     const store = createStore(

--- a/apps/web/src/features/create-site/application/siteSoilsCarbonStorage.reducer.ts
+++ b/apps/web/src/features/create-site/application/siteSoilsCarbonStorage.reducer.ts
@@ -7,7 +7,12 @@ type LoadingState = "idle" | "loading" | "success" | "error";
 
 export type SiteCarbonStorage = {
   total: number;
-  soils: { type: SoilType; surfaceArea: number; carbonStorage: number }[];
+  soils: {
+    type: SoilType;
+    surfaceArea: number;
+    carbonStorage: number;
+    carbonStorageInTonPerSquareMeters: number;
+  }[];
 };
 
 export type State = {

--- a/apps/web/src/features/projects/application/projectImpacts.actions.ts
+++ b/apps/web/src/features/projects/application/projectImpacts.actions.ts
@@ -10,6 +10,7 @@ export type SoilsCarbonStorageResult = {
     type: SoilType;
     surfaceArea: number;
     carbonStorage: number;
+    carbonStorageInTonPerSquareMeters: number;
   }[];
 };
 

--- a/apps/web/src/features/projects/application/projectImpacts.reducer.spec.ts
+++ b/apps/web/src/features/projects/application/projectImpacts.reducer.spec.ts
@@ -13,8 +13,18 @@ import { getTestAppDependencies } from "@/test/testAppDependencies";
 const SOILS_STORAGE_API_MOCKED_RESULT = {
   totalCarbonStorage: 350,
   soilsStorage: [
-    { type: SoilType.BUILDINGS, carbonStorage: 30, surfaceArea: 1400 },
-    { type: SoilType.MINERAL_SOIL, carbonStorage: 320, surfaceArea: 5000 },
+    {
+      type: SoilType.BUILDINGS,
+      carbonStorage: 30,
+      surfaceArea: 1400,
+      carbonStorageInTonPerSquareMeters: 0.021,
+    },
+    {
+      type: SoilType.MINERAL_SOIL,
+      carbonStorage: 320,
+      surfaceArea: 5000,
+      carbonStorageInTonPerSquareMeters: 0.064,
+    },
   ],
 };
 

--- a/apps/web/src/features/projects/application/projectImpactsComparison.actions.ts
+++ b/apps/web/src/features/projects/application/projectImpactsComparison.actions.ts
@@ -10,6 +10,7 @@ type SoilsCarbonStorageResult = {
     type: SoilType;
     surfaceArea: number;
     carbonStorage: number;
+    carbonStorageInTonPerSquareMeters: number;
   }[];
 };
 

--- a/apps/web/src/features/projects/application/projectImpactsComparison.reducer.spec.ts
+++ b/apps/web/src/features/projects/application/projectImpactsComparison.reducer.spec.ts
@@ -13,8 +13,18 @@ import { getTestAppDependencies } from "@/test/testAppDependencies";
 const SOILS_STORAGE_API_MOCKED_RESULT = {
   totalCarbonStorage: 350,
   soilsStorage: [
-    { type: SoilType.BUILDINGS, carbonStorage: 30, surfaceArea: 1400 },
-    { type: SoilType.MINERAL_SOIL, carbonStorage: 320, surfaceArea: 5000 },
+    {
+      type: SoilType.BUILDINGS,
+      carbonStorage: 30,
+      surfaceArea: 1400,
+      carbonStorageInTonPerSquareMeters: 0.021,
+    },
+    {
+      type: SoilType.MINERAL_SOIL,
+      carbonStorage: 320,
+      surfaceArea: 5000,
+      carbonStorageInTonPerSquareMeters: 0.064,
+    },
   ],
 };
 

--- a/apps/web/src/shared/views/components/Charts/SoilsCarbonStorageChart.tsx
+++ b/apps/web/src/shared/views/components/Charts/SoilsCarbonStorageChart.tsx
@@ -6,7 +6,6 @@ import HighchartsReact from "highcharts-react-official";
 
 import { getColorForSoilType, SoilType } from "@/shared/domain/soils";
 import { getLabelForSoilType } from "@/shared/services/label-mapping/soilTypeLabelMapping";
-import { convertSquareMetersToHectares } from "@/shared/services/surface-area/surfaceArea";
 highchartsVariablePie(Highcharts);
 
 type Props = {
@@ -14,6 +13,7 @@ type Props = {
     type: SoilType;
     surfaceArea: number;
     carbonStorage: number;
+    carbonStorageInTonPerSquareMeters: number;
   }[];
 };
 
@@ -28,26 +28,34 @@ const SoilsCarbonStorageChart = ({ soilsCarbonStorage }: Props) => {
         fontFamily: "Marianne",
       },
     },
-    tooltip: {
-      distance: 40,
-      pointFormat:
-        "Superficie : <strong>{point.y:.2f} ha ({point.percentage:.1f}%)</strong><br>Carbone stockable: <strong>{point.z:.2f} t/ha</strong>",
-    },
     credits: {
       enabled: false,
     },
-    plotOptions: { variablepie: { cursor: "pointer" } },
+    tooltip: {
+      distance: 40,
+      pointFormat:
+        "<strong>{point.y:.2f} T de carbone stockées</strong><br>" +
+        "Superficie : {point.options.custom.superficie} m²<br>" +
+        "Carbone stockable / m² : {point.z:.4f} T",
+    },
+    plotOptions: {
+      series: {
+        keys: ["name", "z", "y", "custom.superficie", "color"],
+      },
+      variablepie: { cursor: "pointer" },
+    },
     series: [
       {
         name: "",
         type: "variablepie",
         zMin: 0,
-        data: soilsCarbonStorage.map((soilData) => ({
-          y: convertSquareMetersToHectares(soilData.surfaceArea),
-          z: soilData.carbonStorage,
-          name: getLabelForSoilType(soilData.type),
-          color: getColorForSoilType(soilData.type as SoilType),
-        })),
+        data: soilsCarbonStorage.map((soilData) => [
+          getLabelForSoilType(soilData.type),
+          soilData.carbonStorageInTonPerSquareMeters,
+          soilData.carbonStorage,
+          soilData.surfaceArea,
+          getColorForSoilType(soilData.type as SoilType),
+        ]),
       },
     ],
   };


### PR DESCRIPTION
1. Changement de données pour le graphe de stockage de carbone (formulaire site et projet) : 
- axe y : total carbone stocké pour le type de sol
- axe z : carbone stocké par m² pour le type de sol

![image](https://github.com/incubateur-ademe/benefriches/assets/25612600/830af6d3-71c4-46a2-ac80-3f1646a6a54c)

2. Modification du tooltip 


