### PR TITLE
fix(web): dark mode display and use styledMode to true for Highcharts

### DIFF
--- a/apps/web/src/app/views/pages/home/sections/CallToActionSection.tsx
+++ b/apps/web/src/app/views/pages/home/sections/CallToActionSection.tsx
@@ -12,7 +12,10 @@ import ExternalLink from "@/shared/views/components/ExternalLink/ExternalLink";
 
 export default function CallToActionSection() {
   return (
-    <section className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey")} id="cta-section">
+    <section
+      className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey", "dark:tw-bg-darkGrey")}
+      id="cta-section"
+    >
       <div className={fr.cx("fr-container")}>
         <div className={fr.cx("fr-grid-row")}>
           <div

--- a/apps/web/src/app/views/pages/home/sections/HowItWorksSection.tsx
+++ b/apps/web/src/app/views/pages/home/sections/HowItWorksSection.tsx
@@ -36,7 +36,7 @@ function HowItWorksStep({ number, title, text }: HowItWorksStepProps) {
 
 export default function HowItWorksSection() {
   return (
-    <section className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey")}>
+    <section className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey", "dark:tw-bg-darkGrey")}>
       <div className={fr.cx("fr-container")}>
         <h2>Bénéfriches, comment ça marche&nbsp;?</h2>
         <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-mt-5w")}>

--- a/apps/web/src/app/views/pages/home/sections/SupportedProjectsSection.tsx
+++ b/apps/web/src/app/views/pages/home/sections/SupportedProjectsSection.tsx
@@ -53,8 +53,8 @@ function SupportedProjectCard({
                 className={classNames(
                   fr.cx("fr-text--sm", "fr-m-0", "fr-text--bold"),
                   economicBalanceInMillionEuros > 0
-                    ? "tw-text-impacts-positive"
-                    : "tw-text-impacts-negative",
+                    ? "tw-text-impacts-positive-main dark:tw-text-impacts-positive-light"
+                    : "tw-text-impacts-negative-main dark:tw-text-impacts-negative-light",
                 )}
               >
                 {economicBalanceInMillionEuros > 0 ? "+" : ""}
@@ -68,8 +68,8 @@ function SupportedProjectCard({
                 className={classNames(
                   fr.cx("fr-text--sm", "fr-m-0", "fr-text--bold"),
                   socioEconomicImpactAmountInMillionEuros > 0
-                    ? "tw-text-impacts-positive"
-                    : "tw-text-impacts-negative",
+                    ? "tw-text-impacts-positive-main dark:tw-text-impacts-positive-light"
+                    : "tw-text-impacts-negative-main dark:tw-text-impacts-negative-light",
                 )}
               >
                 {socioEconomicImpactAmountInMillionEuros > 0 ? "+" : ""}
@@ -92,7 +92,7 @@ function SupportedProjectCard({
 
 export default function SupportedProjectsSection() {
   return (
-    <section className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey")}>
+    <section className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey", "dark:tw-bg-darkGrey")}>
       <div className={fr.cx("fr-container")}>
         <h2>Les projets accompagnés par Bénéfriches</h2>
         <div className={classNames("tw-flex", "tw-overflow-x-scroll", fr.cx("fr-mt-5w"))}>

--- a/apps/web/src/app/views/pages/home/sections/TargetsSection.tsx
+++ b/apps/web/src/app/views/pages/home/sections/TargetsSection.tsx
@@ -21,7 +21,7 @@ function TargetItem({ title, text, imgUrl }: TargetItemProps) {
 
 export default function TargetsSection() {
   return (
-    <section className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey")}>
+    <section className={classNames(fr.cx("fr-py-10w"), "tw-bg-lightGrey", "dark:tw-bg-darkGrey")}>
       <div className={fr.cx("fr-container")}>
         <h2>Un service pour tous les projets d'aménagement</h2>
         <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-mt-5w")}>

--- a/apps/web/src/app/views/theme.ts
+++ b/apps/web/src/app/views/theme.ts
@@ -32,13 +32,23 @@ export default {
       blue: "#137FEB",
       lightGrey: "#F6F6F6",
       grey: "#DDDDDD",
+      darkGrey: "#333",
       warning: "#B34000",
       impacts: {
         title: "var(--blue-ecume-sun-247-moon-675)",
         main: "#ECF5FD",
-        positive: "#18753C",
-        neutral: "#161616",
-        negative: "#CE0500",
+        positive: {
+          main: "#18753C",
+          light: "#51DB86",
+        },
+        neutral: {
+          main: "#161616",
+          light: "#F6F6F6",
+        },
+        negative: {
+          main: "#CE0500",
+          light: "#FF918F",
+        },
       },
       // can be used with classes tw-soils-buildings, tw-soils-impermeable-soils...
       soils: soilColors,

--- a/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageHeader.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageHeader.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const ProjectsImpactsPageHeader = ({ projectName, siteName }: Props) => {
   return (
-    <div className={classNames(fr.cx("fr-py-8v"), "tw-bg-impacts-main")}>
+    <div className={classNames(fr.cx("fr-py-8v"), "tw-bg-impacts-main", "dark:tw-bg-darkGrey")}>
       <div className={fr.cx("fr-container")}>
         <div
           className={classNames(

--- a/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageWrapper.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageWrapper.tsx
@@ -54,7 +54,7 @@ function ProjectImpactsPageWrapper({
   onCurrentCategoryFilterChange,
 }: Props) {
   return (
-    <div className="tw-bg-impacts-main">
+    <div className="tw-bg-impacts-main dark:tw-bg-darkGrey">
       <ProjectsImpactsPageHeader
         projectId={projectData?.id ?? ""}
         projectName={projectData?.name ?? "Projet photovoltaïque"}

--- a/apps/web/src/features/projects/views/project-impacts-page/charts-view/ImpactChartCard/ImpactChartCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/charts-view/ImpactChartCard/ImpactChartCard.tsx
@@ -14,7 +14,14 @@ const ImpactChartCard = ({ title, children, onTitleClick }: Props) => {
     <figure
       className={classNames(
         fr.cx("fr-py-2w", "fr-px-3w", "fr-m-0"),
-        "tw-flex tw-flex-col tw-border tw-border-solid tw-border-grey tw-h-full tw-bg-impacts-main",
+        "tw-flex",
+        "tw-flex-col",
+        "tw-border",
+        "tw-border-solid",
+        "tw-border-grey",
+        "tw-h-full",
+        "tw-bg-impacts-main",
+        "dark:tw-bg-darkGrey",
       )}
     >
       <strong

--- a/apps/web/src/features/projects/views/project-impacts-page/charts-view/impacts/environment/SoilsCarbonStorageImpactCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/charts-view/impacts/environment/SoilsCarbonStorageImpactCard.tsx
@@ -8,7 +8,7 @@ import ImpactPercentageVariation from "../../ImpactChartCard/ImpactPercentageVar
 import { ReconversionProjectImpacts } from "@/features/projects/domain/impacts.types";
 import { formatCO2Impact } from "@/features/projects/views/shared/formatImpactValue";
 import { baseAreaChartConfig } from "@/features/projects/views/shared/sharedChartConfig.ts";
-import { getColorForSoilType } from "@/shared/domain/soils";
+import { getHighchartStyleForSoilTypes } from "@/shared/domain/soils";
 import { getLabelForSoilType } from "@/shared/services/label-mapping/soilTypeLabelMapping";
 import { getPercentageDifference } from "@/shared/services/percentage/percentage";
 import { roundTo2Digits } from "@/shared/services/round-numbers/roundNumbers";
@@ -63,7 +63,6 @@ function SoilsCarbonStorageImpactCard({ soilsCarbonStorageImpact, onTitleClick }
     series: soilsTypes.map((soilType) => ({
       name: getLabelForSoilType(soilType),
       type: "area",
-      color: getColorForSoilType(soilType),
       data: getData(soilType, currentSoilsCarbonStorage.soils, forecastSoilsCarbonStorage.soils),
     })),
   };
@@ -81,7 +80,9 @@ function SoilsCarbonStorageImpactCard({ soilsCarbonStorageImpact, onTitleClick }
       <ImpactAbsoluteVariation>
         {formatCO2Impact(soilsCarbonStorageVariation)}
       </ImpactAbsoluteVariation>
-      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+      <div style={getHighchartStyleForSoilTypes(soilsTypes)}>
+        <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+      </div>
     </ImpactCard>
   );
 }

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactValue.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/ImpactValue.tsx
@@ -28,12 +28,13 @@ const ImpactValue = ({ value, type = "default", isTotal = false }: Props) => {
         "tw-p-2",
         "tw-text-center",
         "tw-bg-impacts-main",
+        "dark:tw-bg-darkGrey",
         isTotal && "tw-font-bold",
         value === 0
-          ? "tw-text-impacts-neutral"
+          ? "tw-text-impacts-neutral-main dark:tw-text-impacts-neutral-light"
           : value > 0
-            ? "tw-text-impacts-positive"
-            : "tw-text-impacts-negative",
+            ? "tw-text-impacts-positive-main dark:tw-text-impacts-positive-light"
+            : "tw-text-impacts-negative-main dark:tw-text-impacts-negative-light",
       )}
     >
       {impactTypeFormatterMap[type](value)}

--- a/apps/web/src/features/projects/views/shared/sharedChartConfig.ts
+++ b/apps/web/src/features/projects/views/shared/sharedChartConfig.ts
@@ -2,10 +2,7 @@ export const baseColumnChartConfig: Highcharts.Options = {
   chart: {
     type: "column",
     height: "275px",
-    style: {
-      fontFamily: "Marianne",
-    },
-    backgroundColor: "#ECF5FD",
+    styledMode: true,
   },
   title: {
     text: "",
@@ -22,10 +19,7 @@ export const baseAreaChartConfig: Highcharts.Options = {
     height: "180px",
     marginLeft: 0,
     marginRight: 0,
-    style: {
-      fontFamily: "Marianne",
-    },
-    backgroundColor: "#ECF5FD",
+    styledMode: true,
   },
   title: {
     text: "",

--- a/apps/web/src/main.css
+++ b/apps/web/src/main.css
@@ -1,3 +1,13 @@
+@import "highcharts/css/highcharts";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.highcharts-container {
+  font-family: Marianne;
+}
+
+.highcharts-background {
+  fill: transparent;
+}

--- a/apps/web/src/shared/domain/soils.ts
+++ b/apps/web/src/shared/domain/soils.ts
@@ -40,3 +40,16 @@ export const getColorForSoilType = (value: SoilType): string => {
       return soilColors["water"];
   }
 };
+
+export const getHighchartStyleForSoilTypes = (
+  soilTypes: SoilType[],
+  override: Partial<Record<SoilType, string>> = {},
+): React.CSSProperties => {
+  return soilTypes.reduce(
+    (style, soilType, index) => ({
+      ...style,
+      [`--highcharts-color-${index}`]: override[soilType] ?? getColorForSoilType(soilType),
+    }),
+    {},
+  );
+};

--- a/apps/web/src/shared/views/components/Charts/SoilsCarbonStorageChart.tsx
+++ b/apps/web/src/shared/views/components/Charts/SoilsCarbonStorageChart.tsx
@@ -5,7 +5,7 @@ import highchartsVariablePie from "highcharts/modules/variable-pie";
 import HighchartsReact from "highcharts-react-official";
 import { SoilType } from "shared";
 
-import { getColorForSoilType } from "@/shared/domain/soils";
+import { getHighchartStyleForSoilTypes } from "@/shared/domain/soils";
 import { getLabelForSoilType } from "@/shared/services/label-mapping/soilTypeLabelMapping";
 highchartsVariablePie(Highcharts);
 
@@ -21,13 +21,12 @@ type Props = {
 const SoilsCarbonStorageChart = ({ soilsCarbonStorage }: Props) => {
   const variablePieChartRef = useRef<HighchartsReact.RefObject>(null);
 
+  const soilsData = soilsCarbonStorage.filter(({ surfaceArea }) => surfaceArea > 0);
+
   const variablePieChartOptions: Highcharts.Options = {
     title: { text: "" },
     chart: {
-      backgroundColor: "transparent",
-      style: {
-        fontFamily: "Marianne",
-      },
+      styledMode: true,
     },
     credits: { enabled: false },
     tooltip: {
@@ -39,7 +38,7 @@ const SoilsCarbonStorageChart = ({ soilsCarbonStorage }: Props) => {
     },
     plotOptions: {
       series: {
-        keys: ["name", "z", "y", "custom.carbonStorage", "color"],
+        keys: ["name", "z", "y", "custom.carbonStorage"],
       },
       variablepie: { cursor: "pointer" },
     },
@@ -48,21 +47,26 @@ const SoilsCarbonStorageChart = ({ soilsCarbonStorage }: Props) => {
         name: "",
         type: "variablepie",
         zMin: 0,
-        data: soilsCarbonStorage
-          .filter(({ surfaceArea }) => surfaceArea > 0)
-          .map((soilData) => [
-            getLabelForSoilType(soilData.type),
-            soilData.carbonStorageInTonPerSquareMeters,
-            soilData.surfaceArea,
-            soilData.carbonStorage,
-            getColorForSoilType(soilData.type),
-          ]),
+        data: soilsData.map((soilData) => [
+          getLabelForSoilType(soilData.type),
+          soilData.carbonStorageInTonPerSquareMeters,
+          soilData.surfaceArea,
+          soilData.carbonStorage,
+        ]),
       },
     ],
   };
 
   return (
-    <div className={fr.cx("fr-container", "fr-py-4w")}>
+    <div
+      className={fr.cx("fr-container", "fr-py-4w")}
+      style={getHighchartStyleForSoilTypes(
+        soilsData.map(({ type }) => type),
+        {
+          WATER: fr.colors.decisions.background.default.grey.default,
+        },
+      )}
+    >
       <HighchartsReact
         highcharts={Highcharts}
         options={variablePieChartOptions}

--- a/apps/web/src/shared/views/components/Charts/SurfaceAreaPieChart.tsx
+++ b/apps/web/src/shared/views/components/Charts/SurfaceAreaPieChart.tsx
@@ -5,7 +5,7 @@ import HighchartsReact from "highcharts-react-official";
 import { SoilsDistribution, typedObjectEntries } from "shared";
 import { SQUARE_METERS_HTML_SYMBOL } from "../SurfaceArea/SurfaceArea";
 
-import { getColorForSoilType } from "@/shared/domain/soils";
+import { getHighchartStyleForSoilTypes } from "@/shared/domain/soils";
 import { getLabelForSoilType } from "@/shared/services/label-mapping/soilTypeLabelMapping";
 
 type Props = {
@@ -14,23 +14,21 @@ type Props = {
 
 const SurfaceAreaPieChart = ({ soilsDistribution }: Props) => {
   const variablePieChartRef = useRef<HighchartsReact.RefObject>(null);
-  const data = typedObjectEntries(soilsDistribution)
-    .filter(([, surfaceArea]) => (surfaceArea as number) > 0)
-    .map(([soilType, surfaceArea]) => {
-      return {
-        name: getLabelForSoilType(soilType),
-        y: surfaceArea,
-        color: getColorForSoilType(soilType),
-      };
-    });
+  const soilsEntries = typedObjectEntries(soilsDistribution).filter(
+    ([, surfaceArea]) => (surfaceArea as number) > 0,
+  );
+
+  const data = soilsEntries.map(([soilType, surfaceArea]) => {
+    return {
+      name: getLabelForSoilType(soilType),
+      y: surfaceArea,
+    };
+  });
 
   const variablePieChartOptions: Highcharts.Options = {
     title: { text: "" },
     chart: {
-      backgroundColor: "transparent",
-      style: {
-        fontFamily: "Marianne",
-      },
+      styledMode: true,
     },
     credits: { enabled: false },
     tooltip: {
@@ -47,7 +45,10 @@ const SurfaceAreaPieChart = ({ soilsDistribution }: Props) => {
   };
 
   return (
-    <div className={fr.cx("fr-container", "fr-py-4w")}>
+    <div
+      className={fr.cx("fr-container", "fr-py-4w")}
+      style={getHighchartStyleForSoilTypes(soilsEntries.map(([soilType]) => soilType))}
+    >
       <HighchartsReact
         highcharts={Highcharts}
         options={variablePieChartOptions}

--- a/apps/web/src/shared/views/layout/HeaderFooterLayout/HeaderFooterLayout.tsx
+++ b/apps/web/src/shared/views/layout/HeaderFooterLayout/HeaderFooterLayout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { useIsDark } from "@codegouvfr/react-dsfr/useIsDark";
 import BenefrichesFooter from "./BenefrichesFooter";
 import BenefrichesHeader from "./BenefrichesHeader";
 
@@ -9,8 +10,18 @@ type HeaderFooterLayoutProps = {
 };
 
 function HeaderFooterLayout({ children }: HeaderFooterLayoutProps) {
+  const { isDark } = useIsDark();
   return (
-    <div className={classNames("tw-flex", "tw-flex-col", "tw-h-screen")}>
+    <div
+      className={classNames(
+        "tw-flex",
+        "tw-flex-col",
+        "tw-h-screen",
+        // Force highchart à suivre la config dsfr pour le dark mode,
+        // sinon la lib suit la config du navigateur "prefers-color-scheme"
+        isDark ? "highcharts-dark" : "highcharts-light",
+      )}
+    >
       <BenefrichesHeader />
       <main className="tw-grow">{children}</main>
       <BenefrichesFooter />

--- a/apps/web/src/shared/views/layout/WizardFormLayout/WizardFormLayout.tsx
+++ b/apps/web/src/shared/views/layout/WizardFormLayout/WizardFormLayout.tsx
@@ -23,6 +23,7 @@ function WizardFormLayout({ title, children, instructions = null }: Props) {
             "tw-col-span-12",
             "md:tw-col-span-4",
             "tw-bg-lightGrey",
+            "dark:tw-bg-darkGrey",
           )}
         >
           <div className="*:tw-text-sm">{instructions}</div>

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -4,6 +4,7 @@ import theme from "./src/app/views/theme";
 export default {
   prefix: "tw-",
   content: ["./src/**/*.{ts,tsx}"],
+  darkMode: ["selector", '[data-fr-theme="dark"]'],
   theme,
   plugins: [],
   corePlugins: {


### PR DESCRIPTION
Pour faire fonctionner Highchart avec le thème sombre du dsfr, il a fallu activer l’option `styledMode` et importer le style par défaut de Highchart directement dans le main.css (https://www.highcharts.com/docs/chart-design-and-style/style-by-css). 

Le fait d’activer `styledMode` pour les graphes implique de ne plus pouvoir utiliser les paramètres de style directement dans l’objet config des graphes (comme les couleurs des zones par exemple), il faut passer par l’assignement des variables de style Highchart dans l’attribut style (exemple dans `shared/views/components/Charts/SurfaceAreaPieChart.tsx`)

C’est moins pratique et moins propre mais je n’ai pas trouvé d’autre solution pour le moment (je ne pensais pas rencontrer autant de problème sur les fixes de ce ticket)