### PR TITLE
feat: init environmental monetary impacts with ecosystem services impacts

### DIFF
--- a/apps/api/src/reconversion-projects/domain/model/impacts/permeable-surface/permeableSurfaceAreaImpact.ts
+++ b/apps/api/src/reconversion-projects/domain/model/impacts/permeable-surface/permeableSurfaceAreaImpact.ts
@@ -1,10 +1,9 @@
-import { typedObjectEntries } from "src/shared-kernel/typedEntries";
 import {
   isGreenSoil,
   isMineralSoil,
   isPermeableSoil,
   SoilsDistribution,
-  SoilType,
+  sumSoilsSurfaceAreasWhere,
 } from "src/soils/domain/soils";
 
 export type PermeableSurfaceAreaImpactResult = {
@@ -23,15 +22,6 @@ export type PermeableSurfaceAreaImpactResult = {
 type PermeableSurfaceAreaImpactInput = {
   baseSoilsDistribution: SoilsDistribution;
   forecastSoilsDistribution: SoilsDistribution;
-};
-
-const sumSoilsSurfaceAreasWhere = (
-  soilsDistribution: SoilsDistribution,
-  cb: (s: SoilType) => boolean,
-) => {
-  return typedObjectEntries(soilsDistribution)
-    .filter(([soilType]) => cb(soilType))
-    .reduce((sum, [, area]) => sum + (area ?? 0), 0);
 };
 
 export const computePermeableSurfaceAreaImpact = (

--- a/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.spec.ts
+++ b/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.spec.ts
@@ -1,120 +1,108 @@
 import {
-  computeSocioEconomicImpacts,
+  computeDirectAndIndirectEconomicImpacts,
   type SocioEconomicImpactsResult,
-} from "./computeSocioEconomicImpacts";
+} from "./computeDirectAndIndirectEconomicImpacts";
 
 describe("Socio-economic impacts", () => {
   describe("Rental income", () => {
     it("returns no impact when no current or future rental income", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
     it("returns rental income impact over 10 years for future site owner when the site is not currently rented but will be", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         futureSiteOwner: "Mairie de Paris",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [{ amount: 30000, purpose: "rent" }],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "Mairie de Paris",
-            amount: 300000,
-            impact: "rental_income",
-            impactCategory: "economic_direct",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "Mairie de Paris",
+          amount: 300000,
+          impact: "rental_income",
+          impactCategory: "economic_direct",
+        },
+      ]);
     });
 
     it("returns rental income negative impact over 10 years for current site owner when the site is rented but won't be anymore", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 20000, purpose: "rent" }],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "Current owner",
-            amount: -200000,
-            impact: "rental_income",
-            impactCategory: "economic_direct",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "Current owner",
+          amount: -200000,
+          impact: "rental_income",
+          impactCategory: "economic_direct",
+        },
+      ]);
     });
     it("returns cumulated rental income positive impact over 10 years for site owner when the site is currently rented and will be rented for a higher rent", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 5000, purpose: "rent" }],
         yearlyProjectedCosts: [{ amount: 10000, purpose: "rent" }],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "Current owner",
-            amount: 50000,
-            impact: "rental_income",
-            impactCategory: "economic_direct",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "Current owner",
+          amount: 50000,
+          impact: "rental_income",
+          impactCategory: "economic_direct",
+        },
+      ]);
     });
 
     it("returns rental income impact over 10 years for site owner and future site owner when the site is currently rented and will be but owner will change", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         futureSiteOwner: "New owner",
         yearlyCurrentCosts: [{ amount: 5000, purpose: "rent" }],
         yearlyProjectedCosts: [{ amount: 10000, purpose: "rent" }],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "New owner",
-            amount: 100000,
-            impact: "rental_income",
-            impactCategory: "economic_direct",
-          },
-          {
-            actor: "Current owner",
-            amount: 50000,
-            impact: "rental_income",
-            impactCategory: "economic_direct",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "New owner",
+          amount: 100000,
+          impact: "rental_income",
+          impactCategory: "economic_direct",
+        },
+        {
+          actor: "Current owner",
+          amount: 50000,
+          impact: "rental_income",
+          impactCategory: "economic_direct",
+        },
+      ]);
     });
   });
 
   describe("Avoided friche costs", () => {
     it("returns no impact when no current friche costs", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
 
     it("returns avoided friche costs for current tenant over 10 years when friche costs", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         currentTenant: "Current tenant",
@@ -142,20 +130,18 @@ describe("Socio-economic impacts", () => {
         ],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "Current tenant",
-            amount: 220000,
-            impact: "avoided_friche_costs",
-            impactCategory: "economic_direct",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "Current tenant",
+          amount: 220000,
+          impact: "avoided_friche_costs",
+          impactCategory: "economic_direct",
+        },
+      ]);
     });
 
     it("returns avoided friche costs for current owner over 10 years when friche costs but no tenant", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         currentTenant: undefined,
@@ -175,105 +161,93 @@ describe("Socio-economic impacts", () => {
         ],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "Current owner",
-            amount: 155000,
-            impact: "avoided_friche_costs",
-            impactCategory: "economic_direct",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "Current owner",
+          amount: 155000,
+          impact: "avoided_friche_costs",
+          impactCategory: "economic_direct",
+        },
+      ]);
     });
   });
 
   describe("Taxes income", () => {
     it("returns no impact when no current taxes costs", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
 
     it("returns taxes income impact as difference between projected and current taxes amounts", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 12000, purpose: "taxes" }],
         yearlyProjectedCosts: [{ amount: 20000, purpose: "taxes" }],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "community",
-            amount: 80000,
-            impact: "taxes_income",
-            impactCategory: "economic_indirect",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "community",
+          amount: 80000,
+          impact: "taxes_income",
+          impactCategory: "economic_indirect",
+        },
+      ]);
     });
 
     it("returns taxes income impact when only current taxes amount provided", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 12000, purpose: "taxes" }],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "community",
-            amount: -120000,
-            impact: "taxes_income",
-            impactCategory: "economic_indirect",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "community",
+          amount: -120000,
+          impact: "taxes_income",
+          impactCategory: "economic_indirect",
+        },
+      ]);
     });
 
     it("returns taxes income impact when only projected taxes amount provided", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [{ amount: 1234, purpose: "taxes" }],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "community",
-            amount: 12340,
-            impact: "taxes_income",
-            impactCategory: "economic_indirect",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "community",
+          amount: 12340,
+          impact: "taxes_income",
+          impactCategory: "economic_indirect",
+        },
+      ]);
     });
   });
 
   describe("Property transfer duties income", () => {
     it("returns no impact when no property transfer duties", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
 
     it("returns property transfer duties income impact for community", () => {
-      const result = computeSocioEconomicImpacts({
+      const result = computeDirectAndIndirectEconomicImpacts({
         evaluationPeriodInYears: 10,
         currentOwner: "Current owner",
         currentTenant: "Current tenant",
@@ -281,16 +255,14 @@ describe("Socio-economic impacts", () => {
         yearlyProjectedCosts: [],
         propertyTransferDutiesAmount: 5000,
       });
-      expect(result).toEqual<SocioEconomicImpactsResult>({
-        impacts: [
-          {
-            actor: "community",
-            amount: 5000,
-            impact: "property_transfer_duties_income",
-            impactCategory: "economic_indirect",
-          },
-        ],
-      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([
+        {
+          actor: "community",
+          amount: 5000,
+          impact: "property_transfer_duties_income",
+          impactCategory: "economic_indirect",
+        },
+      ]);
     });
   });
 });

--- a/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.ts
+++ b/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.ts
@@ -1,0 +1,126 @@
+import { ReconversionProject } from "../../reconversionProject";
+
+const RENT_PURPOSE_KEY = "rent";
+const TAXES_PURPOSE_KEY = "taxes";
+
+const FRICHE_COST_PURPOSES = [
+  "security",
+  "illegalDumpingCost",
+  "accidentsCost",
+  "otherSecuringCosts",
+] as const;
+
+type DirectAndIndirectEconomicImpactsInput = {
+  evaluationPeriodInYears: number;
+  currentOwner: string;
+  currentTenant?: string;
+  futureSiteOwner?: string;
+  yearlyCurrentCosts: { purpose: string; amount: number }[];
+  yearlyProjectedCosts: ReconversionProject["yearlyProjectedCosts"];
+  propertyTransferDutiesAmount?: number;
+};
+
+type BaseEconomicImpact = { actor: string; amount: number };
+type RentalIncomeImpact = BaseEconomicImpact & {
+  impact: "rental_income";
+  impactCategory: "economic_direct";
+};
+type AvoidedFricheCostsImpact = BaseEconomicImpact & {
+  impact: "avoided_friche_costs";
+  impactCategory: "economic_direct";
+};
+type TaxesIncomeImpact = BaseEconomicImpact & {
+  impact: "taxes_income";
+  impactCategory: "economic_indirect";
+  actor: "community";
+};
+type PropertyTransferDutiesIncomeImpact = BaseEconomicImpact & {
+  impact: "property_transfer_duties_income";
+  impactCategory: "economic_indirect";
+  actor: "community";
+};
+
+export type DirectAndIndirectEconomicImpact =
+  | RentalIncomeImpact
+  | AvoidedFricheCostsImpact
+  | TaxesIncomeImpact
+  | PropertyTransferDutiesIncomeImpact;
+
+export type SocioEconomicImpactsResult = DirectAndIndirectEconomicImpact[];
+
+export const computeDirectAndIndirectEconomicImpacts = (
+  input: DirectAndIndirectEconomicImpactsInput,
+): SocioEconomicImpactsResult => {
+  const impacts: SocioEconomicImpactsResult = [];
+
+  const projectedRentCost = input.yearlyProjectedCosts.find(
+    ({ purpose }) => purpose === RENT_PURPOSE_KEY,
+  );
+  const currentRentCost = input.yearlyCurrentCosts.find(
+    ({ purpose }) => purpose === RENT_PURPOSE_KEY,
+  );
+  if (projectedRentCost) {
+    if (input.futureSiteOwner) {
+      impacts.push({
+        amount: projectedRentCost.amount * input.evaluationPeriodInYears,
+        actor: input.futureSiteOwner,
+        impact: "rental_income",
+        impactCategory: "economic_direct",
+      });
+    }
+    if (currentRentCost) {
+      impacts.push({
+        amount: (projectedRentCost.amount - currentRentCost.amount) * input.evaluationPeriodInYears,
+        actor: input.currentOwner,
+        impact: "rental_income",
+        impactCategory: "economic_direct",
+      });
+    }
+  } else if (currentRentCost) {
+    impacts.push({
+      amount: -currentRentCost.amount * input.evaluationPeriodInYears,
+      actor: input.currentOwner,
+      impact: "rental_income",
+      impactCategory: "economic_direct",
+    });
+  }
+
+  const currentFricheCosts = input.yearlyCurrentCosts.filter(({ purpose }) =>
+    FRICHE_COST_PURPOSES.includes(purpose as (typeof FRICHE_COST_PURPOSES)[number]),
+  );
+  if (currentFricheCosts.length) {
+    const fricheCostImpactAmount = currentFricheCosts
+      .map(({ amount }) => amount)
+      .reduce((sum, amount) => sum + amount, 0);
+    impacts.push({
+      amount: fricheCostImpactAmount * input.evaluationPeriodInYears,
+      actor: input.currentTenant ?? input.currentOwner,
+      impact: "avoided_friche_costs",
+      impactCategory: "economic_direct",
+    });
+  }
+
+  const currentTaxesAmount =
+    input.yearlyCurrentCosts.find(({ purpose }) => purpose === TAXES_PURPOSE_KEY)?.amount ?? 0;
+  const projectedTaxesAmount =
+    input.yearlyProjectedCosts.find(({ purpose }) => purpose === TAXES_PURPOSE_KEY)?.amount ?? 0;
+  if (currentTaxesAmount || projectedTaxesAmount) {
+    impacts.push({
+      amount: (projectedTaxesAmount - currentTaxesAmount) * input.evaluationPeriodInYears,
+      impact: "taxes_income",
+      impactCategory: "economic_indirect",
+      actor: "community",
+    });
+  }
+
+  if (input.propertyTransferDutiesAmount) {
+    impacts.push({
+      amount: input.propertyTransferDutiesAmount,
+      impact: "property_transfer_duties_income",
+      actor: "community",
+      impactCategory: "economic_indirect",
+    });
+  }
+
+  return impacts;
+};

--- a/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeEnvironmentalMonetaryImpacts.spec.ts
+++ b/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeEnvironmentalMonetaryImpacts.spec.ts
@@ -1,0 +1,135 @@
+import {
+  computeEnvironmentalMonetaryImpacts,
+  computeSoilsDifferential,
+  type EnvironmentalMonetaryImpactResult,
+} from "./computeEnvironmentalMonetaryImpacts";
+
+describe("Environmental monetary impacts", () => {
+  it("returns no impact when no soils differential", () => {
+    const result = computeEnvironmentalMonetaryImpacts({
+      evaluationPeriodInYears: 10,
+      baseSoilsDistribution: {
+        PRAIRIE_BUSHES: 1000,
+        FOREST_CONIFER: 200,
+      },
+      forecastSoilsDistribution: {
+        PRAIRIE_BUSHES: 1000,
+        FOREST_CONIFER: 200,
+      },
+    });
+    expect(result).toEqual<EnvironmentalMonetaryImpactResult>([]);
+  });
+
+  describe("computeSoilsDifferential", () => {
+    it("return empty object", () => {
+      const result = computeSoilsDifferential({}, {});
+      expect(result).toEqual({});
+    });
+
+    it("return no difference", () => {
+      const result = computeSoilsDifferential(
+        { PRAIRIE_BUSHES: 1000, FOREST_CONIFER: 200 },
+        { PRAIRIE_BUSHES: 1000, FOREST_CONIFER: 200 },
+      );
+      expect(result).toEqual({ PRAIRIE_BUSHES: 0, FOREST_CONIFER: 0 });
+    });
+
+    it("compute soils differential between base and forecast", () => {
+      const result = computeSoilsDifferential(
+        {
+          PRAIRIE_BUSHES: 1000,
+          FOREST_CONIFER: 200,
+          WET_LAND: 250,
+          CULTIVATION: 100,
+          VINEYARD: 50,
+          ORCHARD: 50,
+          MINERAL_SOIL: 85,
+        },
+        {
+          PRAIRIE_BUSHES: 2000,
+          FOREST_CONIFER: 150,
+          WET_LAND: 300,
+          ARTIFICIAL_TREE_FILLED: 300,
+        },
+      );
+      expect(result).toEqual({
+        PRAIRIE_BUSHES: 1000,
+        FOREST_CONIFER: -50,
+        WET_LAND: 50,
+        CULTIVATION: -100,
+        VINEYARD: -50,
+        ORCHARD: -50,
+        MINERAL_SOIL: -85,
+        ARTIFICIAL_TREE_FILLED: 300,
+      });
+    });
+  });
+
+  it("returns positive enviromental monetary value for soils differential", () => {
+    const result = computeEnvironmentalMonetaryImpacts({
+      evaluationPeriodInYears: 10,
+      baseSoilsDistribution: {
+        PRAIRIE_BUSHES: 1000,
+        FOREST_CONIFER: 200,
+        WET_LAND: 250,
+        CULTIVATION: 100,
+        VINEYARD: 50,
+        ORCHARD: 50,
+        MINERAL_SOIL: 85,
+      },
+      forecastSoilsDistribution: {
+        PRAIRIE_BUSHES: 2000,
+        FOREST_CONIFER: 150,
+        WET_LAND: 300,
+        ARTIFICIAL_TREE_FILLED: 300,
+      },
+    });
+    expect(result).toEqual<EnvironmentalMonetaryImpactResult>([
+      {
+        amount: 2361,
+        impact: "ecosystem_services",
+        impactCategory: "environmental_monetary",
+        actor: "human_society",
+        details: [
+          { amount: 67, impact: "nature_related_wellness_and_leisure" },
+          { amount: 120, impact: "pollination" },
+          { amount: 44, impact: "invasive_species_regulation" },
+          { amount: 1690, impact: "water_cycle" },
+          { amount: 115, impact: "nitrogen_cycle" },
+          { amount: 325, impact: "soil_erosion" },
+        ],
+      },
+    ]);
+  });
+
+  it("returns negative enviromental monetary value for soils differential", () => {
+    const result = computeEnvironmentalMonetaryImpacts({
+      evaluationPeriodInYears: 10,
+      baseSoilsDistribution: {
+        PRAIRIE_BUSHES: 1000,
+        FOREST_CONIFER: 200,
+        WET_LAND: 250,
+      },
+      forecastSoilsDistribution: {
+        PRAIRIE_BUSHES: 500,
+        FOREST_CONIFER: 150,
+        WET_LAND: 250,
+        IMPERMEABLE_SOILS: 500,
+      },
+    });
+    expect(result).toEqual<EnvironmentalMonetaryImpactResult>([
+      {
+        amount: -882,
+        impact: "ecosystem_services",
+        impactCategory: "environmental_monetary",
+        actor: "human_society",
+        details: [
+          { amount: -51, impact: "nature_related_wellness_and_leisure" },
+          { amount: -51, impact: "pollination" },
+          { amount: -746, impact: "water_cycle" },
+          { amount: -34, impact: "nitrogen_cycle" },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeEnvironmentalMonetaryImpacts.ts
+++ b/apps/api/src/reconversion-projects/domain/model/impacts/socio-economic/computeEnvironmentalMonetaryImpacts.ts
@@ -1,0 +1,208 @@
+import {
+  isForest,
+  isPermeableSurfaceWithoutPermanentVegetation,
+  isPrairie,
+  isSurfaceWithEcosystemBenefits,
+  isSurfaceWithPermanentVegetation,
+  isWetLand,
+  SoilsDistribution,
+  SoilType,
+  sumSoilsSurfaceAreasWhere,
+} from "src/soils/domain/soils";
+
+type EnvironmentalMonetaryImpactInput = {
+  evaluationPeriodInYears: number;
+  baseSoilsDistribution: SoilsDistribution;
+  forecastSoilsDistribution: SoilsDistribution;
+};
+
+export type EnvironmentalMonetaryImpact = EcosystemServicesImpact;
+
+type EcosystemServicesImpact = {
+  amount: number;
+  actor: "human_society";
+  impact: "ecosystem_services";
+  impactCategory: "environmental_monetary";
+  details: {
+    amount: number;
+    impact:
+      | "nature_related_wellness_and_leisure"
+      | "forest_related_product"
+      | "pollination"
+      | "invasive_species_regulation"
+      | "water_cycle"
+      | "nitrogen_cycle"
+      | "soil_erosion";
+  }[];
+};
+
+const ENVIRONMENTAL_AMENITIES_PRAIRIE_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0071;
+const ENVIRONMENTAL_AMENITIES_FOREST_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0315;
+const WET_LAND_ECOSYSTEMIC_SERVICES_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0234;
+
+const computeNatureRelatedWellnessAndLeisure = (
+  prairieSurface: number,
+  forestSurface: number,
+  wetLandSurface: number,
+) => {
+  const prairieEnvironmentalAmenities =
+    prairieSurface * ENVIRONMENTAL_AMENITIES_PRAIRIE_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+  const forestEnvironmentalAmenities =
+    forestSurface * ENVIRONMENTAL_AMENITIES_FOREST_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+
+  const environmentalAmenities = prairieEnvironmentalAmenities + forestEnvironmentalAmenities;
+  const wetLandEcosystemServices =
+    wetLandSurface * WET_LAND_ECOSYSTEMIC_SERVICES_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+
+  return environmentalAmenities + wetLandEcosystemServices;
+};
+
+const FOREST_RELATED_PRODUCT_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0157;
+const computeForestRelatedProduct = (forestSurface: number) =>
+  Math.max(0, forestSurface * FOREST_RELATED_PRODUCT_MONETARY_VALUE_EURO_PER_SQUARE_METER);
+
+const POLLINATION_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0092;
+const computePollination = (surfaceWithEcosystemBenefits: number) =>
+  surfaceWithEcosystemBenefits * POLLINATION_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+
+const INVASIVE_SPECIES_REGULATION_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0034;
+const computeInvasiveSpeciesRegulation = (surfaceWithEcosystemBenefits: number) =>
+  Math.max(
+    0,
+    surfaceWithEcosystemBenefits * INVASIVE_SPECIES_REGULATION_MONETARY_VALUE_EURO_PER_SQUARE_METER,
+  );
+
+const WATER_CYCLE_PERMANENT_VEGETATION_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.1356;
+const WATER_CYCLE_NON_PERMANENT_VEGETATION_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0254;
+const computeWaterCycle = (soilsDifferentiel: SoilsDistribution) => {
+  const permanentVegetation =
+    sumSoilsSurfaceAreasWhere(soilsDifferentiel, isSurfaceWithPermanentVegetation) *
+    WATER_CYCLE_PERMANENT_VEGETATION_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+  const other =
+    sumSoilsSurfaceAreasWhere(soilsDifferentiel, isPermeableSurfaceWithoutPermanentVegetation) *
+    WATER_CYCLE_NON_PERMANENT_VEGETATION_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+
+  return permanentVegetation + other;
+};
+
+const NITROGEN_CYCLE_PRAIRIE_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0069;
+const NITROGEN_CYCLE_WET_LAND_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.0913;
+const computeNitrogenCycle = (prairieSurface: number, wetLandSurface: number) => {
+  const prairie = prairieSurface * NITROGEN_CYCLE_PRAIRIE_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+  const wetLand = wetLandSurface * NITROGEN_CYCLE_WET_LAND_MONETARY_VALUE_EURO_PER_SQUARE_METER;
+
+  return prairie + wetLand;
+};
+
+const SOIL_EROSION_MONETARY_VALUE_EURO_PER_SQUARE_METER = 0.025;
+const computeSoilErosion = (surfaceWithEcosystemBenefits: number) => {
+  return Math.max(
+    0,
+    surfaceWithEcosystemBenefits * SOIL_EROSION_MONETARY_VALUE_EURO_PER_SQUARE_METER,
+  );
+};
+
+export const computeSoilsDifferential = (
+  baseSoilsDistribution: SoilsDistribution,
+  forecastSoilsDistribution: SoilsDistribution,
+): SoilsDistribution => {
+  const soilTypes = Array.from(
+    new Set([...Object.keys(baseSoilsDistribution), ...Object.keys(forecastSoilsDistribution)]),
+  ) as SoilType[];
+
+  return soilTypes.reduce(
+    (difference, soilType) => ({
+      ...difference,
+      [soilType]:
+        (forecastSoilsDistribution[soilType] ?? 0) - (baseSoilsDistribution[soilType] ?? 0),
+    }),
+    {},
+  );
+};
+
+export type EnvironmentalMonetaryImpactResult = EnvironmentalMonetaryImpact[];
+
+export const computeEnvironmentalMonetaryImpacts = (
+  input: EnvironmentalMonetaryImpactInput,
+): EnvironmentalMonetaryImpactResult => {
+  const impacts: EnvironmentalMonetaryImpactResult = [];
+
+  const soilsDifferential = computeSoilsDifferential(
+    input.baseSoilsDistribution,
+    input.forecastSoilsDistribution,
+  );
+
+  const forestSurfaceDifference = sumSoilsSurfaceAreasWhere(soilsDifferential, isForest);
+  const prairieSurfaceDifference = sumSoilsSurfaceAreasWhere(soilsDifferential, isPrairie);
+  const wetLandSurfaceDifference = sumSoilsSurfaceAreasWhere(soilsDifferential, isWetLand);
+  const surfaceWithEcosystemBenefitsDifference = sumSoilsSurfaceAreasWhere(
+    soilsDifferential,
+    isSurfaceWithEcosystemBenefits,
+  );
+
+  const ecosystemServicesImpacts: EcosystemServicesImpact["details"] = [
+    {
+      amount: Math.round(
+        computeNatureRelatedWellnessAndLeisure(
+          prairieSurfaceDifference,
+          forestSurfaceDifference,
+          wetLandSurfaceDifference,
+        ) * input.evaluationPeriodInYears,
+      ),
+      impact: "nature_related_wellness_and_leisure",
+    },
+    {
+      amount: Math.round(
+        computeForestRelatedProduct(forestSurfaceDifference) * input.evaluationPeriodInYears,
+      ),
+      impact: "forest_related_product",
+    },
+    {
+      amount: Math.round(
+        computePollination(surfaceWithEcosystemBenefitsDifference) * input.evaluationPeriodInYears,
+      ),
+      impact: "pollination",
+    },
+    {
+      amount: Math.round(
+        computeInvasiveSpeciesRegulation(surfaceWithEcosystemBenefitsDifference) *
+          input.evaluationPeriodInYears,
+      ),
+      impact: "invasive_species_regulation",
+    },
+    {
+      amount: Math.round(computeWaterCycle(soilsDifferential) * input.evaluationPeriodInYears),
+      impact: "water_cycle",
+    },
+    {
+      amount: Math.round(
+        computeNitrogenCycle(prairieSurfaceDifference, wetLandSurfaceDifference) *
+          input.evaluationPeriodInYears,
+      ),
+      impact: "nitrogen_cycle",
+    },
+    {
+      amount: Math.round(
+        computeSoilErosion(surfaceWithEcosystemBenefitsDifference) * input.evaluationPeriodInYears,
+      ),
+      impact: "soil_erosion",
+    },
+  ].filter(({ amount }) => amount !== 0) as EcosystemServicesImpact["details"];
+
+  const ecosystemServicesTotalImpact = ecosystemServicesImpacts.reduce(
+    (total, { amount }) => total + amount,
+    0,
+  );
+
+  if (ecosystemServicesTotalImpact !== 0) {
+    impacts.push({
+      amount: ecosystemServicesTotalImpact,
+      impact: "ecosystem_services",
+      impactCategory: "environmental_monetary",
+      actor: "human_society",
+      details: ecosystemServicesImpacts,
+    });
+  }
+
+  return impacts;
+};

--- a/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.spec.ts
@@ -173,6 +173,38 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
                 impact: "property_transfer_duties_income",
                 impactCategory: "economic_indirect",
               },
+              {
+                actor: "human_society",
+                amount: 29820,
+                impact: "ecosystem_services",
+                impactCategory: "environmental_monetary",
+                details: [
+                  {
+                    amount: 1420,
+                    impact: "nature_related_wellness_and_leisure",
+                  },
+                  {
+                    amount: 1840,
+                    impact: "pollination",
+                  },
+                  {
+                    amount: 680,
+                    impact: "invasive_species_regulation",
+                  },
+                  {
+                    amount: 19500,
+                    impact: "water_cycle",
+                  },
+                  {
+                    amount: 1380,
+                    impact: "nitrogen_cycle",
+                  },
+                  {
+                    amount: 5000,
+                    impact: "soil_erosion",
+                  },
+                ],
+              },
             ],
           },
           economicBalance: {

--- a/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.ts
+++ b/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.ts
@@ -172,6 +172,8 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
           propertyTransferDutiesAmount:
             reconversionProject.realEstateTransactionPropertyTransferDutiesAmount,
           evaluationPeriodInYears,
+          baseSoilsDistribution: relatedSite.soilsDistribution,
+          forecastSoilsDistribution: reconversionProject.soilsDistribution,
         }),
         permeableSurfaceArea: computePermeableSurfaceAreaImpact({
           baseSoilsDistribution: relatedSite.soilsDistribution,

--- a/apps/api/src/soils/domain/soils.ts
+++ b/apps/api/src/soils/domain/soils.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { typedObjectEntries } from "src/shared-kernel/typedEntries";
 
 export const soilTypeSchema = z.enum([
   "BUILDINGS",
@@ -38,6 +39,15 @@ export const isMineralSoil = (soilType: SoilType) => {
   return soilType === "MINERAL_SOIL";
 };
 
+export const sumSoilsSurfaceAreasWhere = (
+  soilsDistribution: SoilsDistribution,
+  cb: (s: SoilType) => boolean,
+) => {
+  return typedObjectEntries(soilsDistribution)
+    .filter(([soilType]) => cb(soilType))
+    .reduce((sum, [, area]) => sum + (area ?? 0), 0);
+};
+
 const GREEN_SOILS: readonly SoilType[] = [
   "ARTIFICIAL_GRASS_OR_BUSHES_FILLED",
   "ARTIFICIAL_TREE_FILLED",
@@ -53,6 +63,46 @@ const GREEN_SOILS: readonly SoilType[] = [
   "ORCHARD",
 ];
 
+const FOREST_SOILS: readonly SoilType[] = [
+  "FOREST_CONIFER",
+  "FOREST_DECIDUOUS",
+  "FOREST_MIXED",
+  "FOREST_POPLAR",
+];
+const PRAIRIE_SOILS: readonly SoilType[] = ["PRAIRIE_BUSHES", "PRAIRIE_GRASS", "PRAIRIE_TREES"];
+
 export const isGreenSoil = (soilType: SoilType) => {
   return GREEN_SOILS.includes(soilType);
+};
+
+export const isPrairie = (soilType: SoilType) => {
+  return PRAIRIE_SOILS.includes(soilType);
+};
+
+export const isForest = (soilType: SoilType) => {
+  return FOREST_SOILS.includes(soilType);
+};
+
+export const isWetLand = (soilType: SoilType) => {
+  return "WET_LAND" === soilType;
+};
+
+export const isSurfaceWithEcosystemBenefits = (soilType: SoilType) => {
+  return [...FOREST_SOILS, ...PRAIRIE_SOILS, "ARTIFICIAL_TREE_FILLED", "WET_LAND"].includes(
+    soilType,
+  );
+};
+
+export const isSurfaceWithPermanentVegetation = (soilType: SoilType) => {
+  return isSurfaceWithEcosystemBenefits(soilType);
+};
+
+export const isPermeableSurfaceWithoutPermanentVegetation = (soilType: SoilType) => {
+  return [
+    "ARTIFICIAL_GRASS_OR_BUSHES_FILLED",
+    "CULTIVATION",
+    "VINEYARD",
+    "ORCHARD",
+    "MINERAL_SOIL",
+  ].includes(soilType);
 };

--- a/apps/web/src/features/projects/domain/impacts.types.ts
+++ b/apps/web/src/features/projects/domain/impacts.types.ts
@@ -23,6 +23,22 @@ type PropertyTransferDutiesIncomeImpact = BaseEconomicImpact & {
   actor: "community";
 };
 
+export type EcosystemServicesImpact = BaseEconomicImpact & {
+  impact: "ecosystem_services";
+  impactCategory: "environmental_monetary";
+  details: {
+    amount: number;
+    impact:
+      | "nature_related_wellness_and_leisure"
+      | "forest_related_product"
+      | "pollination"
+      | "invasive_species_regulation"
+      | "water_cycle"
+      | "nitrogen_cycle"
+      | "soil_erosion";
+  }[];
+};
+
 export type ReconversionProjectImpacts = {
   permeableSurfaceArea: {
     base: number;
@@ -117,6 +133,7 @@ export type ReconversionProjectImpacts = {
       | AvoidedFricheCostsImpact
       | TaxesIncomeImpact
       | PropertyTransferDutiesIncomeImpact
+      | EcosystemServicesImpact
     )[];
   };
 };

--- a/apps/web/src/features/projects/views/project-impacts-page/impacts/socio-economic/SocioEconomicImpactsByActorChart.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/impacts/socio-economic/SocioEconomicImpactsByActorChart.tsx
@@ -1,7 +1,7 @@
 import * as Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import { baseColumnChartConfig } from "../../../shared/sharedChartConfig";
-import { sumSocioEconomicImpactsByActor } from "./socioEconomicImpacts";
+import { getActorLabel, sumSocioEconomicImpactsByActor } from "./socioEconomicImpacts";
 
 import { ReconversionProjectImpacts } from "@/features/projects/domain/impacts.types";
 import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
@@ -9,11 +9,6 @@ import { roundTo2Digits } from "@/shared/services/round-numbers/roundNumbers";
 
 type Props = {
   socioEconomicImpacts: ReconversionProjectImpacts["socioeconomic"]["impacts"];
-};
-
-const getActorLabel = (actor: string) => {
-  if (actor === "community") return "Collectivité";
-  return actor;
 };
 
 function SocioEconomicImpactsByActorChart({ socioEconomicImpacts }: Props) {

--- a/apps/web/src/features/projects/views/project-impacts-page/impacts/socio-economic/socioEconomicImpacts.ts
+++ b/apps/web/src/features/projects/views/project-impacts-page/impacts/socio-economic/socioEconomicImpacts.ts
@@ -54,5 +54,18 @@ export const getLabelForSocioEconomicImpactCategory = (
       return "Économiques directs";
     case "economic_indirect":
       return "Économiques indirects";
+    case "environmental_monetary":
+      return "Environnementaux monétarisés";
+  }
+};
+
+export const getActorLabel = (label: SocioEconomicImpacts[number]["actor"]) => {
+  switch (label) {
+    case "community":
+      return "Collectivité";
+    case "human_society":
+      return "Société humaine";
+    default:
+      return label;
   }
 };

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/SocioEconomicSection.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/SocioEconomicSection.tsx
@@ -1,3 +1,4 @@
+import { getActorLabel } from "../impacts/socio-economic/socioEconomicImpacts";
 import { formatMonetaryImpact } from "./formatImpactValue";
 import ImpactDetailLabel from "./ImpactDetailLabel";
 import ImpactDetailRow from "./ImpactItemDetailRow";
@@ -5,7 +6,10 @@ import ImpactItemGroup from "./ImpactItemGroup";
 import ImpactLabel from "./ImpactLabel";
 import ImpactValue from "./ImpactValue";
 
-import { ReconversionProjectImpacts } from "@/features/projects/domain/impacts.types";
+import {
+  EcosystemServicesImpact,
+  ReconversionProjectImpacts,
+} from "@/features/projects/domain/impacts.types";
 
 type Props = {
   socioEconomicImpacts: ReconversionProjectImpacts["socioeconomic"]["impacts"];
@@ -15,10 +19,31 @@ type SocioEconomicImpactRowProps = {
   impact: Props["socioEconomicImpacts"][number];
 };
 
+const getLabelForEcosystemServicesImpact = (
+  label: EcosystemServicesImpact["details"][number]["impact"],
+) => {
+  switch (label) {
+    case "forest_related_product":
+      return "🪵 Produits issus de la forêt";
+    case "invasive_species_regulation":
+      return "🦔 Régulation des espèces invasives";
+    case "nature_related_wellness_and_leisure":
+      return "🚵‍♂️ Bien-être et loisirs liés à la nature";
+    case "nitrogen_cycle":
+      return "🍄 Cycle de l’azote";
+    case "pollination":
+      return "🐝 Pollinisation";
+    case "soil_erosion":
+      return "🌾 Régulation de l’érosion des sols";
+    case "water_cycle":
+      return "💧 Cycle de l’eau";
+  }
+};
+
 const SocioEconomicImpactRow = ({ impact }: SocioEconomicImpactRowProps) => {
   return (
     <ImpactDetailRow key={impact.actor + impact.amount}>
-      <ImpactDetailLabel>{impact.actor}</ImpactDetailLabel>
+      <ImpactDetailLabel>{getActorLabel(impact.actor)}</ImpactDetailLabel>
       <ImpactValue>{formatMonetaryImpact(impact.amount)}</ImpactValue>
     </ImpactDetailRow>
   );
@@ -42,6 +67,10 @@ const SocioEconomicImpactsListSection = ({ socioEconomicImpacts }: Props) => {
   const propertyTransferDutiesIncomeImpact =
     socioEconomicImpacts.find((i) => i.impact === "property_transfer_duties_income") ?? null;
 
+  const ecosystemServicesImpact = socioEconomicImpacts.find(
+    (impact) => impact.impact === "ecosystem_services",
+  ) as EcosystemServicesImpact | undefined;
+
   return (
     <section className="fr-mb-5w">
       <h3>Impacts économiques</h3>
@@ -64,7 +93,7 @@ const SocioEconomicImpactsListSection = ({ socioEconomicImpacts }: Props) => {
           </ImpactItemGroup>
         )}
       </section>
-      <section>
+      <section className="fr-mb-5w">
         <h4>Impacts économiques indirects</h4>
         {hasTaxesIncomeImpacts && (
           <ImpactItemGroup>
@@ -84,6 +113,30 @@ const SocioEconomicImpactsListSection = ({ socioEconomicImpacts }: Props) => {
               impact={propertyTransferDutiesIncomeImpact}
             />
           </ImpactItemGroup>
+        )}
+      </section>
+      <section className="fr-mb-5w">
+        <h4>Impacts environnementaux monétarisés</h4>
+        {ecosystemServicesImpact && (
+          <>
+            <ImpactItemGroup>
+              <ImpactLabel>🌻 Services écosystémiques</ImpactLabel>
+              <ImpactDetailRow key={ecosystemServicesImpact.actor + ecosystemServicesImpact.amount}>
+                <ImpactDetailLabel>
+                  {getActorLabel(ecosystemServicesImpact.actor)}
+                </ImpactDetailLabel>
+                <ImpactValue isTotal>
+                  {formatMonetaryImpact(ecosystemServicesImpact.amount)}
+                </ImpactValue>
+              </ImpactDetailRow>
+            </ImpactItemGroup>
+            {ecosystemServicesImpact.details.map(({ amount, impact }) => (
+              <ImpactDetailRow key={impact}>
+                <ImpactDetailLabel>{getLabelForEcosystemServicesImpact(impact)}</ImpactDetailLabel>
+                <ImpactValue>{formatMonetaryImpact(amount)}</ImpactValue>
+              </ImpactDetailRow>
+            ))}
+          </>
         )}
       </section>
     </section>


### PR DESCRIPTION
Le nouveau fichier `/computeDirectAndIndirectEconomicImpacts.ts` est juste un renommage de `computeSocioEconomicImpacts.ts` (je n’ai rien changé au contenu, mais il ne s’affiche pas en renommage vu que j’ai créé un nouveau `computeSocioEconomicImpacts` qui agrège les résultats de `computeDirectAndIndirectEconomicImpacts` et `computeEnvironmentalMonetaryImpacts`)