### PR TITLE
feat(web): init impact description modals for economic main title sections

### DIFF
--- a/apps/web/src/features/projects/views/project-impacts-page/ImpactChartCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ImpactChartCard.tsx
@@ -3,10 +3,10 @@ import { ReactNode } from "react";
 type Props = {
   title: ReactNode;
   children?: ReactNode;
-  displayDescriptionModal?: () => void;
+  onTitleClick?: () => void;
 };
 
-const ImpactCard = ({ title, children, displayDescriptionModal }: Props) => {
+const ImpactCard = ({ title, children, onTitleClick }: Props) => {
   return (
     <figure
       style={{
@@ -16,8 +16,8 @@ const ImpactCard = ({ title, children, displayDescriptionModal }: Props) => {
       }}
       className="tw-flex tw-flex-col fr-py-2w fr-px-3w fr-m-0"
     >
-      {displayDescriptionModal ? (
-        <strong className="tw-cursor-pointer" onClick={displayDescriptionModal}>
+      {onTitleClick ? (
+        <strong className="tw-cursor-pointer" onClick={onTitleClick}>
           {title}
         </strong>
       ) : (

--- a/apps/web/src/features/projects/views/project-impacts-page/ImpactChartCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ImpactChartCard.tsx
@@ -1,19 +1,30 @@
 import { ReactNode } from "react";
-import { fr } from "@codegouvfr/react-dsfr";
 
 type Props = {
   title: ReactNode;
   children?: ReactNode;
+  displayDescriptionModal?: () => void;
 };
 
-const ImpactCard = ({ title, children }: Props) => {
+const ImpactCard = ({ title, children, displayDescriptionModal }: Props) => {
   return (
     <figure
-      style={{ border: "1px solid #DDDDDD", background: "#ECF5FD", height: "100%" }}
-      className={fr.cx("fr-py-2w", "fr-px-3w", "fr-m-0")}
+      style={{
+        border: "1px solid #DDDDDD",
+        background: "#ECF5FD",
+        height: "100%",
+      }}
+      className="tw-flex tw-flex-col fr-py-2w fr-px-3w fr-m-0"
     >
-      <strong>{title}</strong>
-      {children}
+      {displayDescriptionModal ? (
+        <strong className="tw-cursor-pointer" onClick={displayDescriptionModal}>
+          {title}
+        </strong>
+      ) : (
+        <strong>{title}</strong>
+      )}
+
+      <div className="tw-flex tw-flex-col tw-grow tw-justify-center">{children}</div>
     </figure>
   );
 };

--- a/apps/web/src/features/projects/views/project-impacts-page/ImpactsChartsView.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ImpactsChartsView.tsx
@@ -11,19 +11,21 @@ import StoredAndAvoidedCO2ImpactCard from "./impacts/environment/StoredAndAvoide
 import AccidentsImpactCard from "./impacts/social/AccidentsImpactCard";
 import FullTimeJobsImpactCard from "./impacts/social/FullTimeJobsImpactCard";
 import SocioEconomicImpactsCard from "./impacts/socio-economic/SocioEconomicImpactsCard";
+import { ImpactDescriptionModalCategory } from "./modals/ImpactDescriptionModal";
 
 type Props = {
   project: {
     name: string;
   };
   impacts: ReconversionProjectImpacts;
+  openImpactDescriptionModal: (category: ImpactDescriptionModalCategory) => void;
 };
 
 const Row = ({ children }: { children: ReactNode }) => {
   return <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>{children}</div>;
 };
 
-const ImpactsChartsView = ({ project, impacts }: Props) => {
+const ImpactsChartsView = ({ project, impacts, openImpactDescriptionModal }: Props) => {
   return (
     <div>
       <section className={fr.cx("fr-pb-8v")}>
@@ -33,17 +35,28 @@ const ImpactsChartsView = ({ project, impacts }: Props) => {
             <CostBenefitAnalysisCard
               economicBalanceTotal={impacts.economicBalance.total}
               socioEconomicImpactsTotal={impacts.socioeconomic.total}
+              displayDescriptionModal={() => {
+                openImpactDescriptionModal("cost-benefit-analysis");
+              }}
             />
           </div>
           <div className="lg:tw-row-start-1">
             <EconomicBalanceImpactCard
               costs={impacts.economicBalance.costs}
               revenues={impacts.economicBalance.revenues}
+              displayDescriptionModal={() => {
+                openImpactDescriptionModal("economic-balance");
+              }}
             />
           </div>
 
           <div className="lg:tw-row-start-2">
-            <SocioEconomicImpactsCard socioEconomicImpacts={impacts.socioeconomic.impacts} />
+            <SocioEconomicImpactsCard
+              socioEconomicImpacts={impacts.socioeconomic.impacts}
+              displayDescriptionModal={() => {
+                openImpactDescriptionModal("socio-economic");
+              }}
+            />
           </div>
         </div>
       </section>

--- a/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPage.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPage.tsx
@@ -3,6 +3,10 @@ import { fr } from "@codegouvfr/react-dsfr";
 import { ReconversionProjectImpacts } from "../../domain/impacts.types";
 import ProjectsComparisonActionBar from "../shared/actions/ActionBar";
 import ImpactsListView from "./list-view/ImpactsListView";
+import {
+  ImpactDescriptionModal,
+  ImpactDescriptionModalCategory,
+} from "./modals/ImpactDescriptionModal";
 import ImpactsChartsView from "./ImpactsChartsView";
 import ProjectsImpactsPageHeader from "./ProjectImpactsPageHeader";
 
@@ -52,6 +56,9 @@ const ProjectImpactsPage = ({
   const [currentFilter, setSelectedFilter] = useState<ImpactCategoryFilter>("all");
   const [currentViewMode, setViewMode] = useState<ViewMode>("charts");
 
+  const [modalCategoryOpened, setModalCategoryOpened] =
+    useState<ImpactDescriptionModalCategory>(undefined);
+
   return (
     <div style={{ background: "#ECF5FD" }}>
       <ProjectsImpactsPageHeader
@@ -76,10 +83,24 @@ const ProjectImpactsPage = ({
               onViewModeClick={setViewMode}
               onEvaluationPeriodChange={onEvaluationPeriodChange}
             />
+            <ImpactDescriptionModal
+              modalCategory={modalCategoryOpened}
+              onChangeModalCategoryOpened={setModalCategoryOpened}
+            />
             {currentViewMode === "charts" && (
-              <ImpactsChartsView project={project} impacts={impacts} />
+              <ImpactsChartsView
+                project={project}
+                impacts={impacts}
+                openImpactDescriptionModal={setModalCategoryOpened}
+              />
             )}
-            {currentViewMode === "list" && <ImpactsListView project={project} impacts={impacts} />}
+            {currentViewMode === "list" && (
+              <ImpactsListView
+                project={project}
+                impacts={impacts}
+                openImpactDescriptionModal={setModalCategoryOpened}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/features/projects/views/project-impacts-page/impacts/cost-benefit-analysis/CostBenefitAnalysisCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/impacts/cost-benefit-analysis/CostBenefitAnalysisCard.tsx
@@ -9,9 +9,14 @@ import { roundTo2Digits } from "@/shared/services/round-numbers/roundNumbers";
 type Props = {
   economicBalanceTotal: number;
   socioEconomicImpactsTotal: number;
+  displayDescriptionModal: () => void;
 };
 
-function CostBenefitAnalysisCard({ economicBalanceTotal, socioEconomicImpactsTotal }: Props) {
+function CostBenefitAnalysisCard({
+  economicBalanceTotal,
+  socioEconomicImpactsTotal,
+  displayDescriptionModal,
+}: Props) {
   const maxAbsValue =
     Math.abs(economicBalanceTotal) > Math.abs(socioEconomicImpactsTotal)
       ? Math.abs(economicBalanceTotal)
@@ -67,7 +72,7 @@ function CostBenefitAnalysisCard({ economicBalanceTotal, socioEconomicImpactsTot
   };
 
   return (
-    <ImpactCard title="Analyse coûts bénéfices">
+    <ImpactCard title="Analyse coûts bénéfices" displayDescriptionModal={displayDescriptionModal}>
       <HighchartsReact highcharts={Highcharts} options={barChartOptions} />
     </ImpactCard>
   );

--- a/apps/web/src/features/projects/views/project-impacts-page/impacts/cost-benefit-analysis/CostBenefitAnalysisCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/impacts/cost-benefit-analysis/CostBenefitAnalysisCard.tsx
@@ -72,7 +72,7 @@ function CostBenefitAnalysisCard({
   };
 
   return (
-    <ImpactCard title="Analyse coûts bénéfices" displayDescriptionModal={displayDescriptionModal}>
+    <ImpactCard title="Analyse coûts bénéfices" onTitleClick={displayDescriptionModal}>
       <HighchartsReact highcharts={Highcharts} options={barChartOptions} />
     </ImpactCard>
   );

--- a/apps/web/src/features/projects/views/project-impacts-page/impacts/economic-balance/EconomicBalanceImpactCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/impacts/economic-balance/EconomicBalanceImpactCard.tsx
@@ -13,6 +13,7 @@ type SourceRevenue = "operations" | "other";
 type Props = {
   costs: ReconversionProjectImpacts["economicBalance"]["costs"];
   revenues: ReconversionProjectImpacts["economicBalance"]["revenues"];
+  displayDescriptionModal: () => void;
 };
 
 const getYearlyCostPurposeLabel = (purpose: PurposeCost) => {
@@ -87,7 +88,7 @@ const getRevenuesValue = ({
   ].filter((serie) => !!serie.value) as { name: string; value: number }[];
 };
 
-function EconomicBalanceImpactCard({ revenues, costs }: Props) {
+function EconomicBalanceImpactCard({ revenues, costs, displayDescriptionModal }: Props) {
   const { financialAssistance, operationsRevenues } = revenues;
   const { operationsCosts, developmentPlanInstallation, siteReinstatement, realEstateTransaction } =
     costs;
@@ -152,7 +153,7 @@ function EconomicBalanceImpactCard({ revenues, costs }: Props) {
   };
 
   return (
-    <ImpactCard title="Bilan de l'opération">
+    <ImpactCard title="Bilan de l'opération" displayDescriptionModal={displayDescriptionModal}>
       {revenues.total > 0 || costs.total > 0 ? (
         <HighchartsReact highcharts={Highcharts} options={barChartOptions} />
       ) : (

--- a/apps/web/src/features/projects/views/project-impacts-page/impacts/economic-balance/EconomicBalanceImpactCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/impacts/economic-balance/EconomicBalanceImpactCard.tsx
@@ -153,7 +153,7 @@ function EconomicBalanceImpactCard({ revenues, costs, displayDescriptionModal }:
   };
 
   return (
-    <ImpactCard title="Bilan de l'opération" displayDescriptionModal={displayDescriptionModal}>
+    <ImpactCard title="Bilan de l'opération" onTitleClick={displayDescriptionModal}>
       {revenues.total > 0 || costs.total > 0 ? (
         <HighchartsReact highcharts={Highcharts} options={barChartOptions} />
       ) : (

--- a/apps/web/src/features/projects/views/project-impacts-page/impacts/socio-economic/SocioEconomicImpactsCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/impacts/socio-economic/SocioEconomicImpactsCard.tsx
@@ -8,6 +8,7 @@ import { ReconversionProjectImpacts } from "@/features/projects/domain/impacts.t
 
 type Props = {
   socioEconomicImpacts: ReconversionProjectImpacts["socioeconomic"]["impacts"];
+  displayDescriptionModal: () => void;
 };
 
 type ChartViewMode = "by_actor" | "by_category";
@@ -49,7 +50,7 @@ const ChartViewModeControl = ({
   );
 };
 
-function SocioEconomicImpactsCard({ socioEconomicImpacts }: Props) {
+function SocioEconomicImpactsCard({ socioEconomicImpacts, displayDescriptionModal }: Props) {
   const [currentChartViewMode, setChartViewMode] = useState<ChartViewMode>("by_category");
 
   return (
@@ -59,7 +60,9 @@ function SocioEconomicImpactsCard({ socioEconomicImpacts }: Props) {
           className="fr-mb-2w"
           style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
         >
-          <strong>Impacts socio-économiques</strong>
+          <strong className="tw-cursor-pointer" onClick={displayDescriptionModal}>
+            Impacts socio-économiques
+          </strong>
           <ChartViewModeControl
             currentChartViewMode={currentChartViewMode}
             setChartViewMode={setChartViewMode}

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactItemRow.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactItemRow.tsx
@@ -2,15 +2,18 @@ import { ReactNode } from "react";
 
 type ImpactItemRowProps = {
   children: ReactNode;
+  onClick?: () => void;
 };
-const ImpactItemRow = ({ children }: ImpactItemRowProps) => {
+const ImpactItemRow = ({ children, onClick }: ImpactItemRowProps) => {
   return (
     <div
+      onClick={onClick}
       style={{
         display: "flex",
         justifyContent: "space-between",
         alignItems: "center",
         borderBottom: "1px solid #DDDDDD",
+        cursor: onClick ? "pointer" : "default",
       }}
     >
       {children}

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactMainTitle.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactMainTitle.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+
+type Props = {
+  title: ReactNode;
+  onClick: () => void;
+};
+
+const ImpactMainTitle = ({ title, onClick }: Props) => {
+  return (
+    <h3 className="tw-cursor-pointer" onClick={onClick}>
+      {title}
+    </h3>
+  );
+};
+
+export default ImpactMainTitle;

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactsListView.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactsListView.tsx
@@ -34,11 +34,19 @@ const ImpactsListView = ({ impacts, openImpactDescriptionModal }: Props) => {
             openImpactDescriptionModal("cost-benefit-analysis");
           }}
         />
-        <ImpactItemRow>
+        <ImpactItemRow
+          onClick={() => {
+            openImpactDescriptionModal("economic-balance");
+          }}
+        >
           <ImpactLabel>📉 Bilan de l’opération</ImpactLabel>
           <ImpactValue>{formatMonetaryImpact(impacts.economicBalance.total)}</ImpactValue>
         </ImpactItemRow>
-        <ImpactItemRow>
+        <ImpactItemRow
+          onClick={() => {
+            openImpactDescriptionModal("socio-economic");
+          }}
+        >
           <ImpactLabel>🌎 Impacts socio-économiques</ImpactLabel>
           <ImpactValue>{formatMonetaryImpact(impacts.socioeconomic.total)}</ImpactValue>
         </ImpactItemRow>

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactsListView.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactsListView.tsx
@@ -1,4 +1,5 @@
 import { ReconversionProjectImpacts } from "../../../domain/impacts.types";
+import { ImpactDescriptionModalCategory } from "../modals/ImpactDescriptionModal";
 import {
   formatCO2Impact,
   formatDefaultImpact,
@@ -10,6 +11,7 @@ import ImpactDetailRow from "./ImpactItemDetailRow";
 import ImpactItemGroup from "./ImpactItemGroup";
 import ImpactItemRow from "./ImpactItemRow";
 import ImpactLabel from "./ImpactLabel";
+import ImpactMainTitle from "./ImpactMainTitle";
 import ImpactSectionTitle from "./ImpactSectionTitle";
 import ImpactValue from "./ImpactValue";
 import SocioEconomicImpactsListSection from "./SocioEconomicSection";
@@ -19,13 +21,19 @@ type Props = {
     name: string;
   };
   impacts: ReconversionProjectImpacts;
+  openImpactDescriptionModal: (category: ImpactDescriptionModalCategory) => void;
 };
 
-const ImpactsListView = ({ impacts }: Props) => {
+const ImpactsListView = ({ impacts, openImpactDescriptionModal }: Props) => {
   return (
     <div style={{ maxWidth: "900px", margin: "auto" }}>
       <section className="fr-mb-5w">
-        <h3>Analyse coûts bénéfices</h3>
+        <ImpactMainTitle
+          title="Analyse coûts bénéfices"
+          onClick={() => {
+            openImpactDescriptionModal("cost-benefit-analysis");
+          }}
+        />
         <ImpactItemRow>
           <ImpactLabel>📉 Bilan de l’opération</ImpactLabel>
           <ImpactValue>{formatMonetaryImpact(impacts.economicBalance.total)}</ImpactValue>
@@ -36,7 +44,12 @@ const ImpactsListView = ({ impacts }: Props) => {
         </ImpactItemRow>
       </section>
       <section className="fr-mb-5w">
-        <h3>Bilan de l’opération</h3>
+        <ImpactMainTitle
+          title="Bilan de l’opération"
+          onClick={() => {
+            openImpactDescriptionModal("economic-balance");
+          }}
+        />
         {!!impacts.economicBalance.costs.realEstateTransaction && (
           <ImpactItemRow>
             <ImpactLabel>🏠 Acquisition du site</ImpactLabel>
@@ -86,7 +99,10 @@ const ImpactsListView = ({ impacts }: Props) => {
           <ImpactValue isTotal>{formatMonetaryImpact(impacts.economicBalance.total)}</ImpactValue>
         </ImpactItemRow>
       </section>
-      <SocioEconomicImpactsListSection socioEconomicImpacts={impacts.socioeconomic.impacts} />
+      <SocioEconomicImpactsListSection
+        socioEconomicImpacts={impacts.socioeconomic.impacts}
+        openImpactDescriptionModal={openImpactDescriptionModal}
+      />
       <section className="fr-mb-5w">
         <h3>Impacts environnementaux</h3>
         {impacts.nonContaminatedSurfaceArea && (

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/SocioEconomicSection.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/SocioEconomicSection.tsx
@@ -1,10 +1,12 @@
 import { getActorLabel } from "../impacts/socio-economic/socioEconomicImpacts";
+import { ImpactDescriptionModalCategory } from "../modals/ImpactDescriptionModal";
 import { formatMonetaryImpact } from "./formatImpactValue";
 import ImpactDetailLabel from "./ImpactDetailLabel";
 import ImpactDetailRow from "./ImpactItemDetailRow";
 import ImpactItemGroup from "./ImpactItemGroup";
 import ImpactItemRow from "./ImpactItemRow";
 import ImpactLabel from "./ImpactLabel";
+import ImpactMainTitle from "./ImpactMainTitle";
 import ImpactSectionTitle from "./ImpactSectionTitle";
 import ImpactValue from "./ImpactValue";
 import SocioEconomicEnvironmentalMonetaryImpactsSection from "./SocioEconomicEnvironmentalMonetarySection";
@@ -13,6 +15,7 @@ import { ReconversionProjectImpacts } from "@/features/projects/domain/impacts.t
 
 type Props = {
   socioEconomicImpacts: ReconversionProjectImpacts["socioeconomic"]["impacts"];
+  openImpactDescriptionModal: (category: ImpactDescriptionModalCategory) => void;
 };
 
 type SocioEconomicImpactRowProps = {
@@ -36,7 +39,10 @@ const SocioEconomicImpactRow = ({ impact }: SocioEconomicImpactRowProps) => {
   );
 };
 
-const SocioEconomicImpactsListSection = ({ socioEconomicImpacts }: Props) => {
+const SocioEconomicImpactsListSection = ({
+  socioEconomicImpacts,
+  openImpactDescriptionModal,
+}: Props) => {
   const rentalIncomeImpacts = socioEconomicImpacts.filter(
     (impact) => impact.impact === "rental_income",
   );
@@ -66,7 +72,12 @@ const SocioEconomicImpactsListSection = ({ socioEconomicImpacts }: Props) => {
 
   return (
     <section className="fr-mb-5w">
-      <h3>Impacts économiques</h3>
+      <ImpactMainTitle
+        title="Impacts socio-économiques"
+        onClick={() => {
+          openImpactDescriptionModal("socio-economic");
+        }}
+      />
       <section className="fr-mb-5w">
         <ImpactItemRow>
           <ImpactSectionTitle>Impacts économiques directs</ImpactSectionTitle>

--- a/apps/web/src/features/projects/views/project-impacts-page/modals/ImpactDescriptionModal.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/modals/ImpactDescriptionModal.tsx
@@ -1,0 +1,96 @@
+import { ReactElement, useEffect, useMemo } from "react";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
+import CostBenefitAnalysisDescription from "./cost-benefit-analysis";
+import EconomicBalanceDescription from "./economic-balance";
+import ModalBreadcrumb, { ModalBreadcrumbSegments } from "./ModalBreadcrumb";
+import SocioEconomicDescription from "./socio-economic";
+
+export type ImpactDescriptionModalCategory =
+  | "economic-balance"
+  | "cost-benefit-analysis"
+  | "socio-economic"
+  | undefined;
+
+type Props = {
+  modalCategory: ImpactDescriptionModalCategory;
+  onChangeModalCategoryOpened: (modalCategory: ImpactDescriptionModalCategory) => void;
+};
+
+const getModalContent = (
+  modalCategory: Props["modalCategory"],
+  onChangeModalCategoryOpened: Props["onChangeModalCategoryOpened"],
+): { title: string; content?: ReactElement; breadcrumbSegments?: ModalBreadcrumbSegments } => {
+  switch (modalCategory) {
+    case "cost-benefit-analysis":
+      return {
+        title: "⚖️ Analyse coûts bénéfices",
+        content: (
+          <CostBenefitAnalysisDescription
+            onChangeModalCategoryOpened={onChangeModalCategoryOpened}
+          />
+        ),
+      };
+    case "economic-balance":
+      return {
+        title: "📉 Bilan de l’opération",
+        breadcrumbSegments: [
+          {
+            label: "Analyse coûts bénéfices",
+            onClick: () => {
+              onChangeModalCategoryOpened("cost-benefit-analysis");
+            },
+          },
+          { label: "Bilan de l’opération", isCurrent: true },
+        ],
+        content: <EconomicBalanceDescription />,
+      };
+    case "socio-economic":
+      return {
+        title: "🌍 Impacts socio-économiques",
+        breadcrumbSegments: [
+          {
+            label: "Analyse coûts bénéfices",
+            onClick: () => {
+              onChangeModalCategoryOpened("cost-benefit-analysis");
+            },
+          },
+          { label: "Impacts socio-économiques", isCurrent: true },
+        ],
+        content: <SocioEconomicDescription />,
+      };
+    default:
+      return { title: "", content: undefined };
+  }
+};
+
+const modal = createModal({
+  id: `modal-impacts-description`,
+  isOpenedByDefault: false,
+});
+
+export function ImpactDescriptionModal({ modalCategory, onChangeModalCategoryOpened }: Props) {
+  const { title, content, breadcrumbSegments } = useMemo(
+    () => getModalContent(modalCategory, onChangeModalCategoryOpened),
+    [modalCategory, onChangeModalCategoryOpened],
+  );
+
+  useIsModalOpen(modal, {
+    onConceal: () => {
+      onChangeModalCategoryOpened(undefined);
+    },
+  });
+
+  useEffect(() => {
+    if (modalCategory) {
+      modal.open();
+    }
+  }, [modalCategory]);
+
+  return (
+    <modal.Component title={title} concealingBackdrop={true} size="large">
+      {breadcrumbSegments && <ModalBreadcrumb segments={breadcrumbSegments} />}
+      {content}
+    </modal.Component>
+  );
+}

--- a/apps/web/src/features/projects/views/project-impacts-page/modals/ModalBreadcrumb.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/modals/ModalBreadcrumb.tsx
@@ -1,0 +1,44 @@
+import { useId } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+
+export type ModalBreadcrumbSegments = {
+  onClick?: () => void;
+  label: string;
+  isCurrent?: boolean;
+}[];
+type Props = {
+  segments: ModalBreadcrumbSegments;
+};
+
+const ModalBreadcrumb = ({ segments }: Props) => {
+  const id = useId();
+  const breadcrumbId = `breadcrumb-${id}`;
+  return (
+    <nav
+      role="navigation"
+      className="fr-breadcrumb"
+      style={{ position: "absolute", top: fr.spacing("1v"), left: fr.spacing("4w") }}
+    >
+      <button className="fr-breadcrumb__button" aria-expanded="false" aria-controls={breadcrumbId}>
+        Voir le fil d’Ariane
+      </button>
+      <div className="fr-collapse" id={breadcrumbId}>
+        <ol className="fr-breadcrumb__list">
+          {segments.map(({ onClick, isCurrent, label }) => (
+            <li key={label}>
+              <button
+                className="fr-breadcrumb__link"
+                onClick={onClick}
+                aria-current={isCurrent ? "page" : "false"}
+              >
+                {label}
+              </button>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </nav>
+  );
+};
+
+export default ModalBreadcrumb;

--- a/apps/web/src/features/projects/views/project-impacts-page/modals/cost-benefit-analysis/index.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/modals/cost-benefit-analysis/index.tsx
@@ -1,0 +1,65 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { ImpactDescriptionModalCategory } from "../ImpactDescriptionModal";
+
+import ExternalLink from "@/shared/views/components/ExternalLink/ExternalLink";
+
+type Props = {
+  onChangeModalCategoryOpened: (modalCategory: ImpactDescriptionModalCategory) => void;
+};
+
+const CostBenefitAnalysisDescription = ({ onChangeModalCategoryOpened }: Props) => {
+  return (
+    <>
+      <p>
+        BENEFRICHES repose sur les principes de l’analyse coûts-bénéfices, qui a pour objet
+        d’apprécier l’intérêt d’une opération (projet ou investissement), sur une période donnée.
+      </p>
+      <p>
+        Elle est réalisée en analysant les impacts du projet sur les différents types d’acteurs
+        directement ou indirectement concernés, que ces impacts soient positifs ou négatifs. Puis en
+        les comparant au bilan de l’opération (recettes vs. dépenses nécessaires à sa réalisation).
+      </p>
+
+      <ul className="tw-list-none">
+        <li>
+          <Button
+            onClick={() => {
+              onChangeModalCategoryOpened("economic-balance");
+            }}
+            priority="tertiary no outline"
+          >
+            📉 Bilan de l’opération
+          </Button>
+        </li>
+        <li>
+          <Button
+            onClick={() => {
+              onChangeModalCategoryOpened("socio-economic");
+            }}
+            priority="tertiary no outline"
+          >
+            🌍 Impacts socio-économiques
+          </Button>
+        </li>
+      </ul>
+
+      <h2 className={fr.cx("fr-h5")}>Aller plus loin</h2>
+      <ul>
+        <li>
+          <ExternalLink href="https://www.strategie.gouv.fr/publications/guide-de-levaluation-socioeconomique-investissements-publics">
+            Guide de l’évaluation socioéconomique des investissements publics
+          </ExternalLink>
+        </li>
+        <li>
+          Évaluation socioéconomique des opérations d’aménagement urbain :{" "}
+          <ExternalLink href="https://www.strategie.gouv.fr/publications/referentiel-methodologique-de-levaluation-socioeconomique-operations-damenagement">
+            Référentiel&nbsp;méthodologique
+          </ExternalLink>
+        </li>
+      </ul>
+    </>
+  );
+};
+
+export default CostBenefitAnalysisDescription;

--- a/apps/web/src/features/projects/views/project-impacts-page/modals/economic-balance/index.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/modals/economic-balance/index.tsx
@@ -1,0 +1,33 @@
+import { fr } from "@codegouvfr/react-dsfr";
+
+import ExternalLink from "@/shared/views/components/ExternalLink/ExternalLink";
+
+const EconomicBalanceDescription = () => {
+  return (
+    <>
+      <p>
+        Le bilan d’opération regroupe l’ensemble des recettes et des dépenses d’une opération
+        d’aménagement ou de construction. Son périmètre est donc circonscrit au porteur du projet.
+      </p>
+      <p>
+        <strong>Bénéficiaires / déficitaires</strong> : exploitant, aménageur, futur propriétaire
+      </p>
+
+      <h2 className={fr.cx("fr-h5")}>Aller plus loin</h2>
+      <ul>
+        <li>
+          <ExternalLink href="https://outil2amenagement.cerema.fr/outils/bilan-amenageur">
+            Outil aménagement CEREMA
+          </ExternalLink>
+        </li>
+        <li>
+          <ExternalLink href="https://www.reseaunationalamenageurs.logement.gouv.fr/IMG/pdf/2016-02-22_-_ApprocheSCET-OptimisationEconomiqueOperationsAmenagement.pdf">
+            L’optimisation des coûts des opérations d’aménagement
+          </ExternalLink>
+        </li>
+      </ul>
+    </>
+  );
+};
+
+export default EconomicBalanceDescription;

--- a/apps/web/src/features/projects/views/project-impacts-page/modals/socio-economic/index.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/modals/socio-economic/index.tsx
@@ -1,0 +1,57 @@
+import { fr } from "@codegouvfr/react-dsfr";
+
+import ExternalLink from "@/shared/views/components/ExternalLink/ExternalLink";
+
+const SocioEconomicDescription = () => {
+  return (
+    <>
+      <p>
+        L’évaluation socio-économique a pour objet d’apprécier l’intérêt d’un projet ou d’un
+        investissement pour la collectivité.
+      </p>
+      <p>
+        Elle est réalisée en analysant les effets du projet (ses impacts) sur les différents types
+        d’acteurs directement ou indirectement concernés, que ces impacts soient positifs ou
+        négatifs. On parle alors d’impacts socio-économiques.
+      </p>
+      <p>
+        S’agissant de projets de renouvellement urbain, les impacts sont nombreux et de différentes
+        natures :
+        <ul>
+          <li>
+            environnementaux (ex : maintien de capacité de stockage de carbone dans les sols,
+            création d’ilots de fraicheur),
+          </li>
+          <li>
+            économiques (ex : réduction de dépenses futures en entretien de réseaux ou voiries),
+          </li>
+          <li>
+            sociaux (ex : création d’aménités, amélioration de l’attractivité d’un quartier,
+            réduction du besoin en en déplacements, etc.)
+          </li>
+        </ul>
+        Les différents indicateurs utilisés dans BENEFRICHES sont présentés ci-dessous et leurs
+        méthodes de calcul sont détaillées au niveau de chacun.
+      </p>
+
+      <h2 className={fr.cx("fr-h5")}>Aller plus loin</h2>
+      <ul>
+        <li>
+          Évaluer les bénéfices socio-économiques de la reconversion de friches pour lutter contre
+          l'artificialisation :{" "}
+          <ExternalLink href="https://librairie.ademe.fr/changement-climatique-et-energie/3772-evaluer-les-benefices-socio-economiques-de-la-reconversion-de-friches-pour-lutter-contre-l-artificialisation-outil-benefriches.html">
+            Outil BENEFRICHES.
+          </ExternalLink>
+        </li>
+        <li>
+          Évaluation socioéconomique des opérations d’aménagement urbain :{" "}
+          <ExternalLink href="https://www.strategie.gouv.fr/publications/referentiel-methodologique-de-levaluation-socioeconomique-operations-damenagement">
+            Référentiel&nbsp;méthodologique
+          </ExternalLink>
+        </li>
+      </ul>
+    </>
+  );
+};
+
+export default SocioEconomicDescription;


### PR DESCRIPTION
Ajout des modales de description au clic sur les titres (j’ai vu ce point avec Chloë) suivants : 
- Analyse coûts bénéfices
- Bilan de l’opération 
- Impacts socio-économiques

J’ai fait au plus simple pour l’instant (sans le graphe dans la modale comme sur les maquettes) car la modale du dsfr la plus large n’est pas suffisamment large pour mettre le graphe proprement. 
En plus, ça me parait plutôt rentrer dans le design V2 des popins (avec la navigation interne aux popins, le sélecteur de durée inclus, etc.) donc je ne pense pas que ça soit indispensable pour le MVP.

Les pages commencent à devenir chargées (pas mal de passage de props en cascade), j’ai pas osé me lancer dans une refacto maintenant mais il faudra qu’on y passe à un moment ^^. 