### PR TITLE
feat: use PGVIS api to compute expected PV annual power performance

### DIFF
--- a/apps/api/src/location-features/adapters/primary/locationFeatures.controller.integration-spec.ts
+++ b/apps/api/src/location-features/adapters/primary/locationFeatures.controller.integration-spec.ts
@@ -1,7 +1,10 @@
 import { INestApplication } from "@nestjs/common";
 import { Test as NestTest } from "@nestjs/testing";
 import supertest from "supertest";
+import { AppModule } from "src/app.module";
+import { GetPhotovoltaicExpectedPerformanceUseCase } from "src/location-features/domain/usecases/getPhotovoltaicExpectedPerformanceUseCase";
 import { GetTownPopulationDensityUseCase } from "src/location-features/domain/usecases/getTownPopulationDensity.usecase";
+import { MockPhotovoltaicGeoInfoSystemApi } from "../secondary/photovoltaic-data-provider/PhotovoltaicGeoInfoSystemApi.mock";
 import { MockLocalDataInseeService } from "../secondary/town-data-provider/LocalDataInseeService.mock";
 import { LocationFeaturesController } from "./locationFeatures.controller";
 
@@ -10,6 +13,8 @@ describe("LocationFeatures controller", () => {
 
   beforeAll(async () => {
     const moduleRef = await NestTest.createTestingModule({
+      imports: [AppModule],
+
       controllers: [LocationFeaturesController],
       providers: [
         {
@@ -21,6 +26,16 @@ describe("LocationFeatures controller", () => {
           useFactory: (townDataProvider: MockLocalDataInseeService) =>
             new GetTownPopulationDensityUseCase(townDataProvider),
           inject: ["TownDataProvider"],
+        },
+        {
+          provide: "PhotovoltaicDataProvider",
+          useClass: MockPhotovoltaicGeoInfoSystemApi,
+        },
+        {
+          provide: GetPhotovoltaicExpectedPerformanceUseCase,
+          useFactory: (dataProvider: MockPhotovoltaicGeoInfoSystemApi) =>
+            new GetPhotovoltaicExpectedPerformanceUseCase(dataProvider),
+          inject: ["PhotovoltaicDataProvider"],
         },
       ],
     }).compile();
@@ -55,6 +70,76 @@ describe("LocationFeatures controller", () => {
           },
           unit: "hab/km2",
           value: 203.6,
+        },
+      });
+    });
+  });
+
+  describe("Get /location-features/pv-expected-performance", () => {
+    it("can't return information if there is no required parameters", async () => {
+      const response = await supertest(app.getHttpServer()).get(
+        "/location-features/pv-expected-performance",
+      );
+
+      expect(response.status).toEqual(400);
+    });
+
+    it("must return error if latitude or longitude parameters are wrong", async () => {
+      const wrongLat = await supertest(app.getHttpServer()).get(
+        "/location-features/pv-expected-performance?long=200&lat=2000&peakPower=3",
+      );
+
+      expect(wrongLat.status).toEqual(400);
+    });
+
+    it("must return error if peakPower is the wrong format", async () => {
+      const wrongPeakPower = await supertest(app.getHttpServer()).get(
+        "/location-features/pv-expected-performance?long=2.347&lat=48.859&peakPower=test",
+      );
+
+      expect(wrongPeakPower.status).toEqual(400);
+
+      const wrongFormat = await supertest(app.getHttpServer()).get(
+        "/location-features/pv-expected-performance?long=2.347&lat=48.859&peakPower=-15",
+      );
+
+      expect(wrongFormat.status).toEqual(400);
+    });
+
+    it("returns the expected power performance for a location and a peak power", async () => {
+      const response = await supertest(app.getHttpServer()).get(
+        "/location-features/pv-expected-performance?long=2.347&lat=48.859&peakPower=3.0",
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        computationContext: {
+          location: { lat: 48.859, long: 2.347, elevation: 49 },
+          dataSources: {
+            radiation: "PVGIS-SARAH2",
+            meteo: "ERA5",
+            period: "2005 - 2020",
+            horizon: "DEM-calculated",
+          },
+          pvInstallation: {
+            technology: "c-Si",
+            peakPower: 3,
+            systemLoss: 14,
+            slope: { value: 35, optimal: false },
+            azimuth: { value: 0, optimal: false },
+            type: "free-standing",
+          },
+        },
+        expectedPerformance: {
+          kwhPerDay: 9.43,
+          kwhPerMonth: 286.91,
+          kwhPerYear: 3442.92,
+          lossPercents: {
+            angleIncidence: -2.98,
+            spectralIncidence: 1.65,
+            tempAndIrradiance: -5.73,
+            total: -20.05,
+          },
         },
       });
     });

--- a/apps/api/src/location-features/adapters/primary/locationFeatures.controller.ts
+++ b/apps/api/src/location-features/adapters/primary/locationFeatures.controller.ts
@@ -1,9 +1,25 @@
 import { BadRequestException, Controller, Get, Query } from "@nestjs/common";
+import { createZodDto } from "nestjs-zod";
+import { z } from "zod";
+import { GetPhotovoltaicExpectedPerformanceUseCase } from "src/location-features/domain/usecases/getPhotovoltaicExpectedPerformanceUseCase";
 import { GetTownPopulationDensityUseCase } from "src/location-features/domain/usecases/getTownPopulationDensity.usecase";
+
+const GetPhotovoltaicExpectedPerformanceDtoSchema = z.object({
+  lat: z.coerce.number().min(-90).max(90),
+  long: z.coerce.number().min(-180).max(180),
+  peakPower: z.coerce.number().nonnegative(),
+});
+
+class GetPhotovoltaicExpectedPerformanceDto extends createZodDto(
+  GetPhotovoltaicExpectedPerformanceDtoSchema,
+) {}
 
 @Controller("location-features")
 export class LocationFeaturesController {
-  constructor(private readonly getTownPopulationDensity: GetTownPopulationDensityUseCase) {}
+  constructor(
+    private readonly getTownPopulationDensity: GetTownPopulationDensityUseCase,
+    private readonly getPhotovoltaicExpectedPerformanceUseCase: GetPhotovoltaicExpectedPerformanceUseCase,
+  ) {}
 
   @Get()
   async getFeaturesFromLocation(@Query("cityCode") cityCode: string) {
@@ -16,5 +32,18 @@ export class LocationFeaturesController {
       populationDensity: density,
       cityCode,
     };
+  }
+
+  @Get("pv-expected-performance")
+  async getPhotovoltaicExpectedPerformance(@Query() query: GetPhotovoltaicExpectedPerformanceDto) {
+    const { lat, long, peakPower } = query;
+
+    const result = await this.getPhotovoltaicExpectedPerformanceUseCase.execute({
+      lat,
+      long,
+      peakPower,
+    });
+
+    return result;
   }
 }

--- a/apps/api/src/location-features/adapters/primary/locationFeatures.module.ts
+++ b/apps/api/src/location-features/adapters/primary/locationFeatures.module.ts
@@ -1,8 +1,11 @@
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { PhotovoltaicDataProvider } from "src/location-features/domain/gateways/PhotovoltaicDataProvider";
 import { TownDataProvider } from "src/location-features/domain/gateways/TownDataProvider";
+import { GetPhotovoltaicExpectedPerformanceUseCase } from "src/location-features/domain/usecases/getPhotovoltaicExpectedPerformanceUseCase";
 import { GetTownPopulationDensityUseCase } from "src/location-features/domain/usecases/getTownPopulationDensity.usecase";
+import { PhotovoltaicGeoInfoSystemApi } from "../secondary/photovoltaic-data-provider/PhotovoltaicGeoInfoSystemApi";
 import { LocalDataInseeService } from "../secondary/town-data-provider/LocalDataInseeService";
 import { LocationFeaturesController } from "./locationFeatures.controller";
 
@@ -16,6 +19,13 @@ import { LocationFeaturesController } from "./locationFeatures.controller";
       useFactory: (townDataProvider: TownDataProvider) =>
         new GetTownPopulationDensityUseCase(townDataProvider),
       inject: ["TownDataProvider"],
+    },
+    { provide: "PhotovoltaicDataProvider", useClass: PhotovoltaicGeoInfoSystemApi },
+    {
+      provide: GetPhotovoltaicExpectedPerformanceUseCase,
+      useFactory: (photovoltaicDataProvider: PhotovoltaicDataProvider) =>
+        new GetPhotovoltaicExpectedPerformanceUseCase(photovoltaicDataProvider),
+      inject: ["PhotovoltaicDataProvider"],
     },
   ],
 })

--- a/apps/api/src/location-features/adapters/secondary/photovoltaic-data-provider/PhotovoltaicGeoInfoSystemApi.mock.ts
+++ b/apps/api/src/location-features/adapters/secondary/photovoltaic-data-provider/PhotovoltaicGeoInfoSystemApi.mock.ts
@@ -1,0 +1,43 @@
+import { Observable } from "rxjs";
+import {
+  PerformanceResult,
+  PhotovoltaicDataProvider,
+} from "src/location-features/domain/gateways/PhotovoltaicDataProvider";
+
+export class MockPhotovoltaicGeoInfoSystemApi implements PhotovoltaicDataProvider {
+  getPhotovoltaicPerformance(): Observable<PerformanceResult> {
+    return new Observable((subscriber) => {
+      subscriber.next({
+        context: {
+          location: { lat: 48.859, long: 2.347, elevation: 49 },
+          meteoData: {
+            radiationDb: "PVGIS-SARAH2",
+            meteoDb: "ERA5",
+            yearMin: 2005,
+            yearMax: 2020,
+            useHorizon: true,
+            horizonDb: "DEM-calculated",
+          },
+          mountingSystem: {
+            slope: { value: 35, optimal: false },
+            azimuth: { value: 0, optimal: false },
+            type: "free-standing",
+          },
+          pvModule: { technology: "c-Si", peakPower: 3, systemLoss: 14 },
+        },
+        expectedPerformance: {
+          kwhPerDay: 9.43,
+          kwhPerMonth: 286.91,
+          kwhPerYear: 3442.92,
+          lossPercents: {
+            angleIncidence: -2.98,
+            spectralIncidence: 1.65,
+            tempAndIrradiance: -5.73,
+            total: -20.05,
+          },
+        },
+      });
+      subscriber.complete();
+    });
+  }
+}

--- a/apps/api/src/location-features/adapters/secondary/photovoltaic-data-provider/PhotovoltaicGeoInfoSystemApi.ts
+++ b/apps/api/src/location-features/adapters/secondary/photovoltaic-data-provider/PhotovoltaicGeoInfoSystemApi.ts
@@ -1,0 +1,145 @@
+import { HttpService } from "@nestjs/axios";
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { AxiosError } from "axios";
+import { catchError, map } from "rxjs";
+import { PhotovoltaicDataProvider } from "src/location-features/domain/gateways/PhotovoltaicDataProvider";
+
+const API_VERSION = "v5_2";
+const TOOL_NAME = "PVcalc";
+
+const API_URL = `https://re.jrc.ec.europa.eu/api/${API_VERSION}/${TOOL_NAME}?outputformat=json`;
+
+interface PVGISResult {
+  inputs: {
+    location: { latitude: string; longitude: string; elevation: string };
+    meteo_data: {
+      radiation_db: "PVGIS-SARAH2";
+      meteo_db: "ERA5";
+      year_min: number;
+      year_max: number;
+      use_horizon: boolean;
+      horizon_db: "DEM-calculated";
+    };
+    mounting_system: {
+      fixed: {
+        slope: { value: number; optimal: boolean };
+        azimuth: { value: number; optimal: boolean };
+        type: "free-standing";
+      };
+    };
+    pv_module: {
+      technology: "c-Si";
+      peak_power: number; // Nominal (peak) power of the PV module kwh
+      system_loss: number; // %
+    };
+  };
+  outputs: {
+    totals: {
+      fixed: {
+        E_d: number;
+        E_m: number;
+        E_y: number; // Average annual energy production from the given system kwh/y
+        l_aoi: number; // Angle of incidence loss %
+        l_spec: number; // Spectral loss %
+        l_tg: number; // Temperature and irradiance loss %
+        l_total: number; // Total loss %
+      };
+    };
+  };
+}
+
+@Injectable()
+export class PhotovoltaicGeoInfoSystemApi implements PhotovoltaicDataProvider {
+  constructor(private readonly httpService: HttpService) {}
+
+  getPhotovoltaicPerformance({
+    lat,
+    long,
+    peakPower,
+    angle = 35,
+    loss = 14,
+  }: {
+    lat: number;
+    long: number;
+    peakPower: number;
+    angle?: number;
+    loss?: number;
+  }) {
+    return this.httpService
+      .get(`${API_URL}&lat=${lat}&lon=${long}&peakpower=${peakPower}&loss=${loss}&angle=${angle}`)
+      .pipe(
+        map(({ data }: { data: PVGISResult }) => {
+          const { outputs, inputs } = data;
+          const { totals } = outputs;
+          const { location, meteo_data, mounting_system } = inputs;
+          return {
+            context: {
+              location: {
+                lat: Number(location.latitude),
+                long: Number(location.longitude),
+                elevation: Number(location.elevation),
+              },
+              meteoData: {
+                radiationDb: meteo_data.radiation_db,
+                meteoDb: meteo_data.meteo_db,
+                yearMin: meteo_data.year_min,
+                yearMax: meteo_data.year_max,
+                useHorizon: meteo_data.use_horizon,
+                horizonDb: meteo_data.horizon_db,
+              },
+              mountingSystem: {
+                slope: {
+                  value: Number(mounting_system.fixed.slope.value),
+                  optimal: Boolean(mounting_system.fixed.slope.optimal),
+                },
+                azimuth: {
+                  value: Number(mounting_system.fixed.azimuth.value),
+                  optimal: Boolean(mounting_system.fixed.azimuth.optimal),
+                },
+                type: inputs.mounting_system.fixed.type,
+              },
+              pvModule: {
+                technology: inputs.pv_module.technology,
+                peakPower: Number(inputs.pv_module.peak_power),
+                systemLoss: Number(inputs.pv_module.system_loss),
+              },
+            },
+            expectedPerformance: {
+              kwhPerDay: Number(totals.fixed.E_d),
+              kwhPerMonth: Number(totals.fixed.E_m),
+              kwhPerYear: Number(totals.fixed.E_y),
+              lossPercents: {
+                angleIncidence: Number(totals.fixed.l_aoi),
+                spectralIncidence: Number(totals.fixed.l_spec),
+                tempAndIrradiance: Number(totals.fixed.l_tg),
+                total: Number(totals.fixed.l_total),
+              },
+            },
+          };
+        }),
+      )
+      .pipe(
+        catchError((error: AxiosError) => {
+          if (!error.response) {
+            throw new HttpException("Something went wrong while setting up the request", 500);
+          }
+          switch (error.response.status) {
+            case 400:
+              throw new BadRequestException(error.response.data);
+            case 403:
+              throw new ForbiddenException(error.response.data);
+            case 404:
+              throw new NotFoundException(error.response.data);
+            default:
+              throw new HttpException(error.response.data as string, error.response.status);
+          }
+        }),
+      );
+  }
+}

--- a/apps/api/src/location-features/domain/gateways/PhotovoltaicDataProvider.ts
+++ b/apps/api/src/location-features/domain/gateways/PhotovoltaicDataProvider.ts
@@ -1,0 +1,52 @@
+import { Observable } from "rxjs";
+
+type PerformanceParams = {
+  lat: number;
+  long: number;
+  peakPower: number;
+  loss?: number;
+  angle?: number;
+};
+
+export type PerformanceResult = {
+  context: {
+    location: {
+      lat: number;
+      long: number;
+      elevation: number;
+    };
+    meteoData: {
+      radiationDb: "PVGIS-SARAH2";
+      meteoDb: "ERA5";
+      yearMin: number;
+      yearMax: number;
+      useHorizon: boolean;
+      horizonDb: "DEM-calculated";
+    };
+    mountingSystem: {
+      slope: { value: number; optimal: boolean };
+      azimuth: { value: number; optimal: boolean };
+      type: "free-standing";
+    };
+    pvModule: {
+      technology: "c-Si";
+      peakPower: number;
+      systemLoss: number;
+    };
+  };
+  expectedPerformance: {
+    kwhPerDay: number;
+    kwhPerMonth: number;
+    kwhPerYear: number;
+    lossPercents: {
+      angleIncidence: number;
+      spectralIncidence: number;
+      tempAndIrradiance: number;
+      total: number;
+    };
+  };
+};
+
+export interface PhotovoltaicDataProvider {
+  getPhotovoltaicPerformance(params: PerformanceParams): Observable<PerformanceResult>;
+}

--- a/apps/api/src/location-features/domain/usecases/getPhotovoltaicExpectedPerformanceUseCase.ts
+++ b/apps/api/src/location-features/domain/usecases/getPhotovoltaicExpectedPerformanceUseCase.ts
@@ -1,0 +1,77 @@
+import { lastValueFrom } from "rxjs";
+import { UseCase } from "../../../shared-kernel/usecase";
+import { PhotovoltaicDataProvider } from "../gateways/PhotovoltaicDataProvider";
+
+type Request = {
+  lat: number;
+  long: number;
+  peakPower: number;
+};
+
+type Response = {
+  computationContext: {
+    location: {
+      lat: number;
+      long: number;
+      elevation: number;
+    };
+    dataSources: {
+      radiation: string;
+      meteo: string;
+      period: string;
+      horizon?: string;
+    };
+    pvInstallation: {
+      slope: { value: number; optimal: boolean };
+      azimuth: { value: number; optimal: boolean };
+      type: string;
+      technology: string;
+      peakPower: number;
+      systemLoss: number;
+    };
+  };
+  expectedPerformance: {
+    kwhPerDay: number;
+    kwhPerMonth: number;
+    kwhPerYear: number;
+    lossPercents: {
+      angleIncidence: number;
+      spectralIncidence: number;
+      tempAndIrradiance: number;
+      total: number;
+    };
+  };
+};
+
+export class GetPhotovoltaicExpectedPerformanceUseCase implements UseCase<Request, Response> {
+  constructor(private readonly photovoltaicDataProvider: PhotovoltaicDataProvider) {}
+
+  async execute({ lat, long, peakPower }: Request): Promise<Response> {
+    const result = await lastValueFrom(
+      this.photovoltaicDataProvider.getPhotovoltaicPerformance({ lat, long, peakPower }),
+    );
+
+    return {
+      computationContext: {
+        location: result.context.location,
+        dataSources: {
+          radiation: result.context.meteoData.radiationDb,
+          meteo: result.context.meteoData.meteoDb,
+          period: `${result.context.meteoData.yearMin} - ${result.context.meteoData.yearMax}`,
+          horizon: result.context.meteoData.useHorizon
+            ? result.context.meteoData.horizonDb
+            : undefined,
+        },
+        pvInstallation: {
+          technology: result.context.pvModule.technology,
+          peakPower: result.context.pvModule.peakPower,
+          systemLoss: result.context.pvModule.systemLoss,
+          slope: result.context.mountingSystem.slope,
+          azimuth: result.context.mountingSystem.azimuth,
+          type: result.context.mountingSystem.type,
+        },
+      },
+      expectedPerformance: result.expectedPerformance,
+    };
+  }
+}

--- a/apps/api/src/location-features/domain/usecases/getPhotovoltaicExpectedPerformanceUseCase.usecase.spec.ts
+++ b/apps/api/src/location-features/domain/usecases/getPhotovoltaicExpectedPerformanceUseCase.usecase.spec.ts
@@ -1,0 +1,47 @@
+import { MockPhotovoltaicGeoInfoSystemApi } from "src/location-features/adapters/secondary/photovoltaic-data-provider/PhotovoltaicGeoInfoSystemApi.mock";
+import { GetPhotovoltaicExpectedPerformanceUseCase } from "./getPhotovoltaicExpectedPerformanceUseCase";
+
+describe("GetPhotovoltaicExpectedPerformanceUseCase use case", () => {
+  let dataProvider: MockPhotovoltaicGeoInfoSystemApi;
+
+  beforeEach(() => {
+    dataProvider = new MockPhotovoltaicGeoInfoSystemApi();
+  });
+
+  test("it should format the service result", async () => {
+    const usecase = new GetPhotovoltaicExpectedPerformanceUseCase(dataProvider);
+    const result = await usecase.execute({ lat: 48.859, long: 2.347, peakPower: 3.1 });
+
+    expect(result).toBeDefined();
+    expect(result).toEqual({
+      computationContext: {
+        location: { lat: 48.859, long: 2.347, elevation: 49 },
+        dataSources: {
+          radiation: "PVGIS-SARAH2",
+          meteo: "ERA5",
+          period: "2005 - 2020",
+          horizon: "DEM-calculated",
+        },
+        pvInstallation: {
+          technology: "c-Si",
+          peakPower: 3,
+          systemLoss: 14,
+          slope: { value: 35, optimal: false },
+          azimuth: { value: 0, optimal: false },
+          type: "free-standing",
+        },
+      },
+      expectedPerformance: {
+        kwhPerDay: 9.43,
+        kwhPerMonth: 286.91,
+        kwhPerYear: 3442.92,
+        lossPercents: {
+          angleIncidence: -2.98,
+          spectralIncidence: 1.65,
+          tempAndIrradiance: -5.73,
+          total: -20.05,
+        },
+      },
+    });
+  });
+});

--- a/apps/web/src/app/application/appDependencies.ts
+++ b/apps/web/src/app/application/appDependencies.ts
@@ -1,6 +1,7 @@
 import { AppDependencies } from "./store";
 
 import { LocalStorageGetSiteApi } from "@/features/create-project/infrastructure/get-site-service/localStorageGetSiteService";
+import { ExpectedPhotovoltaicPerformanceApi } from "@/features/create-project/infrastructure/photovoltaic-performance-service/photovoltaicPerformanceApi";
 import { LocalStorageSaveProjectApi } from "@/features/create-project/infrastructure/save-project-service/localStorageSaveSiteService";
 import { LocalStorageCreateSiteApi } from "@/features/create-site/infrastructure/create-site-service/localStorageCreateSiteApi";
 import { LocalStorageProjectDetailsApi } from "@/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi";
@@ -16,4 +17,5 @@ export const appDependencies: AppDependencies = {
   projectDetailsService: new LocalStorageProjectDetailsApi(),
   sitesService: new LocalStorageSitesApi(),
   saveProjectGateway: new LocalStorageSaveProjectApi(),
+  photovoltaicPerformanceService: new ExpectedPhotovoltaicPerformanceApi(),
 };

--- a/apps/web/src/app/application/store.ts
+++ b/apps/web/src/app/application/store.ts
@@ -12,6 +12,8 @@ import {
 } from "../../features/projects/application/projectsList.actions";
 
 import projectCreation from "@/features/create-project/application/createProject.reducer";
+import { PhotovoltaicPerformanceGateway } from "@/features/create-project/application/pvExpectedPerformanceStorage.actions";
+import projectPvExpectedPerformancesStorage from "@/features/create-project/application/pvExpectedPerformanceStorage.reducer";
 import projectSoilsCarbonStorage from "@/features/create-project/application/soilsCarbonStorage.reducer";
 import siteCreation from "@/features/create-site/application/createSite.reducer";
 import siteCarbonStorage from "@/features/create-site/application/siteSoilsCarbonStorage.reducer";
@@ -29,6 +31,7 @@ export type AppDependencies = {
   projectsListService: ProjectsListGateway;
   projectDetailsService: ProjectsDetailsGateway;
   sitesService: SitesGateway;
+  photovoltaicPerformanceService: PhotovoltaicPerformanceGateway;
 };
 
 export const createStore = (appDependencies: AppDependencies) =>
@@ -36,6 +39,7 @@ export const createStore = (appDependencies: AppDependencies) =>
     reducer: {
       siteCreation,
       projectCreation,
+      projectPvExpectedPerformancesStorage,
       siteCarbonStorage,
       projectsList,
       currentUser,

--- a/apps/web/src/features/create-project/application/pvExpectedPerformanceStorage.actions.ts
+++ b/apps/web/src/features/create-project/application/pvExpectedPerformanceStorage.actions.ts
@@ -1,0 +1,82 @@
+import { createAppAsyncThunk } from "@/app/application/appAsyncThunk";
+
+export type PhotovoltaicPerformanceApiResult = {
+  computationContext: {
+    location: {
+      lat: number;
+      long: number;
+      elevation: number;
+    };
+    dataSources: {
+      radiation: string;
+      meteo: string;
+      period: string;
+      horizon?: string;
+    };
+    pvInstallation: {
+      slope: { value: number; optimal: boolean };
+      azimuth: { value: number; optimal: boolean };
+      type: string;
+      technology: string;
+      peakPower: number;
+      systemLoss: number;
+    };
+  };
+  expectedPerformance: {
+    kwhPerDay: number;
+    kwhPerMonth: number;
+    kwhPerYear: number;
+    lossPercents: {
+      angleIncidence: number;
+      spectralIncidence: number;
+      tempAndIrradiance: number;
+      total: number;
+    };
+  };
+};
+
+export type PhotovoltaicPerformanceApiPayload = {
+  lat: number;
+  long: number;
+  peakPower: number;
+};
+
+export interface PhotovoltaicPerformanceGateway {
+  getExpectedPhotovoltaicPerformance(
+    payload: PhotovoltaicPerformanceApiPayload,
+  ): Promise<PhotovoltaicPerformanceApiResult>;
+}
+
+export type FetchResult = {
+  computationContext: PhotovoltaicPerformanceApiResult["computationContext"];
+  expectedPerformanceMwhPerYear: number;
+};
+
+export const fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation =
+  createAppAsyncThunk<FetchResult>(
+    "project/fetchPhotovoltaicExpectedAnnualPowerPerformanceForLocation",
+    async (_, { extra, getState }) => {
+      const { projectCreation } = getState();
+      const { lat, long } = projectCreation.siteData?.address ?? {};
+      const peakPower = projectCreation.projectData.photovoltaicInstallationElectricalPowerKWc;
+
+      if (!lat || !long || !peakPower) {
+        return Promise.reject(
+          new Error(
+            "fetchPhotovoltaicExpectedAnnualPowerPerformanceForLocation: Missing required parameters",
+          ),
+        );
+      }
+
+      const result = await extra.photovoltaicPerformanceService.getExpectedPhotovoltaicPerformance({
+        lat,
+        long,
+        peakPower,
+      });
+
+      return {
+        computationContext: result.computationContext,
+        expectedPerformanceMwhPerYear: Math.round(result.expectedPerformance.kwhPerYear / 1000),
+      };
+    },
+  );

--- a/apps/web/src/features/create-project/application/pvExpectedPerformanceStorage.reducer.spec.ts
+++ b/apps/web/src/features/create-project/application/pvExpectedPerformanceStorage.reducer.spec.ts
@@ -1,0 +1,146 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ProjectSite } from "../domain/project.types";
+import { GetSiteServiceMock } from "../infrastructure/get-site-service/GetSiteServiceMock";
+import { ExpectedPhotovoltaicPerformanceMock } from "../infrastructure/photovoltaic-performance-service/photovoltaicPerformanceMock";
+import { fetchRelatedSiteAction } from "./createProject.actions";
+import { setPhotovoltaicInstallationElectricalPower } from "./createProject.reducer";
+import {
+  fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation,
+  PhotovoltaicPerformanceApiResult,
+} from "./pvExpectedPerformanceStorage.actions";
+
+import { createStore } from "@/app/application/store";
+import { getTestAppDependencies } from "@/test/testAppDependencies";
+
+const API_MOCKED_RESULT = {
+  computationContext: {
+    location: { lat: 48.859, long: 2.347, elevation: 49 },
+    dataSources: {
+      radiation: "PVGIS-SARAH2",
+      meteo: "ERA5",
+      period: "2005 - 2020",
+      horizon: "DEM-calculated",
+    },
+    pvInstallation: {
+      technology: "c-Si",
+      peakPower: 3,
+      systemLoss: 14,
+      slope: { value: 35, optimal: false },
+      azimuth: { value: 0, optimal: false },
+      type: "free-standing",
+    },
+  },
+  expectedPerformance: {
+    kwhPerDay: 9.43,
+    kwhPerMonth: 286.91,
+    kwhPerYear: 3442.92,
+    lossPercents: {
+      angleIncidence: -2.98,
+      spectralIncidence: 1.65,
+      tempAndIrradiance: -5.73,
+      total: -20.05,
+    },
+  },
+} as PhotovoltaicPerformanceApiResult;
+
+const SITE_MOCKED_RESULT = {
+  id: "03a53ffd-4f71-419e-8d04-041311eefa23",
+  isFriche: true,
+  owner: { name: "", structureType: "unknown" },
+  name: "Friche industrielle",
+  surfaceArea: 2900,
+  hasContaminatedSoils: false,
+  address: {
+    lat: 48.859,
+    long: 2.347,
+    city: "Paris",
+    id: "75110_7043",
+    cityCode: "75110",
+    postCode: "75010",
+    value: "Rue de Paradis 75010 Paris",
+  },
+} as ProjectSite;
+
+describe("Photovoltaic expected performance reducer", () => {
+  it("should return error when there is no projectData in createProject store", async () => {
+    const store = createStore(
+      getTestAppDependencies({
+        photovoltaicPerformanceService: new ExpectedPhotovoltaicPerformanceMock(API_MOCKED_RESULT),
+      }),
+    );
+
+    await store.dispatch(fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation());
+
+    const state = store.getState();
+    expect(state.projectPvExpectedPerformancesStorage).toEqual({
+      loadingState: "error",
+      computationContext: undefined,
+      expectedPerformanceMwhPerYear: undefined,
+    });
+  });
+
+  it("should call ExpectedPhotovoltaicPerformanceMock with the right payload", async () => {
+    const mockSpy = new ExpectedPhotovoltaicPerformanceMock(API_MOCKED_RESULT);
+    jest.spyOn(mockSpy, "getExpectedPhotovoltaicPerformance");
+    const store = createStore(
+      getTestAppDependencies({
+        photovoltaicPerformanceService: mockSpy,
+        getSiteService: new GetSiteServiceMock(SITE_MOCKED_RESULT),
+      }),
+    );
+
+    await store.dispatch(fetchRelatedSiteAction(SITE_MOCKED_RESULT["id"]));
+    store.dispatch(setPhotovoltaicInstallationElectricalPower(3));
+    await store.dispatch(fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation());
+
+    expect(mockSpy.getExpectedPhotovoltaicPerformance).toHaveBeenCalledTimes(1);
+    expect(mockSpy.getExpectedPhotovoltaicPerformance).toHaveBeenCalledWith({
+      long: 2.347,
+      lat: 48.859,
+      peakPower: 3,
+    });
+  });
+
+  it("should get expected performance power for site geo coordinates and installation power", async () => {
+    const store = createStore(
+      getTestAppDependencies({
+        photovoltaicPerformanceService: new ExpectedPhotovoltaicPerformanceMock(API_MOCKED_RESULT),
+        getSiteService: new GetSiteServiceMock(SITE_MOCKED_RESULT),
+      }),
+    );
+
+    await store.dispatch(fetchRelatedSiteAction(SITE_MOCKED_RESULT["id"]));
+    store.dispatch(setPhotovoltaicInstallationElectricalPower(3.0));
+    await store.dispatch(fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation());
+
+    const state = store.getState();
+    expect(state.projectPvExpectedPerformancesStorage).toEqual({
+      loadingState: "success",
+      computationContext: API_MOCKED_RESULT.computationContext,
+      expectedPerformanceMwhPerYear: 3,
+    });
+  });
+
+  it("should return error state when service fails", async () => {
+    const store = createStore(
+      getTestAppDependencies({
+        photovoltaicPerformanceService: new ExpectedPhotovoltaicPerformanceMock(
+          // @ts-expect-error intended failure
+          null,
+          true,
+        ),
+      }),
+    );
+
+    await store.dispatch(fetchRelatedSiteAction(SITE_MOCKED_RESULT["id"]));
+    store.dispatch(setPhotovoltaicInstallationElectricalPower(3.0));
+    await store.dispatch(fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation());
+
+    const state = store.getState();
+    expect(state.projectPvExpectedPerformancesStorage).toEqual({
+      loadingState: "error",
+      expectedPerformanceMwhPerYear: undefined,
+      computationContext: undefined,
+    });
+  });
+});

--- a/apps/web/src/features/create-project/application/pvExpectedPerformanceStorage.reducer.ts
+++ b/apps/web/src/features/create-project/application/pvExpectedPerformanceStorage.reducer.ts
@@ -1,0 +1,58 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation } from "./pvExpectedPerformanceStorage.actions";
+
+export type LoadingState = "idle" | "loading" | "success" | "error";
+
+export type State = {
+  loadingState: LoadingState;
+  computationContext?: {
+    location: {
+      lat: number;
+      long: number;
+      elevation: number;
+    };
+    dataSources: {
+      radiation: string;
+      meteo: string;
+      period: string;
+      horizon?: string;
+    };
+    pvInstallation: {
+      slope: { value: number; optimal: boolean };
+      azimuth: { value: number; optimal: boolean };
+      type: string;
+      technology: string;
+      peakPower: number;
+      systemLoss: number;
+    };
+  };
+  expectedPerformanceMwhPerYear?: number;
+};
+
+const initialState: State = {
+  loadingState: "idle",
+};
+
+export const pvExpectedPerformanceStorage = createSlice({
+  name: "pvExpectedPerformanceStorage",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation.pending, (state) => {
+      state.loadingState = "loading";
+    });
+    builder.addCase(
+      fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation.fulfilled,
+      (state, action) => {
+        state.loadingState = "success";
+        state.computationContext = action.payload.computationContext;
+        state.expectedPerformanceMwhPerYear = action.payload.expectedPerformanceMwhPerYear;
+      },
+    );
+    builder.addCase(fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation.rejected, (state) => {
+      state.loadingState = "error";
+    });
+  },
+});
+
+export default pvExpectedPerformanceStorage.reducer;

--- a/apps/web/src/features/create-project/domain/photovoltaic.ts
+++ b/apps/web/src/features/create-project/domain/photovoltaic.ts
@@ -4,13 +4,6 @@ export const PHOTOVOLTAIC_RATIO_KWC_PER_M2 = 0.0714;
 // 14 000 m² pour 1000 kWc
 export const PHOTOVOLTAIC_RATIO_M2_PER_KWC = 14;
 
-// Production annuelle en kWh/kWc en France
-// https://www.hellowatt.fr/panneaux-solaires-photovoltaiques/production-panneaux-solaires
-// TODO: Get real accurate value from localisation
-// https://re.jrc.ec.europa.eu/pvg_tools/fr/tools.html
-// https://www.monkitsolaire.fr/blog/kwh-et-kwc-comprendre-les-unites-de-mesure-en-autoconsommation-n400
-export const AVERAGE_PHOTOVOLTAIC_ANNUAL_PRODUCTION_IN_KWH_BY_KWC_IN_FRANCE = 1100;
-
 export const AVERAGE_PHOTOVOLTAIC_CONTRACT_DURATION_IN_YEARS = 30;
 
 export const RECOMMENDED_M2_PER_KWC_FOR_ACCESS_PATHS = 0.88;

--- a/apps/web/src/features/create-project/infrastructure/photovoltaic-performance-service/photovoltaicPerformanceApi.ts
+++ b/apps/web/src/features/create-project/infrastructure/photovoltaic-performance-service/photovoltaicPerformanceApi.ts
@@ -1,0 +1,23 @@
+import {
+  PhotovoltaicPerformanceApiPayload,
+  PhotovoltaicPerformanceApiResult,
+  PhotovoltaicPerformanceGateway,
+} from "../../application/pvExpectedPerformanceStorage.actions";
+
+import { objectToQueryParams } from "@/shared/services/object-query-parameters/objectToQueryParameters";
+
+export class ExpectedPhotovoltaicPerformanceApi implements PhotovoltaicPerformanceGateway {
+  async getExpectedPhotovoltaicPerformance({
+    lat,
+    long,
+    peakPower,
+  }: PhotovoltaicPerformanceApiPayload) {
+    const queryString = objectToQueryParams({ lat, long, peakPower });
+    const response = await fetch(`/api/location-features/pv-expected-performance?${queryString}`);
+
+    if (!response.ok) throw new Error("Error while getting expected PV performance");
+
+    const jsonResponse = (await response.json()) as PhotovoltaicPerformanceApiResult;
+    return jsonResponse;
+  }
+}

--- a/apps/web/src/features/create-project/infrastructure/photovoltaic-performance-service/photovoltaicPerformanceMock.ts
+++ b/apps/web/src/features/create-project/infrastructure/photovoltaic-performance-service/photovoltaicPerformanceMock.ts
@@ -1,0 +1,49 @@
+import {
+  PhotovoltaicPerformanceApiResult,
+  PhotovoltaicPerformanceGateway,
+} from "../../application/pvExpectedPerformanceStorage.actions";
+
+export const MOCK_RESULT = {
+  computationContext: {
+    location: { lat: 48.859, long: 2.347, elevation: 49 },
+    dataSources: {
+      radiation: "PVGIS-SARAH2",
+      meteo: "ERA5",
+      period: "2005 - 2020",
+      horizon: "DEM-calculated",
+    },
+    pvInstallation: {
+      technology: "c-Si",
+      peakPower: 3,
+      systemLoss: 14,
+      slope: { value: 35, optimal: false },
+      azimuth: { value: 0, optimal: false },
+      type: "free-standing",
+    },
+  },
+  expectedPerformance: {
+    kwhPerDay: 9.43,
+    kwhPerMonth: 286.91,
+    kwhPerYear: 3442.92,
+    lossPercents: {
+      angleIncidence: -2.98,
+      spectralIncidence: 1.65,
+      tempAndIrradiance: -5.73,
+      total: -20.05,
+    },
+  },
+};
+
+export class ExpectedPhotovoltaicPerformanceMock implements PhotovoltaicPerformanceGateway {
+  constructor(
+    private result: PhotovoltaicPerformanceApiResult,
+    private shouldFail: boolean = false,
+  ) {}
+
+  async getExpectedPhotovoltaicPerformance() {
+    if (this.shouldFail) {
+      throw new Error("Intended error");
+    }
+    return Promise.resolve(this.result);
+  }
+}

--- a/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionComputationDetails.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionComputationDetails.tsx
@@ -1,0 +1,182 @@
+import Accordion from "@codegouvfr/react-dsfr/Accordion";
+
+import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
+
+type Props = {
+  surfaceArea: number;
+  computationContext: {
+    location: {
+      lat: number;
+      long: number;
+      elevation: number;
+    };
+    dataSources: {
+      radiation: string;
+      meteo: string;
+      period: string;
+      horizon?: string;
+    };
+    pvInstallation: {
+      slope: { value: number; optimal: boolean };
+      azimuth: { value: number; optimal: boolean };
+      type: string;
+      technology: string;
+      peakPower: number;
+      systemLoss: number;
+    };
+  };
+};
+
+function ExpectedAnnualProductionInstructions({ computationContext, surfaceArea }: Props) {
+  return (
+    <>
+      <Accordion label="En savoir plus sur le calcul de cette donnée">
+        <>
+          <h3>Données d’entrée :</h3>
+          <ul>
+            <li>
+              Coordonnées géographiques : {computationContext.location.lat},{" "}
+              {computationContext.location.long}
+            </li>
+            <li>Altitude : {formatNumberFr(computationContext.location.elevation)} m</li>
+            <li>
+              Puissance de crềte de l’installation :{" "}
+              {formatNumberFr(computationContext.pvInstallation.peakPower)} kWc
+            </li>
+            <li>Superficie l’installation : {formatNumberFr(surfaceArea)} m²</li>
+            <li>
+              Position : libre
+              <button
+                className="fr-btn--tooltip fr-btn"
+                id="button-position"
+                aria-describedby="tooltip-position"
+              >
+                Information contextuelle
+              </button>
+              <span
+                className="fr-tooltip fr-placement"
+                id="tooltip-position"
+                role="tooltip"
+                aria-hidden="true"
+              >
+                Cela signifie que les panneaux sont montés sur une structure de support qui permet
+                la libre circulation d'air derrière les modules.
+              </span>
+            </li>
+            <li>Technologie : Silicium cristallin</li>
+          </ul>
+          <h4>Options de le l’outil PVGIS :</h4>
+          <ul>
+            <li>
+              Pertes estimées du système : {computationContext.pvInstallation.systemLoss} %
+              <button
+                className="fr-btn--tooltip fr-btn"
+                id="button-loss"
+                aria-describedby="tooltip-loss"
+              >
+                Information contextuelle
+              </button>
+              <span
+                className="fr-tooltip fr-placement"
+                id="tooltip-loss"
+                role="tooltip"
+                aria-hidden="true"
+              >
+                Les pertes estimées du système sont toutes les pertes dans le système qui font que
+                la puissance vraiment délivrée sur le réseau électrique est plus basse que la
+                puissance produite par les modules. <br />
+                <br />
+                Il y a plusieurs causes de ces pertes, comme les pertes dues au câblage, à
+                l'onduleur, à la saleté sur les modules, etc. <br />
+                Par défaut, la perte est définie à 14%.
+              </span>
+            </li>
+            <li>
+              Horizon calculé : {computationContext.dataSources.horizon ? "Oui" : "Non"}
+              <button
+                className="fr-btn--tooltip fr-btn"
+                id="button-horizon"
+                aria-describedby="tooltip-horizon"
+              >
+                Information contextuelle
+              </button>
+              <span
+                className="fr-tooltip fr-placement"
+                id="tooltip-horizon"
+                role="tooltip"
+                aria-hidden="true"
+              >
+                La radiation solaire et la production d'électricité photovoltaïque changent s'il y a
+                des collines ou des montagnes voisines qui bloquent la radiation solaire pour
+                quelques périodes du jour. <br />
+                PVGIS peut calculer cet effet en utilisant les données de l'élévation de la région
+                avoisinante qui ont une résolution de 3 secondes d'arc (environ 90 m).
+                <br />
+                Ce calcul ne tient pas compte des ombres portées par les objets proches comme
+                maisons ou arbres.
+              </span>
+            </li>
+            <li>
+              Angle : {computationContext.pvInstallation.slope.value}°
+              <button
+                className="fr-btn--tooltip fr-btn"
+                id="button-slope"
+                aria-describedby="tooltip-slope"
+              >
+                Information contextuelle
+              </button>
+              <span
+                className="fr-tooltip fr-placement"
+                id="tooltip-slope"
+                role="tooltip"
+                aria-hidden="true"
+              >
+                C'est l'angle entre le plan des panneaux photovoltaïques et l'horizontale, pour un
+                montage fixe (sans système de suivi).
+              </span>
+            </li>
+            <li>
+              Azimut : {computationContext.pvInstallation.azimuth.value}°
+              <button
+                className="fr-btn--tooltip fr-btn"
+                id="button-azimuth"
+                aria-describedby="tooltip-azimuth"
+              >
+                Information contextuelle
+              </button>
+              <span
+                className="fr-tooltip fr-placement"
+                id="tooltip-azimuth"
+                role="tooltip"
+                aria-hidden="true"
+              >
+                C'est l'angle des panneaux photovoltaïques par rapport à la direction sud. -90° est
+                est, 0° est sud et 90° est ouest.
+              </span>
+            </li>
+          </ul>
+
+          <h4>Bases de données PVGIS :</h4>
+          <ul>
+            <li>Météo : {computationContext.dataSources.meteo}</li>
+            <li>Radiations : {computationContext.dataSources.radiation}</li>
+            {computationContext.dataSources.horizon && (
+              <li>Horizon : {computationContext.dataSources.horizon}</li>
+            )}
+            <li>Période : {computationContext.dataSources.period}</li>
+          </ul>
+          <a
+            title="Source des données PGVIS - ouvre une nouvelle fenêtre"
+            target="_blank"
+            rel="noopener noreferrer external"
+            href="https://joint-research-centre.ec.europa.eu/photovoltaic-geographical-information-system-pvgis/pvgis-data-download_en"
+          >
+            Source des données
+          </a>
+        </>
+      </Accordion>
+    </>
+  );
+}
+
+export default ExpectedAnnualProductionInstructions;

--- a/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionForm.tsx
@@ -1,12 +1,17 @@
 import { useForm } from "react-hook-form";
 import Button from "@codegouvfr/react-dsfr/Button";
+import ExpectedAnnualProductionComputationDetails from "./ExpectedAnnualProductionComputationDetails";
+import ExpectedAnnualProductionHint from "./ExpectedAnnualProductionHint";
 
+import { State } from "@/features/create-project/application/pvExpectedPerformanceStorage.reducer";
 import NumericInput from "@/shared/views/components/form/NumericInput/NumericInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
   onSubmit: (data: FormValues) => void;
-  suggestedAnnualProductionInMegaWattPerYear: number;
+  surfaceArea?: number;
+  computationContext?: State["computationContext"];
+  expectedPerformanceMwhPerYear?: State["expectedPerformanceMwhPerYear"];
 };
 
 type FormValues = {
@@ -15,11 +20,13 @@ type FormValues = {
 
 function PhotovoltaicAnnualProductionForm({
   onSubmit,
-  suggestedAnnualProductionInMegaWattPerYear,
+  expectedPerformanceMwhPerYear,
+  computationContext,
+  surfaceArea,
 }: Props) {
   const { control, handleSubmit } = useForm<FormValues>({
     defaultValues: {
-      photovoltaicExpectedAnnualProduction: suggestedAnnualProductionInMegaWattPerYear,
+      photovoltaicExpectedAnnualProduction: expectedPerformanceMwhPerYear,
     },
   });
 
@@ -28,11 +35,16 @@ function PhotovoltaicAnnualProductionForm({
       title="Quelle est la production annuelle attendue de votre installation ?"
       instructions={
         <>
-          <p>
-            Production calculée à partir de la puissance, de la superficie au sol et du taux
-            d’ensoleillement dans la zone géographique du site. Vous pouvez la modifier.
-          </p>
-          <p>Vous pouvez modifier cette valeur.</p>
+          <ExpectedAnnualProductionHint
+            expectedPerformanceMwhPerYear={expectedPerformanceMwhPerYear}
+          />
+
+          {computationContext && surfaceArea && (
+            <ExpectedAnnualProductionComputationDetails
+              computationContext={computationContext}
+              surfaceArea={surfaceArea}
+            />
+          )}
         </>
       }
     >

--- a/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionHint.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionHint.tsx
@@ -1,0 +1,81 @@
+import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
+
+type Props = {
+  expectedPerformanceMwhPerYear?: number;
+};
+
+function ExpectedAnnualProductionHint({ expectedPerformanceMwhPerYear }: Props) {
+  return (
+    <>
+      {expectedPerformanceMwhPerYear ? (
+        <>
+          <p>
+            D’après la puissance de crête de votre installation, sa superficie au sol et sa
+            situation géographique (ensoleillement, horizon, etc.), vous pouvez espérer produire en
+            moyenne {formatNumberFr(expectedPerformanceMwhPerYear)} MWh par an.
+          </p>
+          <p>
+            La valeur qui vous est proposée a été calculée à partir des données du{" "}
+            <a
+              target="_blank"
+              rel="noopener noreferrer external"
+              title="Site du Photovoltaic Geographical Information System - ouvre une nouvelle fenêtre"
+              href="https://re.jrc.ec.europa.eu/pvg_tools/fr/"
+            >
+              PVGIS.
+            </a>
+            <button
+              className="fr-btn--tooltip fr-btn"
+              id="button-PVGIS"
+              aria-describedby="tooltip-PVGIS"
+            >
+              Information contextuelle
+            </button>{" "}
+          </p>
+
+          <p>
+            Si vous savez que votre production annuelle sera différente, vous pouvez modifier cette
+            valeur.
+          </p>
+        </>
+      ) : (
+        <p>
+          Nous n’avons pas réussi à pré-calculer votre potentielle production annuelle. Vous pouvez
+          évaluer votre production grâce à l’outil{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer external"
+            title="Site du Photovoltaic Geographical Information System - ouvre une nouvelle fenêtre"
+            href="https://re.jrc.ec.europa.eu/pvg_tools/fr/"
+          >
+            PVGIS.
+          </a>
+          <button
+            className="fr-btn--tooltip fr-btn"
+            id="button-PVGIS"
+            aria-describedby="tooltip-PVGIS"
+          >
+            Information contextuelle
+          </button>
+        </p>
+      )}
+
+      <span
+        className="fr-tooltip fr-placement"
+        id="tooltip-PVGIS"
+        role="tooltip"
+        aria-hidden="true"
+      >
+        Le <strong>PVGIS (Photovoltaic Geographical Information System)</strong> est un outil
+        gratuit en ligne développé par la Commission Européenne qui permet d’évaluer la production
+        d’énergie d’une installation photovoltaïque. <br />
+        <br />
+        Les <strong>paramètres</strong> comprennent le choix de la base de données d’ensoleillement,
+        le type de technologie PV, la puissance de crête, les pertes du système, la position de
+        montage, l’inclinaison et l’azimut de la centrale solaire.
+      </span>
+    </>
+  );
+}
+
+export default ExpectedAnnualProductionHint;

--- a/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/index.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import PhotovoltaicExpectedAnnualProductionForm from "./ExpectedAnnualProductionForm";
 
 import {
@@ -5,25 +6,32 @@ import {
   ProjectCreationStep,
   setPhotovoltaicExpectedAnnualProduction,
 } from "@/features/create-project/application/createProject.reducer";
-import { AVERAGE_PHOTOVOLTAIC_ANNUAL_PRODUCTION_IN_KWH_BY_KWC_IN_FRANCE } from "@/features/create-project/domain/photovoltaic";
+import { fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation } from "@/features/create-project/application/pvExpectedPerformanceStorage.actions";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
-
-const computeAveragePhotovoltaicAnnualProductionInMegaWattPerYear = (electricalPower: number) =>
-  Math.round(
-    (AVERAGE_PHOTOVOLTAIC_ANNUAL_PRODUCTION_IN_KWH_BY_KWC_IN_FRANCE * electricalPower) / 1000,
-  );
 
 function PhotovoltaicExpectedAnnualProductionContainer() {
   const dispatch = useAppDispatch();
-  const electricalPowerKWc = useAppSelector(
-    (state) => state.projectCreation.projectData.photovoltaicInstallationElectricalPowerKWc ?? 0,
+
+  const { loadingState, expectedPerformanceMwhPerYear, computationContext } = useAppSelector(
+    (state) => state.projectPvExpectedPerformancesStorage,
   );
+  const surfaceArea = useAppSelector(
+    (state) => state.projectCreation.projectData.photovoltaicInstallationSurfaceSquareMeters,
+  );
+
+  useEffect(() => {
+    void dispatch(fetchPhotovoltaicExpectedAnnulPowerPerformanceForLocation());
+  }, [dispatch]);
+
+  if (loadingState === "loading") {
+    return "Chargement des données...";
+  }
 
   return (
     <PhotovoltaicExpectedAnnualProductionForm
-      suggestedAnnualProductionInMegaWattPerYear={computeAveragePhotovoltaicAnnualProductionInMegaWattPerYear(
-        electricalPowerKWc,
-      )}
+      expectedPerformanceMwhPerYear={expectedPerformanceMwhPerYear}
+      computationContext={computationContext}
+      surfaceArea={surfaceArea}
       onSubmit={(data) => {
         dispatch(
           setPhotovoltaicExpectedAnnualProduction(data.photovoltaicExpectedAnnualProduction),

--- a/apps/web/src/test/testAppDependencies.ts
+++ b/apps/web/src/test/testAppDependencies.ts
@@ -1,5 +1,9 @@
 import { AppDependencies } from "@/app/application/store";
 import { LocalStorageGetSiteApi } from "@/features/create-project/infrastructure/get-site-service/localStorageGetSiteService";
+import {
+  ExpectedPhotovoltaicPerformanceMock,
+  MOCK_RESULT,
+} from "@/features/create-project/infrastructure/photovoltaic-performance-service/photovoltaicPerformanceMock";
 import { LocalStorageSaveProjectApi } from "@/features/create-project/infrastructure/save-project-service/localStorageSaveSiteService";
 import { LocalStorageCreateSiteApi } from "@/features/create-site/infrastructure/create-site-service/localStorageCreateSiteApi";
 import { LocalStorageProjectDetailsApi } from "@/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi";
@@ -21,6 +25,7 @@ export const getTestAppDependencies = (
     projectDetailsService: new LocalStorageProjectDetailsApi(),
     saveProjectGateway: new LocalStorageSaveProjectApi(),
     sitesService: new LocalStorageSitesApi(),
+    photovoltaicPerformanceService: new ExpectedPhotovoltaicPerformanceMock(MOCK_RESULT),
     ...depsOverride,
   };
 };


### PR DESCRIPTION
- Ajout d’un endpoint qui permet de requêter l’API de l’outil [Photovoltaic Geographical Information System
](https://re.jrc.ec.europa.eu/pvg_tools/fr/) porté par la Commission Européenne 
- Ajout d’un service et d’un store dans le front pour récupérer la valeur 
- Ajout du détail du calcul dans la vue 

![image](https://github.com/incubateur-ademe/benefriches/assets/25612600/861598c1-6303-44c7-9c8a-7466a3024aae)

