### PR TITLE
feat: assign economic balance to project developer instead of futureOperator

### DIFF
--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.integration-spec.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.integration-spec.ts
@@ -74,6 +74,8 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
           schedule_start_date: new Date("2025-01-01"),
           schedule_end_date: new Date("2025-05-15"),
           type: "any",
+          developer_name: "Terre cuite d’occitanie",
+          developer_structure_type: "company",
           features: {
             expectedAnnualProduction: 10,
             surfaceArea: 2000,
@@ -117,6 +119,7 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
         operationsFirstYear: 2025,
         developmentPlanElectricalPowerKWc: 300,
         developmentPlanSurfaceArea: 2000,
+        developmentPlanDeveloperName: "Terre cuite d’occitanie",
       });
     });
     it("gets reconversion project when optional data does not exist", async () => {
@@ -177,6 +180,7 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
         conversionFullTimeJobs: undefined,
         conversionSchedule: undefined,
         developmentPlanInstallationCost: 0,
+        developmentPlanDeveloperName: undefined,
         futureOperatorName: undefined,
         futureSiteOwnerName: undefined,
         operationsFullTimeJobs: undefined,

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
@@ -46,7 +46,7 @@ export class SqlReconversionProjectImpactsRepository
       .where("reconversion_project_id", reconversionProjectId);
 
     const sqlDevelopmentPlan = await this.sqlConnection("reconversion_project_development_plans")
-      .select("schedule_start_date", "schedule_end_date", "cost", "features")
+      .select("schedule_start_date", "schedule_end_date", "cost", "features", "developer_name")
       .where("reconversion_project_id", reconversionProjectId)
       .first();
     const conversionSchedule =
@@ -120,6 +120,7 @@ export class SqlReconversionProjectImpactsRepository
       developmentPlanExpectedAnnualEnergyProductionMWh,
       developmentPlanSurfaceArea,
       developmentPlanElectricalPowerKWc,
+      developmentPlanDeveloperName: sqlDevelopmentPlan?.developer_name ?? undefined,
       operationsFirstYear: reconversionProject.operations_first_year ?? undefined,
     };
   }

--- a/apps/api/src/reconversion-projects/domain/model/impacts/economic-balance/economicBalanceImpact.spec.ts
+++ b/apps/api/src/reconversion-projects/domain/model/impacts/economic-balance/economicBalanceImpact.spec.ts
@@ -14,6 +14,7 @@ describe("EconomicBalance impact", () => {
           developmentPlanInstallationCost: 150000,
           realEstateTransactionTotalCost: 100000,
           futureOperatorName: "Mairie de Blajan",
+          developmentPlanDeveloperName: "Mairie de Blajan",
           futureSiteOwnerName: "Mairie de Blajan",
           reinstatementContractOwnerName: "Mairie de Blajan",
         }),
@@ -40,6 +41,7 @@ describe("EconomicBalance impact", () => {
           developmentPlanInstallationCost: 150000,
           realEstateTransactionTotalCost: 100000,
           futureOperatorName: "Mairie de Blajan",
+          developmentPlanDeveloperName: "Mairie de Blajan",
           futureSiteOwnerName: "Acheteur",
           reinstatementContractOwnerName: "Mairie de Blajan",
         }),
@@ -65,6 +67,7 @@ describe("EconomicBalance impact", () => {
           developmentPlanInstallationCost: 150000,
           realEstateTransactionTotalCost: 100000,
           futureOperatorName: "Mairie de Blajan",
+          developmentPlanDeveloperName: "Mairie de Blajan",
           futureSiteOwnerName: "Acheteur",
           reinstatementContractOwnerName: "Propriétaire",
         }),
@@ -154,7 +157,7 @@ describe("EconomicBalance impact", () => {
     });
   });
   describe("computeEconomicBalanceImpact", () => {
-    it("should sum installation result and operation result", () => {
+    it("should sum installation result and operation result if projectDeveloper is futureOperator", () => {
       expect(
         computeEconomicBalanceImpact(
           {
@@ -163,6 +166,7 @@ describe("EconomicBalance impact", () => {
             developmentPlanInstallationCost: 150000,
             realEstateTransactionTotalCost: 100000,
             futureOperatorName: "Mairie de Blajan",
+            developmentPlanDeveloperName: "Mairie de Blajan",
             futureSiteOwnerName: "Acheteur",
             reinstatementContractOwnerName: "Propriétaire",
             yearlyProjectedCosts: [],
@@ -198,6 +202,7 @@ describe("EconomicBalance impact", () => {
             developmentPlanInstallationCost: 150000,
             realEstateTransactionTotalCost: 100000,
             futureOperatorName: "Mairie de Blajan",
+            developmentPlanDeveloperName: "Mairie de Blajan",
             futureSiteOwnerName: "Acheteur",
             reinstatementContractOwnerName: "Mairie de Blajan",
             yearlyProjectedCosts: [
@@ -237,6 +242,73 @@ describe("EconomicBalance impact", () => {
               { amount: 100000, source: "other" },
             ],
           },
+          financialAssistance: 50000,
+        },
+      });
+    });
+
+    it("should sum installation and reinstatement result only if projectDeveloper is not futureOperator", () => {
+      expect(
+        computeEconomicBalanceImpact(
+          {
+            reinstatementFinancialAssistanceAmount: 50000,
+            reinstatementCost: 1000000,
+            developmentPlanInstallationCost: 150000,
+            realEstateTransactionTotalCost: 100000,
+            futureOperatorName: "Exploitant",
+            developmentPlanDeveloperName: "Mairie de Blajan",
+            futureSiteOwnerName: "Acheteur",
+            reinstatementContractOwnerName: "Propriétaire",
+            yearlyProjectedCosts: [],
+            yearlyProjectedRevenues: [],
+          },
+          1,
+        ),
+      ).toEqual({
+        total: -150000,
+        bearer: "Mairie de Blajan",
+        costs: {
+          total: -150000,
+          developmentPlanInstallation: -150000,
+        },
+        revenues: {
+          total: 0,
+        },
+      });
+
+      expect(
+        computeEconomicBalanceImpact(
+          {
+            reinstatementFinancialAssistanceAmount: 50000,
+            reinstatementCost: 1000000,
+            developmentPlanInstallationCost: 150000,
+            realEstateTransactionTotalCost: 100000,
+            futureOperatorName: "Exploitant",
+            developmentPlanDeveloperName: "Mairie de Blajan",
+            futureSiteOwnerName: "Acheteur",
+            reinstatementContractOwnerName: "Mairie de Blajan",
+            yearlyProjectedCosts: [
+              { amount: 60000, purpose: "taxes" },
+              { amount: 500, purpose: "maintenance" },
+            ],
+            yearlyProjectedRevenues: [
+              { amount: 10000, source: "rent" },
+              { amount: 20000, source: "sell" },
+              { amount: 5000, source: "other" },
+            ],
+          },
+          20,
+        ),
+      ).toEqual({
+        total: 50000 - 1150000,
+        bearer: "Mairie de Blajan",
+        costs: {
+          total: -1150000,
+          siteReinstatement: -1000000,
+          developmentPlanInstallation: -150000,
+        },
+        revenues: {
+          total: 50000,
           financialAssistance: 50000,
         },
       });

--- a/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.spec.ts
@@ -100,6 +100,7 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
       developmentPlanInstallationCost: 200000,
       developmentPlanElectricalPowerKWc: 258,
       developmentPlanSurfaceArea: 20000,
+      developmentPlanDeveloperName: "Mairie de Blajan",
       reinstatementFinancialAssistanceAmount: 150000,
       yearlyProjectedCosts: [
         { amount: 1000, purpose: "taxes" },

--- a/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.ts
+++ b/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.ts
@@ -12,7 +12,7 @@ import {
 import {
   computeEconomicBalanceImpact,
   EconomicBalanceImpactResult,
-} from "../model/impacts/economicBalance/economicBalanceImpact";
+} from "../model/impacts/economic-balance/economicBalanceImpact";
 import {
   computeFullTimeJobsImpact,
   FullTimeJobsImpactResult,
@@ -85,6 +85,7 @@ export type ReconversionProjectImpactsDataView = {
   developmentPlanExpectedAnnualEnergyProductionMWh?: number;
   developmentPlanSurfaceArea?: number;
   developmentPlanElectricalPowerKWc?: number;
+  developmentPlanDeveloperName?: string;
   operationsFirstYear?: number;
 };
 
@@ -198,6 +199,7 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
       impacts: {
         economicBalance: computeEconomicBalanceImpact(
           {
+            developmentPlanDeveloperName: reconversionProject.developmentPlanDeveloperName,
             futureOperatorName: reconversionProject.futureOperatorName,
             futureSiteOwnerName: reconversionProject.futureSiteOwnerName,
             reinstatementContractOwnerName: reconversionProject.reinstatementContractOwnerName,

--- a/apps/web/src/features/projects/domain/impacts.types.ts
+++ b/apps/web/src/features/projects/domain/impacts.types.ts
@@ -96,7 +96,7 @@ export type ReconversionProjectImpacts = {
     bearer?: string;
     costs: {
       total: number;
-      operationsCosts: {
+      operationsCosts?: {
         total: number;
         expenses: { purpose: PurposeCost; amount: number }[];
       };
@@ -106,7 +106,7 @@ export type ReconversionProjectImpacts = {
     };
     revenues: {
       total: number;
-      operationsRevenues: {
+      operationsRevenues?: {
         bearer?: string;
         total: number;
         revenues: { source: SourceRevenue; amount: number }[];

--- a/apps/web/src/features/projects/views/project-impacts-page/charts-view/impacts/economic-balance/EconomicBalanceImpactCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/charts-view/impacts/economic-balance/EconomicBalanceImpactCard.tsx
@@ -62,7 +62,7 @@ const getCostsValues = ({
       name: "Transaction immobilière",
       value: realEstateTransaction,
     },
-    ...operationsCosts.expenses.map(({ amount, purpose }) => ({
+    ...(operationsCosts?.expenses ?? []).map(({ amount, purpose }) => ({
       name: getYearlyCostPurposeLabel(purpose),
       value: amount,
     })),
@@ -81,7 +81,7 @@ const getRevenuesValue = ({
       name: "Aides financières",
       value: financialAssistance,
     },
-    ...operationsRevenues.revenues.map(({ amount, source }) => ({
+    ...(operationsRevenues?.revenues ?? []).map(({ amount, source }) => ({
       name: getYearlyRevenueSourceLabel(source),
       value: amount,
     })),

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/sections/EconomicBalance.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/sections/EconomicBalance.tsx
@@ -48,14 +48,19 @@ const EconomicBalanceListSection = ({ impact, openImpactDescriptionModal }: Prop
           <ImpactValue value={impact.revenues.financialAssistance} type="monetary" />
         </ImpactItemRow>
       )}
-      <ImpactItemRow>
-        <ImpactLabel>💸️ Charges d'exploitation</ImpactLabel>
-        <ImpactValue value={impact.costs.operationsCosts.total} type="monetary" />
-      </ImpactItemRow>
-      <ImpactItemRow>
-        <ImpactLabel>💰 Recettes d'exploitation</ImpactLabel>
-        <ImpactValue value={impact.revenues.operationsRevenues.total} type="monetary" />
-      </ImpactItemRow>
+      {!!impact.costs.operationsCosts && (
+        <ImpactItemRow>
+          <ImpactLabel>💸️ Charges d'exploitation</ImpactLabel>
+          <ImpactValue value={impact.costs.operationsCosts.total} type="monetary" />
+        </ImpactItemRow>
+      )}
+      {!!impact.revenues.operationsRevenues && (
+        <ImpactItemRow>
+          <ImpactLabel>💰 Recettes d'exploitation</ImpactLabel>
+          <ImpactValue value={impact.revenues.operationsRevenues.total} type="monetary" />
+        </ImpactItemRow>
+      )}
+
       <ImpactItemRow>
         <ImpactLabel>Total du bilan de l'opération</ImpactLabel>
         <ImpactValue isTotal value={impact.total} type="monetary" />


### PR DESCRIPTION
Je suppose que dans le cas où l’aménageur est différent du futur exploitant, les charges et dépenses d’exploitation apparaîtront dans les impacts socio-économiques, j’ai posé la question à Chloë, si elle confirme, je ferais un ticket sur Notion.
Edit: réponse de Laurent, à priori non car ces impacts risque de disparaitre
