### PR TITLE
feat: add route "premiers pas" with identity form 

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { LocationFeaturesModule } from "./location-features/adapters/primary/loc
 import { ReconversionProjectsModule } from "./reconversion-projects/adapters/primary/reconversionProjects.module";
 import { SqlConnectionModule } from "./shared-kernel/adapters/sql-knex/sqlConnection.module";
 import { SitesModule } from "./sites/adapters/primary/sites.module";
+import { UsersModule } from "./users/adapters/primary/users.module";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { SitesModule } from "./sites/adapters/primary/sites.module";
     CarbonStorageModule,
     SitesModule,
     ReconversionProjectsModule,
+    UsersModule,
   ],
   providers: [{ provide: APP_PIPE, useClass: ZodValidationPipe }],
 })

--- a/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240328153524_update-users-table.ts
+++ b/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240328153524_update-users-table.ts
@@ -11,6 +11,7 @@ export async function up(knex: Knex): Promise<void> {
     t.string("firstname");
     t.string("lastname");
     t.string("structure_type");
+    t.string("structure_activity");
     t.string("structure_name");
     t.timestamp("created_at").notNullable();
     t.timestamp("personal_data_storage_consented_at").notNullable();

--- a/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240328153524_update-users-table.ts
+++ b/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240328153524_update-users-table.ts
@@ -11,7 +11,6 @@ export async function up(knex: Knex): Promise<void> {
     t.string("firstname");
     t.string("lastname");
     t.string("structure_type");
-    t.string("structure_activity");
     t.string("structure_name");
     t.timestamp("created_at").notNullable();
     t.timestamp("personal_data_storage_consented_at").notNullable();

--- a/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240402162956_add-structure-activity-to-users-table.ts
+++ b/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240402162956_add-structure-activity-to-users-table.ts
@@ -1,0 +1,13 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table("users", function (table) {
+    table.string("structure_activity");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table("users", function (table) {
+    table.dropColumn("structure_activity");
+  });
+}

--- a/apps/api/src/users/adapters/primary/users.controller.integration-spec.ts
+++ b/apps/api/src/users/adapters/primary/users.controller.integration-spec.ts
@@ -1,0 +1,73 @@
+import { INestApplication } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { Test } from "@nestjs/testing";
+import { Knex } from "knex";
+import { z } from "nestjs-zod/z";
+import { Server } from "net";
+import supertest from "supertest";
+import { AppModule } from "src/app.module";
+import { SqlConnection } from "src/shared-kernel/adapters/sql-knex/sqlConnection.module";
+import { buildExhaustiveUserProps, buildMinimalUserProps } from "src/users/domain/model/user.mock";
+import { createUserBodychema } from "./users.controller";
+
+type BadRequestResponseBody = {
+  errors: { path: string[] }[];
+};
+
+describe("Users controller", () => {
+  let app: INestApplication<Server>;
+  let sqlConnection: Knex;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideModule(ConfigModule)
+      .useModule(ConfigModule.forRoot({ envFilePath: ".env.test" }))
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    sqlConnection = app.get(SqlConnection);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await sqlConnection.destroy();
+  });
+
+  describe("POST /users", () => {
+    it.each(["id", "email", "structureType", "structureActivity"] as (keyof z.infer<
+      typeof createUserBodychema
+    >)[])("can't create an user without mandatory field %s", async (mandatoryField) => {
+      const requestBody = buildMinimalUserProps();
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete requestBody[mandatoryField];
+
+      const response = await supertest(app.getHttpServer()).post("/users").send(requestBody);
+
+      expect(response.status).toEqual(400);
+      expect(response.body).toHaveProperty("errors");
+
+      const responseErrors = (response.body as BadRequestResponseBody).errors;
+      expect(responseErrors).toHaveLength(1);
+      expect(responseErrors[0].path).toContain(mandatoryField);
+    });
+
+    it.each([
+      { case: "with minimal data", requestBody: buildMinimalUserProps() },
+      { case: "with exhaustive data", requestBody: buildExhaustiveUserProps() },
+    ])("get a 201 response and user is created $case", async ({ requestBody }) => {
+      const response = await supertest(app.getHttpServer()).post("/users").send(requestBody);
+
+      expect(response.status).toEqual(201);
+
+      const usersInDb = await sqlConnection("users").select("id", "email");
+      expect(usersInDb.length).toEqual(1);
+      expect(usersInDb[0]).toEqual({
+        id: requestBody.id,
+        email: requestBody.email,
+      });
+    });
+  });
+});

--- a/apps/api/src/users/adapters/primary/users.controller.ts
+++ b/apps/api/src/users/adapters/primary/users.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Post } from "@nestjs/common";
+import { createZodDto } from "nestjs-zod";
+import { z } from "zod";
+import { CreateUserUseCase } from "src/users/domain/usecases/createUser.usecase";
+
+export const createUserBodychema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  firstname: z.string().optional(),
+  lastname: z.string().optional(),
+  structureType: z.string(),
+  structureActivity: z.string(),
+  structureName: z.string().optional(),
+  personalDataStorageConsented: z.literal(true),
+  personalDataAnalyticsUseConsented: z.boolean(),
+  personalDataCommunicationUseConsented: z.boolean(),
+});
+
+class CreateUserBodyDto extends createZodDto(createUserBodychema) {}
+
+@Controller("users")
+export class UsersController {
+  constructor(private readonly createUserUseCase: CreateUserUseCase) {}
+
+  @Post()
+  async createUser(@Body() createUserDto: CreateUserBodyDto) {
+    await this.createUserUseCase.execute({
+      user: createUserDto,
+    });
+  }
+}

--- a/apps/api/src/users/adapters/primary/users.module.ts
+++ b/apps/api/src/users/adapters/primary/users.module.ts
@@ -1,0 +1,21 @@
+import { Module } from "@nestjs/common";
+import { DateProvider } from "src/shared-kernel/adapters/date/DateProvider";
+import { IDateProvider } from "src/shared-kernel/adapters/date/IDateProvider";
+import { CreateUserUseCase, UserRepository } from "src/users/domain/usecases/createUser.usecase";
+import { SqlUserRepository } from "../secondary/user-repository/SqlUserRepository";
+import { UsersController } from "./users.controller";
+
+@Module({
+  controllers: [UsersController],
+  providers: [
+    {
+      provide: CreateUserUseCase,
+      useFactory: (userRepository: UserRepository, dateProvider: IDateProvider) =>
+        new CreateUserUseCase(userRepository, dateProvider),
+      inject: [SqlUserRepository, DateProvider],
+    },
+    SqlUserRepository,
+    DateProvider,
+  ],
+})
+export class UsersModule {}

--- a/apps/api/src/users/adapters/secondary/user-repository/InMemoryUserRepository.ts
+++ b/apps/api/src/users/adapters/secondary/user-repository/InMemoryUserRepository.ts
@@ -1,0 +1,19 @@
+import { User } from "src/users/domain/model/user";
+import { UserRepository } from "src/users/domain/usecases/createUser.usecase";
+
+export class InMemoryUserRepository implements UserRepository {
+  private users: User[] = [];
+
+  async save(user: User) {
+    this.users.push(user);
+    await Promise.resolve();
+  }
+
+  _getUsers() {
+    return this.users;
+  }
+
+  _setUsers(users: User[]) {
+    this.users = users;
+  }
+}

--- a/apps/api/src/users/adapters/secondary/user-repository/SqlUserRepository.integration-spec.ts
+++ b/apps/api/src/users/adapters/secondary/user-repository/SqlUserRepository.integration-spec.ts
@@ -1,0 +1,61 @@
+import knex, { Knex } from "knex";
+import knexConfig from "src/shared-kernel/adapters/sql-knex/knexConfig";
+import { buildExhaustiveUserProps, buildUser } from "src/users/domain/model/user.mock";
+import { SqlUserRepository } from "./SqlUserRepository";
+
+describe("SqlSiteRepository integration", () => {
+  let sqlConnection: Knex;
+  let userRepository: SqlUserRepository;
+
+  beforeAll(() => {
+    sqlConnection = knex(knexConfig);
+  });
+
+  afterAll(async () => {
+    await sqlConnection.destroy();
+  });
+
+  beforeEach(() => {
+    userRepository = new SqlUserRepository(sqlConnection);
+  });
+
+  it("Saves user with minimal required props", async () => {
+    const user = buildUser();
+
+    await userRepository.save(user);
+
+    const [result] = await sqlConnection("users").select().where({ id: user.id });
+    expect(result.id).toEqual(user.id);
+    expect(result.email).toEqual(user.email);
+    expect(result.personal_data_storage_consented_at).toEqual(user.personalDataStorageConsentedAt);
+    expect(result.firstname).toEqual(null);
+    expect(result.lastname).toEqual(null);
+    expect(result.structure_name).toEqual(null);
+    expect(result.structure_type).toEqual(user.structureType);
+    expect(result.structure_activity).toEqual(user.structureActivity);
+    expect(result.personal_data_analytics_use_consented_at).toEqual(null);
+    expect(result.personal_data_communication_use_consented_at).toEqual(null);
+  });
+
+  it("Saves user with full props", async () => {
+    const user = buildUser(buildExhaustiveUserProps());
+
+    await userRepository.save(user);
+
+    const [result] = await sqlConnection("users").select().where({ id: user.id });
+    expect(result).toEqual({
+      id: user.id,
+      email: user.email,
+      personal_data_storage_consented_at: user.personalDataStorageConsentedAt,
+      firstname: user.firstname,
+      lastname: user.lastname,
+      created_at: user.createdAt,
+      structure_name: user.structureName,
+      structure_type: user.structureType,
+      structure_activity: user.structureActivity,
+      personal_data_analytics_use_consented_at: user.personalDataAnalyticsUseConsentedAt ?? null,
+      personal_data_communication_use_consented_at:
+        user.personalDataCommunicationUseConsentedAt ?? null,
+    });
+  });
+});

--- a/apps/api/src/users/adapters/secondary/user-repository/SqlUserRepository.ts
+++ b/apps/api/src/users/adapters/secondary/user-repository/SqlUserRepository.ts
@@ -1,0 +1,50 @@
+import { Inject } from "@nestjs/common";
+import { Knex } from "knex";
+import { SqlConnection } from "src/shared-kernel/adapters/sql-knex/sqlConnection.module";
+import { User } from "src/users/domain/model/user";
+import { UserRepository } from "src/users/domain/usecases/createUser.usecase";
+
+declare module "knex/types/tables" {
+  interface Tables {
+    users: SqlUser;
+  }
+}
+type SqlUser = {
+  id: string;
+  email: string;
+  firstname?: string;
+  lastname?: string;
+  structure_name?: string;
+  structure_type?: string;
+  structure_activity?: string;
+  created_at: Date;
+  personal_data_storage_consented_at: Date;
+  personal_data_analytics_use_consented_at?: Date;
+  personal_data_communication_use_consented_at?: Date;
+};
+
+export class SqlUserRepository implements UserRepository {
+  constructor(@Inject(SqlConnection) private readonly sqlConnection: Knex) {}
+
+  async save(user: User): Promise<void> {
+    await this.sqlConnection.transaction(async (trx) => {
+      await trx("users").insert(
+        {
+          id: user.id,
+          email: user.email,
+          firstname: user.firstname,
+          lastname: user.lastname,
+          structure_name: user.structureName,
+          structure_type: user.structureType,
+          structure_activity: user.structureActivity,
+          created_at: user.createdAt,
+          personal_data_storage_consented_at: user.personalDataStorageConsentedAt,
+          personal_data_analytics_use_consented_at: user.personalDataAnalyticsUseConsentedAt,
+          personal_data_communication_use_consented_at:
+            user.personalDataCommunicationUseConsentedAt,
+        },
+        "id",
+      );
+    });
+  }
+}

--- a/apps/api/src/users/domain/model/user.mock.ts
+++ b/apps/api/src/users/domain/model/user.mock.ts
@@ -1,0 +1,38 @@
+import { UserProps } from "../usecases/createUser.usecase";
+import { User } from "./user";
+
+export const buildMinimalUserProps = (): UserProps => {
+  return {
+    id: "ecf6d4b1-d394-48c8-8208-fad936afe6ca",
+    email: "user@collectivite.fr",
+    structureActivity: "urban_planner",
+    structureType: "company",
+    personalDataAnalyticsUseConsented: false,
+    personalDataCommunicationUseConsented: false,
+    personalDataStorageConsented: true,
+  };
+};
+
+export const buildExhaustiveUserProps = (): Required<UserProps> => {
+  return {
+    id: "2096a04d-4876-4e1e-b071-d5355fd0ee4c",
+    email: "user@collectivite.fr",
+    firstname: "Jane",
+    lastname: "Doe",
+    structureType: "municipality",
+    structureActivity: "local_authority",
+    structureName: "Mairie de Blajan",
+    personalDataAnalyticsUseConsented: false,
+    personalDataCommunicationUseConsented: true,
+    personalDataStorageConsented: true,
+  };
+};
+
+export const buildUser = (props?: Partial<User>): User => {
+  return {
+    ...buildMinimalUserProps(),
+    createdAt: new Date(),
+    personalDataStorageConsentedAt: new Date(),
+    ...props,
+  };
+};

--- a/apps/api/src/users/domain/model/user.ts
+++ b/apps/api/src/users/domain/model/user.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  firstname: z.string().optional(),
+  lastname: z.string().optional(),
+  structureActivity: z.string(),
+  structureType: z.string(),
+  structureName: z.string().optional(),
+  createdAt: z.date(),
+  personalDataStorageConsentedAt: z.date(),
+  personalDataAnalyticsUseConsentedAt: z.date().optional(),
+  personalDataCommunicationUseConsentedAt: z.date().optional(),
+});
+
+export type User = z.infer<typeof userSchema>;

--- a/apps/api/src/users/domain/usecases/createUser.usecase.spec.ts
+++ b/apps/api/src/users/domain/usecases/createUser.usecase.spec.ts
@@ -1,0 +1,94 @@
+/* eslint-disable jest/no-conditional-expect */
+import { z } from "zod";
+import { DeterministicDateProvider } from "src/shared-kernel/adapters/date/DeterministicDateProvider";
+import { InMemoryUserRepository } from "src/users/adapters/secondary/user-repository/InMemoryUserRepository";
+import { User } from "../model/user";
+import { buildExhaustiveUserProps, buildMinimalUserProps } from "../model/user.mock";
+import { CreateUserUseCase, DateProvider } from "./createUser.usecase";
+
+describe("CreateUser Use Case", () => {
+  let dateProvider: DateProvider;
+  let userRepository: InMemoryUserRepository;
+  const fakeNow = new Date("2024-01-05T13:00:00");
+
+  const getZodIssues = (err: unknown) => {
+    if (err instanceof z.ZodError) {
+      return err.issues;
+    }
+    throw new Error("Not a ZodError");
+  };
+
+  beforeEach(() => {
+    dateProvider = new DeterministicDateProvider(fakeNow);
+    userRepository = new InMemoryUserRepository();
+  });
+
+  describe("Error cases", () => {
+    describe("Mandatory input data", () => {
+      it.each(["id", "email"])(
+        "Cannot create an user without providing %s",
+        async (mandatoryField) => {
+          const userProps = buildMinimalUserProps(); // @ts-expect-error dynamic delete
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete userProps[mandatoryField];
+
+          const usecase = new CreateUserUseCase(userRepository, dateProvider);
+
+          expect.assertions(3);
+          try {
+            await usecase.execute({ user: userProps });
+          } catch (err) {
+            const zIssues = getZodIssues(err);
+            expect(zIssues.length).toEqual(1);
+            expect(zIssues[0].path).toEqual([mandatoryField]);
+            expect(zIssues[0].code).toEqual("invalid_type");
+          }
+        },
+      );
+
+      it("Cannot create an user without providing storage consentment", async () => {
+        const userProps = buildMinimalUserProps();
+
+        const usecase = new CreateUserUseCase(userRepository, dateProvider);
+
+        await expect(async () =>
+          usecase.execute({
+            user: { ...userProps, personalDataStorageConsented: false },
+          }),
+        ).rejects.toThrow("Personal data storage consented field should be true");
+      });
+    });
+  });
+
+  describe("Success cases", () => {
+    it.each([
+      { case: "with minimal data", props: buildMinimalUserProps() },
+      { case: "with exhaustive data", props: buildExhaustiveUserProps() },
+    ])("Can create an user $case", async ({ props }) => {
+      const usecase = new CreateUserUseCase(userRepository, dateProvider);
+      await usecase.execute({ user: props });
+
+      const savedUser = userRepository._getUsers();
+
+      expect(savedUser).toEqual<User[]>([
+        {
+          id: props.id,
+          email: props.email,
+          firstname: props.firstname,
+          lastname: props.lastname,
+          structureType: props.structureType,
+          structureName: props.structureName,
+          structureActivity: props.structureActivity,
+          createdAt: fakeNow,
+          personalDataStorageConsentedAt: fakeNow,
+          personalDataAnalyticsUseConsentedAt: props.personalDataAnalyticsUseConsented
+            ? fakeNow
+            : undefined,
+          personalDataCommunicationUseConsentedAt: props.personalDataCommunicationUseConsented
+            ? fakeNow
+            : undefined,
+        },
+      ]);
+    });
+  });
+});

--- a/apps/api/src/users/domain/usecases/createUser.usecase.ts
+++ b/apps/api/src/users/domain/usecases/createUser.usecase.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { UseCase } from "src/shared-kernel/usecase";
+import { User, userSchema } from "../model/user";
+
+export interface UserRepository {
+  save(user: User): Promise<void>;
+}
+
+export interface DateProvider {
+  now(): Date;
+}
+
+export const userPropsSchema = userSchema
+  .omit({
+    createdAt: true,
+    personalDataAnalyticsUseConsentedAt: true,
+    personalDataCommunicationUseConsentedAt: true,
+    personalDataStorageConsentedAt: true,
+  })
+  .extend({
+    personalDataCommunicationUseConsented: z.boolean(),
+    personalDataAnalyticsUseConsented: z.boolean(),
+    personalDataStorageConsented: z.boolean(),
+  });
+export type UserProps = z.infer<typeof userPropsSchema>;
+
+type Request = {
+  user: UserProps;
+};
+
+export class CreateUserUseCase implements UseCase<Request, void> {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly dateProvider: DateProvider,
+  ) {}
+
+  async execute({ user: userProps }: Request): Promise<void> {
+    const {
+      personalDataCommunicationUseConsented,
+      personalDataAnalyticsUseConsented,
+      personalDataStorageConsented,
+      ...user
+    } = await userPropsSchema.parseAsync(userProps);
+
+    if (!personalDataStorageConsented) {
+      throw new Error("Personal data storage consented field should be true");
+    }
+
+    await this.userRepository.save({
+      ...user,
+      createdAt: this.dateProvider.now(),
+      personalDataStorageConsentedAt: this.dateProvider.now(),
+      personalDataAnalyticsUseConsentedAt: personalDataAnalyticsUseConsented
+        ? this.dateProvider.now()
+        : undefined,
+      personalDataCommunicationUseConsentedAt: personalDataCommunicationUseConsented
+        ? this.dateProvider.now()
+        : undefined,
+    });
+  }
+}

--- a/apps/web/src/app/application/appDependencies.ts
+++ b/apps/web/src/app/application/appDependencies.ts
@@ -7,7 +7,8 @@ import { HttpCreateSiteApi } from "@/features/create-site/infrastructure/create-
 import { LocalStorageProjectDetailsApi } from "@/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi";
 import { HttpReconversionProjectsListApi } from "@/features/projects/infrastructure/projects-list-service/HttpProjectsListApi";
 import { HttpReconversionProjectImpactsApi } from "@/features/projects/infrastructure/reconversion-project-impacts-service/HttpReconversionProjectImpactsService";
-import { LocalStorageUserService } from "@/features/users/infra/get-user-service/LocalStorageUserService";
+import { HttpCreateUserService } from "@/features/users/infra/create-user-service/HttpCreateUserService";
+import { LocalStorageUserService } from "@/features/users/infra/current-user-service/LocalStorageUserService";
 import { AdministrativeDivisionGeoApi } from "@/shared/infrastructure/administrative-division-service/administrativeDivisionGeoApi";
 import { SoilsCarbonStorageApi } from "@/shared/infrastructure/soils-carbon-storage-service/soilsCarbonStorageApi";
 
@@ -20,6 +21,7 @@ export const appDependencies: AppDependencies = {
   saveReconversionProjectService: new HttpSaveReconversionProjectService(),
   reconversionProjectImpacts: new HttpReconversionProjectImpactsApi(),
   photovoltaicPerformanceService: new ExpectedPhotovoltaicPerformanceApi(),
-  userService: new LocalStorageUserService(),
   municipalityDataService: new AdministrativeDivisionGeoApi(),
+  currentUserService: new LocalStorageUserService(),
+  createUserService: new HttpCreateUserService(),
 };

--- a/apps/web/src/app/application/store.ts
+++ b/apps/web/src/app/application/store.ts
@@ -21,7 +21,8 @@ import projectImpacts from "@/features/projects/application/projectImpacts.reduc
 import { ProjectsDetailsGateway } from "@/features/projects/application/projectImpactsComparison.actions";
 import projectImpactsComparison from "@/features/projects/application/projectImpactsComparison.reducer";
 import reconversionProjectsList from "@/features/projects/application/projectsList.reducer";
-import { UserGateway } from "@/features/users/application/initCurrentUser.action";
+import { CreateUserGateway } from "@/features/users/application/createUser.action";
+import { CurrentUserGateway } from "@/features/users/application/initCurrentUser.action";
 import currentUser from "@/features/users/application/user.reducer";
 
 export type AppDependencies = {
@@ -32,9 +33,10 @@ export type AppDependencies = {
   projectDetailsService: ProjectsDetailsGateway;
   getSiteByIdService: GetSitesByIdGateway;
   photovoltaicPerformanceService: PhotovoltaicPerformanceGateway;
-  userService: UserGateway;
   municipalityDataService: CreateSiteMunicipalityDataGateway | CreateProjectMunicipalityDataGateway;
   reconversionProjectImpacts: ReconversionProjectImpactsGateway;
+  currentUserService: CurrentUserGateway;
+  createUserService: CreateUserGateway;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/web/src/app/views/App.tsx
+++ b/apps/web/src/app/views/App.tsx
@@ -15,12 +15,14 @@ import CreateProjectPage from "@/features/create-project/views/ProjectCreationWi
 import CreateSiteIntroductionPage from "@/features/create-site/views/introduction/CreateSiteIntroductionPage";
 import CreateSiteFoncierPage from "@/features/create-site/views/SiteCreationWizard";
 import LoginPage from "@/features/login";
+import OnboardingPage from "@/features/onboarding";
 import MyProjectsPage from "@/features/projects/views/my-projects-page";
 import ProjectImpactsPage from "@/features/projects/views/project-impacts-page";
 import ProjectsImpactsComparisonPage from "@/features/projects/views/projects-impacts-comparison";
 import ProjectsComparisonSelectionPage from "@/features/projects/views/select-projects-comparison-page";
-import { initCurrentUserAction } from "@/features/users/application/initCurrentUser.action";
+import { initCurrentUser } from "@/features/users/application/initCurrentUser.action";
 import CreateUserPage from "@/features/users/views";
+import RequireRegisteredUser from "@/shared/views/components/RequireRegisteredUser/RequireRegisteredUser";
 import { useAppDispatch } from "@/shared/views/hooks/store.hooks";
 import HeaderFooterLayout from "@/shared/views/layout/HeaderFooterLayout/HeaderFooterLayout";
 
@@ -29,36 +31,67 @@ function App() {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    void dispatch(initCurrentUserAction());
+    void dispatch(initCurrentUser());
   }, [dispatch]);
 
   return (
     <HeaderFooterLayout>
       <>
         {route.name === routes.home.name && <HomePage />}
+        {route.name === routes.onboarding.name && <OnboardingPage />}
         {route.name === routes.login.name && <LoginPage />}
-        {route.name === routes.createUser.name && <CreateUserPage />}
-        {route.name === routes.createSiteFoncierIntro.name && <CreateSiteIntroductionPage />}
-        {route.name === routes.createSiteFoncier.name && <CreateSiteFoncierPage />}
-        {route.name === routes.myProjects.name && <MyProjectsPage />}
-        {route.name === routes.createProjectIntro.name && (
-          <CreateProjectIntroductionPage route={route} />
-        )}
-        {route.name === routes.createProject.name && <CreateProjectPage />}
-        {route.name === routes.compareProjects.name && (
-          <ProjectsImpactsComparisonPage route={route} />
-        )}
-        {route.name === routes.selectProjectToCompare.name && (
-          <ProjectsComparisonSelectionPage route={route} />
-        )}
-        {route.name === routes.projectImpacts.name && (
-          <ProjectImpactsPage projectId={route.params.projectId} />
-        )}
         {route.name === routes.budget.name && <BudgetPage />}
         {route.name === routes.stats.name && <StatsPage />}
         {route.name === routes.mentionsLegales.name && <MentionsLegalesPage />}
         {route.name === routes.accessibilite.name && <AccessibilitePage />}
         {route.name === routes.politiqueConfidentialite.name && <PolitiqueConfidentialitePage />}
+        {/* protected pages */}
+        {route.name === routes.createUser.name && (
+          <RequireRegisteredUser>
+            <CreateUserPage />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.createSiteFoncierIntro.name && (
+          <RequireRegisteredUser>
+            <CreateSiteIntroductionPage />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.createSiteFoncier.name && (
+          <RequireRegisteredUser>
+            <CreateSiteFoncierPage />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.myProjects.name && (
+          <RequireRegisteredUser>
+            <MyProjectsPage />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.createProjectIntro.name && (
+          <RequireRegisteredUser>
+            <CreateProjectIntroductionPage route={route} />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.createProject.name && (
+          <RequireRegisteredUser>
+            <CreateProjectPage />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.compareProjects.name && (
+          <RequireRegisteredUser>
+            <ProjectsImpactsComparisonPage route={route} />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.selectProjectToCompare.name && (
+          <RequireRegisteredUser>
+            <ProjectsComparisonSelectionPage route={route} />
+          </RequireRegisteredUser>
+        )}
+        {route.name === routes.projectImpacts.name && (
+          <RequireRegisteredUser>
+            <ProjectImpactsPage projectId={route.params.projectId} />
+          </RequireRegisteredUser>
+        )}
+        {/* 404 */}
         {route.name === false && (
           <section className={fr.cx("fr-container", "fr-py-4w")}>Page non trouvée</section>
         )}

--- a/apps/web/src/app/views/pages/PolitiqueConfidentialitePage.tsx
+++ b/apps/web/src/app/views/pages/PolitiqueConfidentialitePage.tsx
@@ -1,29 +1,12 @@
 import { fr } from "@codegouvfr/react-dsfr";
 
+import PolitiqueConfidentialiteContent from "@/shared/app-settings/views/PolitiqueConfidentialiteContent/PolitiqueConfidentialiteContent";
+
 function PolitiqueConfidentialitePage() {
   return (
     <section className={fr.cx("fr-container", "fr-py-4w")}>
       <h1>Politique de confidentialité</h1>
-      <p>Bénéfriches ne vous demande ni ne stocke d’information nominative.</p>
-      <p>
-        Vous êtes en droit de saisir la Commission Nationale de l’Informatique et des Libertés pour
-        toute réclamation à{" "}
-        <a
-          href="https://www.cnil.fr/fr/cnil-direct/question/adresser-une-reclamation-plainte-la-cnil-quelles-conditions-et-comment"
-          target="_blank"
-          rel="nofollow noopener noreferrer"
-        >
-          l’adresse suivante
-        </a>
-        .
-      </p>
-      <h2 id="cookies">Cookies</h2>
-      <p>
-        Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour
-        but de collecter des informations relatives à votre navigation et de vous adresser des
-        services adaptés à votre terminal (ordinateur, mobile ou tablette).
-      </p>
-      <p>Bénéfriches n'utilise pas de cookies.</p>
+      <PolitiqueConfidentialiteContent />
     </section>
   );
 }

--- a/apps/web/src/app/views/router.ts
+++ b/apps/web/src/app/views/router.ts
@@ -2,6 +2,7 @@ import { createRouter, defineRoute, param } from "type-route";
 
 const { RouteProvider, useRoute, routes } = createRouter({
   home: defineRoute("/"),
+  onboarding: defineRoute("/premiers-pas"),
   login: defineRoute("/se-connecter"),
   createUser: defineRoute("/creer-un-compte"),
   createSiteFoncierIntro: defineRoute("/creer-site-foncier/introduction"),

--- a/apps/web/src/features/create-project/domain/stakeholders.ts
+++ b/apps/web/src/features/create-project/domain/stakeholders.ts
@@ -1,6 +1,6 @@
 import { ProjectSite } from "./project.types";
 
-import { User } from "@/features/users/domain/user";
+import { UserStructure } from "@/features/users/domain/user";
 import { OwnerStructureType, TenantStructureType } from "@/shared/domain/stakeholder";
 import { LOCAL_AUTHORITY_AVAILABLE_VALUES } from "@/shared/views/components/form/LocalAuthoritySelect/values";
 
@@ -24,23 +24,23 @@ export const getSiteStakeholders = (site: ProjectSite): SiteStakeholder[] => {
 };
 
 export const isCurrentUserSameSiteStakeholderEntity = (
-  currentUserOrganization: Exclude<User["organization"], undefined>,
-  stakeholderEntity?: SiteStakeholder,
+  currentUserStructure: UserStructure,
+  stakeholder?: SiteStakeholder,
 ): boolean => {
-  if (!stakeholderEntity) {
+  if (!stakeholder) {
     return false;
   }
   return (
-    currentUserOrganization.type === stakeholderEntity.structureType &&
-    currentUserOrganization.name === stakeholderEntity.name
+    currentUserStructure.type === stakeholder.structureType &&
+    currentUserStructure.name === stakeholder.name
   );
 };
 
 export const getLocalAuthoritiesExcludedValues = (
-  currentUserOrganization: Exclude<User["organization"], undefined>,
+  currentUserStructure: UserStructure,
   siteStakeholderEntities: SiteStakeholder[],
 ) =>
   [
-    currentUserOrganization.type,
+    currentUserStructure.type,
     ...siteStakeholderEntities.map(({ structureType }) => structureType),
   ].filter((value) => LOCAL_AUTHORITY_AVAILABLE_VALUES.includes(value));

--- a/apps/web/src/features/create-project/views/stakeholders/future-site-owner/FutureSiteOwnerForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/future-site-owner/FutureSiteOwnerForm.tsx
@@ -7,7 +7,7 @@ import {
   isCurrentUserSameSiteStakeholderEntity,
   SiteStakeholder,
 } from "@/features/create-project/domain/stakeholders";
-import { User } from "@/features/users/domain/user";
+import { UserStructure } from "@/features/users/domain/user";
 import { LocalAutorityStructureType } from "@/shared/domain/stakeholder";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import Fieldset from "@/shared/views/components/form/Fieldset/Fieldset";
@@ -20,7 +20,7 @@ type Props = {
   onSubmit: (data: FormValues) => void;
   onBack: () => void;
   siteStakeholders: SiteStakeholder[];
-  currentUserCompany: Exclude<User["organization"], undefined>;
+  currentUserStructure?: UserStructure;
   projectSiteLocalAuthorities: ProjectSiteLocalAuthoritiesState;
 };
 
@@ -44,19 +44,19 @@ export type FormValues =
 const requiredMessage = "Ce champ est requis";
 
 const isCurrentUserSiteOwner = (
-  currentUserCompany: Props["currentUserCompany"],
+  currentUserStructure: UserStructure,
   currentSiteOwner?: SiteStakeholder,
-): boolean => isCurrentUserSameSiteStakeholderEntity(currentUserCompany, currentSiteOwner);
+): boolean => isCurrentUserSameSiteStakeholderEntity(currentUserStructure, currentSiteOwner);
 
 const isCurrentUserSiteTenant = (
-  currentUserCompany: Props["currentUserCompany"],
+  currentUserStructure: UserStructure,
   currentSiteTenant: SiteStakeholder,
-): boolean => isCurrentUserSameSiteStakeholderEntity(currentUserCompany, currentSiteTenant);
+): boolean => isCurrentUserSameSiteStakeholderEntity(currentUserStructure, currentSiteTenant);
 
 function FutureSiteOwnerForm({
   onSubmit,
   onBack,
-  currentUserCompany,
+  currentUserStructure,
   siteStakeholders,
   projectSiteLocalAuthorities,
 }: Props) {
@@ -69,18 +69,18 @@ function FutureSiteOwnerForm({
   const currentSiteOwner = siteStakeholders.find(({ role }) => role === "site_owner");
   const currentSiteTenant = siteStakeholders.find(({ role }) => role === "site_tenant");
 
-  const shouldDisplayCurrentUserCompanyOption = !isCurrentUserSiteOwner(
-    currentUserCompany,
-    currentSiteOwner,
-  );
+  const shouldDisplayCurrentUserCompanyOption = currentUserStructure
+    ? !isCurrentUserSiteOwner(currentUserStructure, currentSiteOwner)
+    : false;
 
   const shouldDisplaySiteTenantOption =
-    currentSiteTenant && !isCurrentUserSiteTenant(currentUserCompany, currentSiteTenant);
+    currentUserStructure && currentSiteTenant
+      ? !isCurrentUserSiteTenant(currentUserStructure, currentSiteTenant)
+      : false;
 
-  const localAuthoritiesExcludedValues = getLocalAuthoritiesExcludedValues(
-    currentUserCompany,
-    siteStakeholders,
-  );
+  const localAuthoritiesExcludedValues = currentUserStructure
+    ? getLocalAuthoritiesExcludedValues(currentUserStructure, siteStakeholders)
+    : [];
 
   return (
     <WizardFormLayout title="Qui sera le nouveau propriétaire du site ?">
@@ -91,15 +91,15 @@ function FutureSiteOwnerForm({
             formState.errors.futureSiteOwner ? formState.errors.futureSiteOwner.message : undefined
           }
         >
-          {shouldDisplayCurrentUserCompanyOption && (
+          {currentUserStructure && shouldDisplayCurrentUserCompanyOption && (
             <RadioButton
-              label={currentUserCompany.name}
+              label={currentUserStructure.name}
               value="user_company"
               {...register("futureSiteOwner", { required: requiredMessage })}
             />
           )}
 
-          {shouldDisplaySiteTenantOption && (
+          {currentSiteTenant && shouldDisplaySiteTenantOption && (
             <RadioButton
               label={currentSiteTenant.name}
               value="site_tenant"

--- a/apps/web/src/features/create-project/views/stakeholders/future-site-owner/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/future-site-owner/index.tsx
@@ -9,15 +9,15 @@ import { fetchSiteLocalAuthorities } from "@/features/create-project/application
 import { SiteLocalAuthorities } from "@/features/create-project/application/projectSiteLocalAuthorities.reducer";
 import { ProjectSite, ProjectStakeholder } from "@/features/create-project/domain/project.types";
 import { getSiteStakeholders } from "@/features/create-project/domain/stakeholders";
-import { selectCurrentUserCompany } from "@/features/users/application/user.reducer";
-import { User } from "@/features/users/domain/user";
+import { selectCurrentUserStructure } from "@/features/users/application/user.reducer";
+import { UserStructure } from "@/features/users/domain/user";
 import formatLocalAuthorityName from "@/shared/services/strings/formatLocalAuthorityName";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
 
 const convertFormValuesForStore = (
   data: FormValues,
   projectSite: ProjectSite,
-  currentUserCompany: Exclude<User["organization"], undefined>,
+  currentUserStructure: UserStructure | undefined,
   siteLocalAuthorities: SiteLocalAuthorities,
 ): ProjectStakeholder => {
   switch (data.futureSiteOwner) {
@@ -29,9 +29,10 @@ const convertFormValuesForStore = (
         structureType: data.localAuthority,
       };
     case "user_company":
+      if (!currentUserStructure) return { name: "", structureType: "unknown" };
       return {
-        name: currentUserCompany.name,
-        structureType: currentUserCompany.type,
+        name: currentUserStructure.name ?? "",
+        structureType: currentUserStructure.type as ProjectStakeholder["structureType"],
       };
     case "other_structure":
       return {
@@ -49,7 +50,7 @@ const convertFormValuesForStore = (
 function FutureOwnerFormContainer() {
   const dispatch = useAppDispatch();
   const projectSite = useAppSelector((state) => state.projectCreation.siteData);
-  const currentUserCompany = useAppSelector(selectCurrentUserCompany);
+  const currentUserStructure = useAppSelector(selectCurrentUserStructure);
   const projectSiteLocalAuthorities = useAppSelector((state) => state.projectSiteLocalAuthorities);
   const siteStakeholders = projectSite ? getSiteStakeholders(projectSite) : [];
 
@@ -59,7 +60,7 @@ function FutureOwnerFormContainer() {
     if (!projectSite || !siteLocalAuthorities) return;
     dispatch(
       completeFutureSiteOwner(
-        convertFormValuesForStore(data, projectSite, currentUserCompany, siteLocalAuthorities),
+        convertFormValuesForStore(data, projectSite, currentUserStructure, siteLocalAuthorities),
       ),
     );
   };
@@ -75,7 +76,7 @@ function FutureOwnerFormContainer() {
       onSubmit={onSubmit}
       onBack={onBack}
       siteStakeholders={siteStakeholders}
-      currentUserCompany={currentUserCompany}
+      currentUserStructure={currentUserStructure}
       projectSiteLocalAuthorities={projectSiteLocalAuthorities}
     />
   );

--- a/apps/web/src/features/create-project/views/stakeholders/operator/SiteOperatorForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/operator/SiteOperatorForm.tsx
@@ -7,7 +7,7 @@ import {
   isCurrentUserSameSiteStakeholderEntity,
   SiteStakeholder,
 } from "@/features/create-project/domain/stakeholders";
-import { User } from "@/features/users/domain/user";
+import { UserStructure } from "@/features/users/domain/user";
 import { LocalAutorityStructureType } from "@/shared/domain/stakeholder";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import Fieldset from "@/shared/views/components/form/Fieldset/Fieldset";
@@ -20,7 +20,7 @@ type Props = {
   onSubmit: (data: FormValues) => void;
   onBack: () => void;
   siteStakeholders: SiteStakeholder[];
-  currentUserCompany: Exclude<User["organization"], undefined>;
+  currentUserStructure?: UserStructure;
   projectSiteLocalAuthorities: ProjectSiteLocalAuthoritiesState;
 };
 
@@ -45,16 +45,23 @@ const requiredMessage = "Ce champ est requis";
 
 const getSiteRelatedOperatorOptions = (
   siteStakeholders: Props["siteStakeholders"],
-  currentUserCompany: Props["currentUserCompany"],
+  currentUserStructure?: Props["currentUserStructure"],
 ) => {
+  if (!currentUserStructure?.name) {
+    return siteStakeholders.map(({ name, role }) => ({
+      label: name,
+      value: role,
+    }));
+  }
+
   return [
     {
-      label: currentUserCompany.name,
+      label: currentUserStructure.name,
       value: "user_company",
     },
     ...siteStakeholders
       .filter(
-        (stakeholder) => !isCurrentUserSameSiteStakeholderEntity(currentUserCompany, stakeholder),
+        (stakeholder) => !isCurrentUserSameSiteStakeholderEntity(currentUserStructure, stakeholder),
       )
       .map(({ name, role }) => ({
         label: name,
@@ -67,7 +74,7 @@ function SiteOperatorForm({
   onSubmit,
   onBack,
   siteStakeholders,
-  currentUserCompany,
+  currentUserStructure,
   projectSiteLocalAuthorities,
 }: Props) {
   const { register, handleSubmit, formState, watch } = useForm<FormValues>({
@@ -76,10 +83,9 @@ function SiteOperatorForm({
 
   const selectedFutureOperator = watch("futureOperator");
 
-  const localAuthoritiesExcludedValues = getLocalAuthoritiesExcludedValues(
-    currentUserCompany,
-    siteStakeholders,
-  );
+  const localAuthoritiesExcludedValues = currentUserStructure
+    ? getLocalAuthoritiesExcludedValues(currentUserStructure, siteStakeholders)
+    : [];
 
   return (
     <WizardFormLayout title="Qui sera l'exploitant du site ?">
@@ -90,7 +96,7 @@ function SiteOperatorForm({
             formState.errors.futureOperator ? formState.errors.futureOperator.message : undefined
           }
         >
-          {getSiteRelatedOperatorOptions(siteStakeholders, currentUserCompany).map(
+          {getSiteRelatedOperatorOptions(siteStakeholders, currentUserStructure).map(
             ({ label, value }) => (
               <RadioButton
                 label={label}

--- a/apps/web/src/features/create-project/views/stakeholders/operator/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/operator/index.tsx
@@ -9,14 +9,14 @@ import { fetchSiteLocalAuthorities } from "@/features/create-project/application
 import { SiteLocalAuthorities } from "@/features/create-project/application/projectSiteLocalAuthorities.reducer";
 import { ProjectSite, ProjectStakeholder } from "@/features/create-project/domain/project.types";
 import { getSiteStakeholders } from "@/features/create-project/domain/stakeholders";
-import { selectCurrentUserCompany } from "@/features/users/application/user.reducer";
+import { selectCurrentUserStructure } from "@/features/users/application/user.reducer";
 import formatLocalAuthorityName from "@/shared/services/strings/formatLocalAuthorityName";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
 
 const convertFormValuesForStore = (
   data: FormValues,
   projectSite: ProjectSite,
-  currentUserCompany: string,
+  currentUserStructureName: string | undefined,
   siteLocalAuthorities: SiteLocalAuthorities,
 ): ProjectStakeholder => {
   switch (data.futureOperator) {
@@ -31,7 +31,7 @@ const convertFormValuesForStore = (
       };
     case "user_company":
       return {
-        name: currentUserCompany,
+        name: currentUserStructureName ?? "",
         structureType: "company",
       };
     case "other_structure":
@@ -50,7 +50,7 @@ const convertFormValuesForStore = (
 function SiteOperatorFormContainer() {
   const dispatch = useAppDispatch();
   const projectSite = useAppSelector((state) => state.projectCreation.siteData);
-  const currentUserCompany = useAppSelector(selectCurrentUserCompany);
+  const currentUserStructure = useAppSelector(selectCurrentUserStructure);
   const projectSiteLocalAuthorities = useAppSelector((state) => state.projectSiteLocalAuthorities);
 
   const siteStakeholders = projectSite ? getSiteStakeholders(projectSite) : [];
@@ -60,7 +60,12 @@ function SiteOperatorFormContainer() {
     if (!projectSite || !siteLocalAuthorities) return;
     dispatch(
       completeFutureOperator(
-        convertFormValuesForStore(data, projectSite, currentUserCompany.name, siteLocalAuthorities),
+        convertFormValuesForStore(
+          data,
+          projectSite,
+          currentUserStructure?.name,
+          siteLocalAuthorities,
+        ),
       ),
     );
   };
@@ -76,7 +81,7 @@ function SiteOperatorFormContainer() {
       onSubmit={onSubmit}
       onBack={onBack}
       siteStakeholders={siteStakeholders}
-      currentUserCompany={currentUserCompany}
+      currentUserStructure={currentUserStructure}
       projectSiteLocalAuthorities={projectSiteLocalAuthorities}
     />
   );

--- a/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/index.tsx
@@ -11,14 +11,14 @@ import { fetchSiteLocalAuthorities } from "@/features/create-project/application
 import { SiteLocalAuthorities } from "@/features/create-project/application/projectSiteLocalAuthorities.reducer";
 import { ProjectSite, ProjectStakeholder } from "@/features/create-project/domain/project.types";
 import { getSiteStakeholders } from "@/features/create-project/domain/stakeholders";
-import { selectCurrentUserCompany } from "@/features/users/application/user.reducer";
+import { selectCurrentUserStructure } from "@/features/users/application/user.reducer";
 import formatLocalAuthorityName from "@/shared/services/strings/formatLocalAuthorityName";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
 
 const convertFormValuesForStore = (
   data: FormValues,
   projectSite: ProjectSite,
-  currentUserCompany: string,
+  currentUserStructureName: string | undefined,
   siteLocalAuthorities: SiteLocalAuthorities,
 ): ProjectStakeholder => {
   switch (data.futureOperator) {
@@ -33,7 +33,7 @@ const convertFormValuesForStore = (
       };
     case "user_company":
       return {
-        name: currentUserCompany,
+        name: currentUserStructureName ?? "",
         structureType: "company",
       };
     case "other_structure":
@@ -51,7 +51,7 @@ const convertFormValuesForStore = (
 
 function SiteReinstatementContractOwnerFormContainer() {
   const dispatch = useAppDispatch();
-  const currentUserCompany = useAppSelector(selectCurrentUserCompany);
+  const currentUserStructure = useAppSelector(selectCurrentUserStructure);
   const projectSite = useAppSelector((state) => state.projectCreation.siteData);
 
   const projectSiteLocalAuthorities = useAppSelector((state) => state.projectSiteLocalAuthorities);
@@ -63,7 +63,12 @@ function SiteReinstatementContractOwnerFormContainer() {
     if (!projectSite || !siteLocalAuthorities) return;
     dispatch(
       completeReinstatementContractOwner(
-        convertFormValuesForStore(data, projectSite, currentUserCompany.name, siteLocalAuthorities),
+        convertFormValuesForStore(
+          data,
+          projectSite,
+          currentUserStructure?.name,
+          siteLocalAuthorities,
+        ),
       ),
     );
   };
@@ -79,7 +84,7 @@ function SiteReinstatementContractOwnerFormContainer() {
       onSubmit={onSubmit}
       onBack={onBack}
       siteStakeholders={siteStakeholders}
-      currentUserCompany={currentUserCompany}
+      currentUserStructure={currentUserStructure}
       projectSiteLocalAuthorities={projectSiteLocalAuthorities}
     />
   );

--- a/apps/web/src/features/create-site/application/createSite.reducer.spec.ts
+++ b/apps/web/src/features/create-site/application/createSite.reducer.spec.ts
@@ -941,6 +941,8 @@ describe("Create site reducer", () => {
         siteCreation: initialState,
         currentUser: {
           currentUser: buildUser(),
+          createUserState: "idle",
+          currentUserLoaded: true,
         },
       });
       await store.dispatch(saveSiteAction());
@@ -981,7 +983,14 @@ describe("Create site reducer", () => {
       const shouldFail = true;
       const store = createStore(
         getTestAppDependencies({ createSiteService: new InMemoryCreateSiteService(shouldFail) }),
-        { siteCreation: initialState, currentUser: { currentUser: buildUser() } },
+        {
+          siteCreation: initialState,
+          currentUser: {
+            currentUser: buildUser(),
+            createUserState: "idle",
+            currentUserLoaded: true,
+          },
+        },
       );
       await store.dispatch(saveSiteAction());
 
@@ -1006,7 +1015,11 @@ describe("Create site reducer", () => {
 
       const store = createStore(getTestAppDependencies(), {
         siteCreation: initialState,
-        currentUser: { currentUser: buildUser() },
+        currentUser: {
+          currentUser: buildUser(),
+          createUserState: "idle",
+          currentUserLoaded: true,
+        },
       });
 
       await store.dispatch(saveSiteAction());

--- a/apps/web/src/features/create-site/views/site-management/owner/SiteOwnerForm.tsx
+++ b/apps/web/src/features/create-site/views/site-management/owner/SiteOwnerForm.tsx
@@ -16,7 +16,7 @@ import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormL
 type Props = {
   onSubmit: (data: FormValues) => void;
   onBack: () => void;
-  currentUserCompany: string;
+  currentUserStructureName?: string;
   siteLocalAuthorities: { loadingState: LoadingState; localAuthorities?: SiteLocalAuthorities };
 };
 
@@ -39,7 +39,12 @@ export type FormValues =
 
 const requiredMessage = "Ce champ requis pour la suite du formulaire";
 
-function SiteOwnerForm({ onSubmit, onBack, currentUserCompany, siteLocalAuthorities }: Props) {
+function SiteOwnerForm({
+  onSubmit,
+  onBack,
+  currentUserStructureName,
+  siteLocalAuthorities,
+}: Props) {
   const { register, handleSubmit, watch, formState } = useForm<FormValues>({
     shouldUnregister: true,
   });
@@ -76,11 +81,13 @@ function SiteOwnerForm({ onSubmit, onBack, currentUserCompany, siteLocalAuthorit
               })}
             />
           )}
-          <RadioButton
-            label={`Mon entreprise, ${currentUserCompany}`}
-            value="user_company"
-            {...register("ownerType", { required: requiredMessage })}
-          />
+          {currentUserStructureName && (
+            <RadioButton
+              label={`Votre entreprise, ${currentUserStructureName}`}
+              value="user_company"
+              {...register("ownerType", { required: requiredMessage })}
+            />
+          )}
           <RadioButton
             label={`Une autre entreprise`}
             value="other_company"

--- a/apps/web/src/features/create-site/views/site-management/owner/index.tsx
+++ b/apps/web/src/features/create-site/views/site-management/owner/index.tsx
@@ -6,19 +6,19 @@ import { completeOwner } from "@/features/create-site/application/createSite.red
 import { fetchSiteMunicipalityData } from "@/features/create-site/application/siteMunicipalityData.actions";
 import { SiteLocalAuthorities } from "@/features/create-site/application/siteMunicipalityData.reducer";
 import { Owner } from "@/features/create-site/domain/siteFoncier.types";
-import { selectCurrentUserCompany } from "@/features/users/application/user.reducer";
+import { selectCurrentUserStructure } from "@/features/users/application/user.reducer";
 import formatLocalAuthorityName from "@/shared/services/strings/formatLocalAuthorityName";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
 
 const convertFormValuesForStore = (
   data: FormValues,
-  currentUserCompany: string,
+  currentUserStructure: string,
   localAuthorities: SiteLocalAuthorities,
 ): Owner => {
   switch (data.ownerType) {
     case "user_company":
       return {
-        name: currentUserCompany,
+        name: currentUserStructure,
         structureType: "company",
       };
     case "local_or_regional_authority":
@@ -40,7 +40,7 @@ const convertFormValuesForStore = (
 };
 
 function SiteOwnerFormContainer() {
-  const currentUserCompany = useAppSelector(selectCurrentUserCompany);
+  const currentUserStructure = useAppSelector(selectCurrentUserStructure);
   const { localAuthorities, loadingState } = useAppSelector((state) => state.siteMunicipalityData);
   const dispatch = useAppDispatch();
 
@@ -48,7 +48,7 @@ function SiteOwnerFormContainer() {
     if (!localAuthorities) return;
     dispatch(
       completeOwner({
-        owner: convertFormValuesForStore(data, currentUserCompany.name, localAuthorities),
+        owner: convertFormValuesForStore(data, currentUserStructure?.name || "", localAuthorities),
       }),
     );
   };
@@ -64,7 +64,7 @@ function SiteOwnerFormContainer() {
   return (
     <SiteOwnerForm
       siteLocalAuthorities={{ localAuthorities, loadingState }}
-      currentUserCompany={currentUserCompany.name}
+      currentUserStructureName={currentUserStructure?.name}
       onSubmit={onSubmit}
       onBack={onBack}
     />

--- a/apps/web/src/features/onboarding/index.tsx
+++ b/apps/web/src/features/onboarding/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { selectCurrentUserId } from "../users/application/user.reducer";
+import CreateUserForm from "../users/views/CreateUserForm";
+
+import { routes } from "@/app/views/router";
+import { useAppSelector } from "@/shared/views/hooks/store.hooks";
+
+function OnboardingPage() {
+  const currentUserId = useAppSelector(selectCurrentUserId);
+
+  useEffect(() => {
+    if (currentUserId) {
+      routes.createSiteFoncierIntro().push();
+    }
+  }, [currentUserId]);
+
+  return <CreateUserForm />;
+}
+
+export default OnboardingPage;

--- a/apps/web/src/features/users/application/createUser.action.ts
+++ b/apps/web/src/features/users/application/createUser.action.ts
@@ -1,0 +1,22 @@
+import { v4 as uuid } from "uuid";
+import { User, userSchema } from "../domain/user";
+
+import { createAppAsyncThunk } from "@/app/application/appAsyncThunk";
+
+export type CreateUserProps = Omit<User, "id">;
+
+export interface CreateUserGateway {
+  save(user: User): Promise<void>;
+}
+
+export const createUser = createAppAsyncThunk<User, CreateUserProps>(
+  "user/createUser",
+  async (createUserProps, { extra }) => {
+    const user = userSchema.parse({ ...createUserProps, id: uuid() });
+
+    await extra.createUserService.save(user);
+    await extra.currentUserService.save(user);
+
+    return user;
+  },
+);

--- a/apps/web/src/features/users/application/initCurrentUser.action.ts
+++ b/apps/web/src/features/users/application/initCurrentUser.action.ts
@@ -1,27 +1,14 @@
-import { v4 as uuid } from "uuid";
 import { User } from "../domain/user";
 
 import { createAppAsyncThunk } from "@/app/application/appAsyncThunk";
 
-export interface UserGateway {
-  getCurrentUser(): Promise<User | undefined>;
-  saveCurrentUser(user: User): Promise<void>;
+export interface CurrentUserGateway {
+  get(): Promise<User | undefined>;
+  save(user: User): Promise<void>;
 }
 
-export const initCurrentUserAction = createAppAsyncThunk(
-  "user/initCurrentUser",
-  async (_, { extra }) => {
-    const currentUser = await extra.userService.getCurrentUser();
+export const initCurrentUser = createAppAsyncThunk("user/initCurrentUser", async (_, { extra }) => {
+  const currentUser = await extra.currentUserService.get();
 
-    if (currentUser) return currentUser;
-
-    const anonymousUser = {
-      id: uuid(),
-      firstName: "Utilisateur/rice",
-      lastName: "Anonyme",
-    };
-    await extra.userService.saveCurrentUser(anonymousUser);
-
-    return anonymousUser;
-  },
-);
+  return currentUser;
+});

--- a/apps/web/src/features/users/domain/user.mock.ts
+++ b/apps/web/src/features/users/domain/user.mock.ts
@@ -2,9 +2,15 @@ import { User } from "./user";
 
 export const buildUser = (props?: Partial<User>): User => {
   return {
-    firstName: "John",
-    lastName: "Doe",
     id: "301d0f47-3775-4320-8e06-381047bebbed",
+    email: "john.doe@mail.com",
+    firstname: "John",
+    lastname: "Doe",
+    personalDataAnalyticsUseConsented: true,
+    personalDataCommunicationUseConsented: true,
+    personalDataStorageConsented: true,
+    structureActivity: "photovoltaic_plants_developer",
+    structureType: "company",
     ...props,
   };
 };

--- a/apps/web/src/features/users/domain/user.ts
+++ b/apps/web/src/features/users/domain/user.ts
@@ -1,10 +1,38 @@
-export type User = {
-  id: string;
-  firstName: string;
-  lastName: string;
-  organization?: {
-    id: string;
-    name: string;
-    type: "company";
-  };
+import { z } from "zod";
+
+const structureActivitySchema = z.enum([
+  "urban_planner",
+  "real_estate_developer",
+  "local_authority_landlord",
+  "local_authority",
+  "photovoltaic_plants_developer",
+  "industrialist",
+  "other",
+]);
+
+export type UserStructureActivity = z.infer<typeof structureActivitySchema>;
+
+const structureTypeSchema = z.enum(["local_authority", "company"]);
+
+export type UserStructureType = z.infer<typeof structureTypeSchema>;
+
+export const userSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  firstname: z.string().optional(),
+  lastname: z.string().optional(),
+  structureType: structureTypeSchema,
+  structureActivity: structureActivitySchema,
+  structureName: z.string().optional(),
+  personalDataStorageConsented: z.boolean(),
+  personalDataAnalyticsUseConsented: z.boolean(),
+  personalDataCommunicationUseConsented: z.boolean(),
+});
+
+export type User = z.infer<typeof userSchema>;
+
+export type UserStructure = {
+  type: UserStructureType;
+  activity: UserStructureActivity;
+  name?: string;
 };

--- a/apps/web/src/features/users/infra/create-user-service/HttpCreateUserService.ts
+++ b/apps/web/src/features/users/infra/create-user-service/HttpCreateUserService.ts
@@ -1,0 +1,16 @@
+import { CreateUserGateway } from "../../application/createUser.action";
+import { User } from "../../domain/user";
+
+export class HttpCreateUserService implements CreateUserGateway {
+  async save(user: User) {
+    const response = await fetch(`/api/users`, {
+      method: "POST",
+      body: JSON.stringify(user),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) throw new Error("Error while creating user");
+  }
+}

--- a/apps/web/src/features/users/infra/create-user-service/inMemoryCreateUserService.ts
+++ b/apps/web/src/features/users/infra/create-user-service/inMemoryCreateUserService.ts
@@ -1,0 +1,14 @@
+import { CreateUserGateway } from "../../application/createUser.action";
+import { User } from "../../domain/user";
+
+export class InMemoryCreateUserService implements CreateUserGateway {
+  _users: User[] = [];
+
+  constructor(private readonly shouldFail: boolean = false) {}
+
+  async save(newUser: User) {
+    if (this.shouldFail) throw new Error("Intended error");
+
+    await Promise.resolve(this._users.push(newUser));
+  }
+}

--- a/apps/web/src/features/users/infra/current-user-service/LocalStorageUserService.ts
+++ b/apps/web/src/features/users/infra/current-user-service/LocalStorageUserService.ts
@@ -1,16 +1,16 @@
-import { UserGateway } from "../../application/initCurrentUser.action";
+import { CurrentUserGateway } from "../../application/initCurrentUser.action";
 import { User } from "../../domain/user";
 
 const CURRENT_USER_STORAGE_KEY = "benefriches/current-user";
 
-export class LocalStorageUserService implements UserGateway {
-  getCurrentUser(): Promise<User | undefined> {
+export class LocalStorageUserService implements CurrentUserGateway {
+  get(): Promise<User | undefined> {
     const fromLocalStorage = localStorage.getItem(CURRENT_USER_STORAGE_KEY);
     const user = fromLocalStorage ? (JSON.parse(fromLocalStorage) as User) : undefined;
     return Promise.resolve(user);
   }
 
-  saveCurrentUser(user: User): Promise<void> {
+  save(user: User): Promise<void> {
     localStorage.setItem(CURRENT_USER_STORAGE_KEY, JSON.stringify(user));
     return Promise.resolve();
   }

--- a/apps/web/src/features/users/infra/current-user-service/LocalStorageUserService.ts
+++ b/apps/web/src/features/users/infra/current-user-service/LocalStorageUserService.ts
@@ -1,7 +1,7 @@
 import { CurrentUserGateway } from "../../application/initCurrentUser.action";
 import { User } from "../../domain/user";
 
-const CURRENT_USER_STORAGE_KEY = "benefriches/current-user";
+const CURRENT_USER_STORAGE_KEY = "benefriches/current-user/v0";
 
 export class LocalStorageUserService implements CurrentUserGateway {
   get(): Promise<User | undefined> {

--- a/apps/web/src/features/users/views/CreateUserForm/CreateUserForm.tsx
+++ b/apps/web/src/features/users/views/CreateUserForm/CreateUserForm.tsx
@@ -1,0 +1,180 @@
+import { useForm } from "react-hook-form";
+import { fr } from "@codegouvfr/react-dsfr";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import Select from "@codegouvfr/react-dsfr/SelectNext";
+import { UserStructureActivity } from "../../domain/user";
+
+import PolitiqueConfidentialiteContent from "@/shared/app-settings/views/PolitiqueConfidentialiteContent/PolitiqueConfidentialiteContent";
+import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
+import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
+
+const modal = createModal({
+  id: "terms-modal",
+  isOpenedByDefault: false,
+});
+
+export type FormValues = {
+  lastname: string;
+  firstname: string;
+  email: string;
+  structureActivity: UserStructureActivity;
+  structureName?: string;
+  personnalDataUseConsentment: "agreed";
+};
+
+type Props = {
+  createUserLoadingState: "idle" | "loading" | "success" | "error";
+  onSubmit: (data: FormValues) => void;
+};
+
+const structureActivityLabelMap = new Map<UserStructureActivity, string>([
+  ["urban_planner", "Aménageur urbain"],
+  ["real_estate_developer", "Promoteur"],
+  ["local_authority_landlord", "Bailleur social"],
+  ["local_authority", "Collectivité"],
+  ["photovoltaic_plants_developer", "Développeur de centrale photovoltaïque"],
+  ["industrialist", "Industriel"],
+  ["other", "Autre"],
+]);
+
+const structureActivityOptions = Array.from(structureActivityLabelMap).map(([value, label]) => ({
+  value,
+  label,
+}));
+
+function CreateUserForm({ onSubmit, createUserLoadingState }: Props) {
+  const { register, handleSubmit, formState } = useForm<FormValues>();
+
+  return (
+    <section className={fr.cx("fr-container", "fr-py-4w")}>
+      <WizardFormLayout title="Avant de commencer...">
+        <p>... nous avons besoin de connaître quelques informations sur vous.</p>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <h4>Votre identité</h4>
+          <Input
+            label={<RequiredLabel label="Email" />}
+            state={formState.errors.email ? "error" : "default"}
+            stateRelatedMessage={
+              formState.errors.email ? formState.errors.email.message : undefined
+            }
+            nativeInputProps={{
+              placeholder: "user@ademe.fr",
+              ...register("email", {
+                required: "Vous devez renseigner votre e-mail pour continuer.",
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: "Veuillez entrer une adresse email valide.",
+                },
+              }),
+            }}
+          />
+          <div className={fr.cx("fr-grid-row")}>
+            <Input
+              label="Nom"
+              nativeInputProps={{ ...register("lastname"), placeholder: "Chateau" }}
+              className={fr.cx("fr-col-6", "fr-pr-3v")}
+            />
+            <Input
+              label="Prénom"
+              nativeInputProps={{ ...register("firstname"), placeholder: "Laurent" }}
+              className={fr.cx("fr-col-6")}
+            />
+          </div>
+          <h4>Votre structure</h4>
+          <div className={fr.cx("fr-grid-row")}>
+            <Select
+              className={fr.cx("fr-col-6", "fr-pr-3v")}
+              label={<RequiredLabel label="Profil" />}
+              placeholder="Collectivité, aménageur urbain..."
+              state={formState.errors.structureActivity ? "error" : "default"}
+              stateRelatedMessage={
+                formState.errors.structureActivity
+                  ? formState.errors.structureActivity.message
+                  : undefined
+              }
+              nativeSelectProps={{
+                ...register("structureActivity", {
+                  required: "Vous devez sélectionner un type de profil pour continuer",
+                }),
+              }}
+              options={structureActivityOptions}
+            />
+            <Input
+              label="Nom"
+              className={fr.cx("fr-col-6")}
+              nativeInputProps={{
+                placeholder: "La région Auvergne-Rhône-Alpes",
+                ...register("structureName"),
+              }}
+            />
+          </div>
+          <Checkbox
+            state={formState.errors.personnalDataUseConsentment ? "error" : "default"}
+            stateRelatedMessage={
+              formState.errors.personnalDataUseConsentment
+                ? formState.errors.personnalDataUseConsentment.message
+                : undefined
+            }
+            options={[
+              {
+                label: "J’ai lu et j’accepte la politique de confidentialité de Bénéfriches",
+                nativeInputProps: {
+                  value: "agreed",
+                  ...register("personnalDataUseConsentment", {
+                    required: "Vous devez accepter la politique de confidentialité pour continuer.",
+                  }),
+                },
+              },
+            ]}
+          />
+          {createUserLoadingState === "error" && (
+            <Alert
+              description="Une erreur s’est produite lors de la sauvegarde des données... Veuillez réessayer."
+              severity="error"
+              title="Échec de l’enregistrement"
+              className="fr-my-7v"
+            />
+          )}
+
+          <ButtonsGroup
+            inlineLayoutWhen="always"
+            buttons={[
+              {
+                children: createUserLoadingState === "loading" ? "Chargement..." : "Commencer",
+                type: "submit",
+                disabled: createUserLoadingState === "loading",
+              },
+              {
+                children: "Lire la politique de confidentialité",
+                priority: "secondary",
+                type: "button",
+                onClick: () => {
+                  modal.open();
+                },
+              },
+            ]}
+          />
+        </form>
+
+        <modal.Component
+          size="large"
+          title="Politique de confidentialité"
+          buttons={[
+            {
+              children: "C’est compris",
+              type: "button",
+            },
+          ]}
+        >
+          <PolitiqueConfidentialiteContent />
+        </modal.Component>
+      </WizardFormLayout>
+    </section>
+  );
+}
+
+export default CreateUserForm;

--- a/apps/web/src/features/users/views/CreateUserForm/index.tsx
+++ b/apps/web/src/features/users/views/CreateUserForm/index.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { createUser } from "../../application/createUser.action";
+import CreateUserForm, { FormValues } from "./CreateUserForm";
+
+import { routes } from "@/app/views/router";
+import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
+
+function CreateUserFormContainer() {
+  const dispatch = useAppDispatch();
+  const createUserLoadingState = useAppSelector((state) => state.currentUser.createUserState);
+
+  const onSubmit = (data: FormValues) => {
+    void dispatch(
+      createUser({
+        email: data.email,
+        firstname: data.firstname,
+        lastname: data.lastname,
+        structureType: data.structureActivity === "local_authority" ? "local_authority" : "company",
+        structureActivity: data.structureActivity,
+        structureName: data.structureName,
+        personalDataStorageConsented: true,
+        personalDataAnalyticsUseConsented: true,
+        personalDataCommunicationUseConsented: true,
+      }),
+    );
+  };
+
+  useEffect(() => {
+    if (createUserLoadingState === "success") {
+      routes.createSiteFoncierIntro().push();
+    }
+  }, [createUserLoadingState]);
+
+  return <CreateUserForm onSubmit={onSubmit} createUserLoadingState={createUserLoadingState} />;
+}
+
+export default CreateUserFormContainer;

--- a/apps/web/src/shared/app-settings/infrastructure/LocalStorageUISettings.ts
+++ b/apps/web/src/shared/app-settings/infrastructure/LocalStorageUISettings.ts
@@ -1,7 +1,7 @@
 import { AppSettings, DEFAULT_APP_SETTINGS } from "../domain/appSettings";
 import { AppSettingsGateway } from "../domain/AppSettingsGateway";
 
-export const APP_SETTINGS_STORAGE_KEY = "benefriches/app-settings";
+export const APP_SETTINGS_STORAGE_KEY = "benefriches/app-settings/v0";
 
 export class LocalStorageAppSettings implements AppSettingsGateway {
   getAll(): AppSettings {

--- a/apps/web/src/shared/app-settings/views/PolitiqueConfidentialiteContent/PolitiqueConfidentialiteContent.tsx
+++ b/apps/web/src/shared/app-settings/views/PolitiqueConfidentialiteContent/PolitiqueConfidentialiteContent.tsx
@@ -87,7 +87,6 @@ function PolitiqueConfidentialiteContent() {
           préférences de internaute (thème sombre ou clair, choix de ne plus afficher certaines
           informations, etc.)
         </li>
-        <li>Bénéfriches n'utilise pas de cookies nominatifs.</li>
         <li>
           Bénéfriches n'utilise pas de cookies non essentiels au service ou n’ayant pas pour
           finalité exclusive de faciliter la communication par voie électronique.{" "}

--- a/apps/web/src/shared/app-settings/views/PolitiqueConfidentialiteContent/PolitiqueConfidentialiteContent.tsx
+++ b/apps/web/src/shared/app-settings/views/PolitiqueConfidentialiteContent/PolitiqueConfidentialiteContent.tsx
@@ -1,0 +1,111 @@
+import { routes } from "@/app/views/router";
+
+function PolitiqueConfidentialiteContent() {
+  return (
+    <>
+      <h2>Collecte directes de données</h2>
+      <h3>Quelles sont les données que nous traitons ?</h3>
+      La plateforme Bénéfriches peut traiter les données à caractère personnel suivantes :{" "}
+      <ul>
+        <li>
+          Données relatives au formulaire d’accès à l’outil (nom, prénom, email, nom et type de la
+          structure) ;
+        </li>
+      </ul>
+      L’accès à l’outil Bénéfriches est conditionné à la fourniture des informations suivantes :{" "}
+      <ul>
+        <li>Adresse e-mail</li>
+        <li>Type de structure </li>
+      </ul>
+      <h3>Traitement</h3>
+      <p>
+        Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé
+        par l’éditeur de la plateforme{" "}
+        <a {...routes.mentionsLegales().link} target="_blank" rel="nofollow noopener noreferrer">
+          voir les mentions légales
+        </a>{" "}
+        pour identifier les internautes de Bénéfriches à des fins fonctionnelles, statistiques et de
+        contact.
+      </p>
+      <p>La base légale du traitement est le consentement de l’internaute.</p>
+      <p>Les données collectées seront communiquées au seul destinataires suivant : l’ADEME. </p>
+      <p>
+        Les données sont conservées pendant une durée maximale de 5 ans à compter de leur collecte
+        ou du dernier contact émanant de l’internaute.
+      </p>
+      <ul>
+        <li>
+          Vous pouvez accéder aux données vous concernant, les rectifier, demander leur effacement
+          ou exercer votre droit à la limitation du traitement de vos données;
+        </li>
+        <li>Vous pouvez retirer à tout moment votre consentement au traitement de vos données ;</li>
+        <li>Vous pouvez également vous opposer au traitement de vos données ;</li>
+        <li>Vous pouvez également exercer votre droit à la portabilité de vos données</li>
+      </ul>
+      <p>
+        Pour exercer ces droits ou pour toute question sur le traitement de vos données dans ce
+        dispositif, vous pouvez nous contacter via le{" "}
+        <a rel="noopener noreferrer" target="_blank" href="https://tally.so/r/w7xBV6">
+          formulaire de contact Bénéfriches
+        </a>
+      </p>
+      <p>
+        Si vous estimez, après nous avoir contactés, que vos droits « Informatique et Libertés » ne
+        sont pas respectés, vous pouvez adresser une réclamation à la Commission Nationale de
+        l’Informatique et des Libertés à{" "}
+        <a
+          href="https://www.cnil.fr/fr/cnil-direct/question/adresser-une-reclamation-plainte-la-cnil-quelles-conditions-et-comment"
+          target="_blank"
+          rel="nofollow noopener noreferrer"
+        >
+          l’adresse suivante
+        </a>
+        .
+      </p>
+      <h2 id="cookies">Cookies</h2>
+      <p>
+        Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour
+        but de collecter des informations relatives à votre navigation et de vous adresser des
+        services adaptés à votre terminal (ordinateur, mobile ou tablette).
+      </p>
+      <p>
+        En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le
+        traitement des données à caractère personnel et la protection de la vie privée dans le
+        secteur des communications électroniques, transposée à l’article 82 de la loi n°78-17 du 6
+        janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les traceurs ou
+        cookies suivent deux régimes distincts.
+      </p>
+      <p>
+        Les cookies strictement nécessaires au service ou ayant pour finalité exclusive de faciliter
+        la communication par voie électronique sont dispensés de consentement préalable au titre de
+        l’article 82 de la loi n°78-17 du 6 janvier 1978.
+      </p>
+      <ul>
+        <li>Bénéfriches utilise des cookies techniques essentiels à l’utilisation du service.</li>
+        <li>
+          Bénéfriches utilise des cookies techniques de personnalisation pour mémoriser certaines
+          préférences de internaute (thème sombre ou clair, choix de ne plus afficher certaines
+          informations, etc.)
+        </li>
+        <li>Bénéfriches n'utilise pas de cookies nominatifs.</li>
+        <li>
+          Bénéfriches n'utilise pas de cookies non essentiels au service ou n’ayant pas pour
+          finalité exclusive de faciliter la communication par voie électronique.{" "}
+        </li>
+        <li>
+          Les cookies utilisés ne permettent pas de suivre la navigation de l’internaute sur
+          d’autres sites.
+        </li>
+      </ul>
+      <p>
+        À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur
+        votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible
+        notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari
+        et Opera). Néanmoins, il est possible que certaines sections du site ne fonctionnent pas
+        correctement suite à cette désactivation.
+      </p>
+    </>
+  );
+}
+
+export default PolitiqueConfidentialiteContent;

--- a/apps/web/src/shared/views/components/RequireRegisteredUser/RequireRegisteredUser.tsx
+++ b/apps/web/src/shared/views/components/RequireRegisteredUser/RequireRegisteredUser.tsx
@@ -10,7 +10,6 @@ export default function RequireRegisteredUser({ children }: { children: React.Re
   const currentUserLoaded = useAppSelector(isCurrentUserLoaded);
   const currentUserId = useAppSelector(selectCurrentUserId);
 
-  console.log(currentUserLoaded, currentUserId);
   if (!currentUserLoaded) {
     return null;
   }

--- a/apps/web/src/shared/views/components/RequireRegisteredUser/RequireRegisteredUser.tsx
+++ b/apps/web/src/shared/views/components/RequireRegisteredUser/RequireRegisteredUser.tsx
@@ -1,0 +1,24 @@
+import { useAppSelector } from "../../hooks/store.hooks";
+
+import { routes } from "@/app/views/router";
+import {
+  isCurrentUserLoaded,
+  selectCurrentUserId,
+} from "@/features/users/application/user.reducer";
+
+export default function RequireRegisteredUser({ children }: { children: React.ReactNode }) {
+  const currentUserLoaded = useAppSelector(isCurrentUserLoaded);
+  const currentUserId = useAppSelector(selectCurrentUserId);
+
+  console.log(currentUserLoaded, currentUserId);
+  if (!currentUserLoaded) {
+    return null;
+  }
+
+  if (!currentUserId) {
+    routes.onboarding().replace();
+    return null;
+  }
+
+  return children;
+}

--- a/apps/web/src/test/testAppDependencies.ts
+++ b/apps/web/src/test/testAppDependencies.ts
@@ -9,7 +9,8 @@ import { InMemoryCreateSiteService } from "@/features/create-site/infrastructure
 import { LocalStorageProjectDetailsApi } from "@/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi";
 import { InMemoryReconversionProjectsListService } from "@/features/projects/infrastructure/projects-list-service/InMemoryProjectsListService";
 import { MockReconversionProjectImpactsApi } from "@/features/projects/infrastructure/reconversion-project-impacts-service/MockReconversionProjectImpactsService";
-import { LocalStorageUserService } from "@/features/users/infra/get-user-service/LocalStorageUserService";
+import { InMemoryCreateUserService } from "@/features/users/infra/create-user-service/inMemoryCreateUserService";
+import { LocalStorageUserService } from "@/features/users/infra/current-user-service/LocalStorageUserService";
 import { AdministrativeDivisionMock } from "@/shared/infrastructure/administrative-division-service/administrativeDivisionMock";
 import { SoilsCarbonStorageMock } from "@/shared/infrastructure/soils-carbon-storage-service/soilsCarbonStorageMock";
 
@@ -28,7 +29,6 @@ export const getTestAppDependencies = (
     saveReconversionProjectService: new LocalStorageSaveProjectApi(),
     getSiteByIdService: new SitesServiceMock(),
     photovoltaicPerformanceService: new ExpectedPhotovoltaicPerformanceMock(MOCK_RESULT),
-    userService: new LocalStorageUserService(),
     municipalityDataService: new AdministrativeDivisionMock({
       localAuthorities: {
         city: {
@@ -50,6 +50,8 @@ export const getTestAppDependencies = (
       },
       population: 0,
     }),
+    currentUserService: new LocalStorageUserService(),
+    createUserService: new InMemoryCreateUserService(),
     ...depsOverride,
   };
 };


### PR DESCRIPTION
- Création d’une route /premiers-pas qui affiche le formulaire d’identité
- Si l’utilisateur a déjà renseigné son identité, on le redirige directement vers l’intro de création de site
- Je n’ai pas fait de get sur les infos de l’identité car comme on n’a pas encore de système d’auth, ça implique d’ouvrir un endpoint qui peut divulger des infos personnelles (email, etc)