### PR TITLE
fix: use warning instead of error for photovoltaic power and surface

### DIFF
--- a/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceForm.tsx
@@ -1,8 +1,8 @@
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 
 import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
-import NumericInput from "@/shared/views/components/form/NumericInput/NumericInput";
+import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
 import FormDefinition from "@/shared/views/layout/WizardFormLayout/FormDefinition";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
@@ -18,13 +18,17 @@ type FormValues = {
 };
 
 function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>();
+  const { control, handleSubmit, watch } = useForm<FormValues>();
 
-  const hintText = `en m² (maximum : ${formatNumberFr(siteSurfaceArea)} m²)`;
+  const hintText = `Maximum : ${formatNumberFr(siteSurfaceArea)} m²`;
 
   const maxErrorMessage = `La superficie des panneaux ne peut pas être supérieure à la superficie totale du site (${formatNumberFr(
     siteSurfaceArea,
   )} m²).`;
+
+  const surface = watch("photovoltaicInstallationSurfaceSquareMeters");
+
+  const displayTooHighValueWarning = surface > siteSurfaceArea;
 
   return (
     <WizardFormLayout
@@ -54,19 +58,26 @@ function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
       }
     >
       <form onSubmit={handleSubmit(onSubmit)}>
-        <NumericInput
+        <Controller
+          control={control}
           name="photovoltaicInstallationSurfaceSquareMeters"
-          label={<RequiredLabel label="Superficie de l'installation" />}
-          hintText={hintText}
           rules={{
             min: 0,
-            max: {
-              value: siteSurfaceArea,
-              message: maxErrorMessage,
-            },
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
           }}
-          control={control}
+          render={(controller) => {
+            return (
+              <ControlledRowNumericInput
+                {...controller}
+                stateRelatedMessage={displayTooHighValueWarning ? maxErrorMessage : undefined}
+                state={displayTooHighValueWarning ? "warning" : "default"}
+                label={<RequiredLabel label="Superficie de l'installation" />}
+                hintText={hintText}
+                hintInputText="en m²"
+                className="!tw-pt-4 tw-pb-6"
+              />
+            );
+          }}
         />
         <BackNextButtonsGroup onBack={onBack} />
       </form>

--- a/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceFromPowerForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceFromPowerForm.tsx
@@ -1,9 +1,9 @@
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 
 import { PHOTOVOLTAIC_RATIO_M2_PER_KWC } from "@/features/create-project/domain/photovoltaic";
 import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
-import NumericInput from "@/shared/views/components/form/NumericInput/NumericInput";
+import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
 import FormDefinition from "@/shared/views/layout/WizardFormLayout/FormDefinition";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
@@ -27,7 +27,7 @@ function PhotovoltaicSurfaceFromPowerForm({
   recommendedSurface,
   siteSurfaceArea,
 }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>({
+  const { control, handleSubmit, watch } = useForm<FormValues>({
     defaultValues: {
       photovoltaicInstallationSurfaceSquareMeters: recommendedSurface,
     },
@@ -38,6 +38,10 @@ function PhotovoltaicSurfaceFromPowerForm({
   const maxErrorMessage = `La superficie des panneaux ne peut pas être supérieure à la superficie totale du site (${formatNumberFr(
     siteSurfaceArea,
   )} m²).`;
+
+  const surface = watch("photovoltaicInstallationSurfaceSquareMeters");
+
+  const displayTooHighValueWarning = surface > siteSurfaceArea;
 
   return (
     <WizardFormLayout
@@ -81,19 +85,26 @@ function PhotovoltaicSurfaceFromPowerForm({
       }
     >
       <form onSubmit={handleSubmit(onSubmit)}>
-        <NumericInput
+        <Controller
+          control={control}
           name="photovoltaicInstallationSurfaceSquareMeters"
-          label={<RequiredLabel label="Superficie de l'installation" />}
-          hintText={hintText}
           rules={{
             min: 0,
-            max: {
-              value: siteSurfaceArea,
-              message: maxErrorMessage,
-            },
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
           }}
-          control={control}
+          render={(controller) => {
+            return (
+              <ControlledRowNumericInput
+                {...controller}
+                stateRelatedMessage={displayTooHighValueWarning ? maxErrorMessage : undefined}
+                state={displayTooHighValueWarning ? "warning" : "default"}
+                label={<RequiredLabel label="Superficie de l'installation" />}
+                hintText={hintText}
+                hintInputText="en m²"
+                className="!tw-pt-4 tw-pb-6"
+              />
+            );
+          }}
         />
         <BackNextButtonsGroup onBack={onBack} />
       </form>

--- a/apps/web/src/features/create-site/views/site-management/yearly-expenses/SiteYearlyExpensesForm.tsx
+++ b/apps/web/src/features/create-site/views/site-management/yearly-expenses/SiteYearlyExpensesForm.tsx
@@ -9,6 +9,7 @@ import {
   stringToNumber,
 } from "@/shared/services/number-conversion/numberConversion";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
+import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
 import RadioButtons from "@/shared/views/components/RadioButtons/RadioButtons";
 import TooltipInfoButton from "@/shared/views/components/TooltipInfoButton/TooltipInfoButton";
@@ -162,24 +163,10 @@ function SiteYearlyExpensesForm({
                     message: "Veuillez sélectionner un montant valide",
                   },
                 }}
-                render={({ field }) => {
+                render={(controller) => {
                   return (
-                    <RowNumericInput
-                      state={formState.errors[name]?.amount ? "error" : "default"}
-                      stateRelatedMessage={
-                        formState.errors[name]?.amount
-                          ? formState.errors[name]?.amount?.message
-                          : undefined
-                      }
-                      nativeInputProps={{
-                        name: field.name,
-                        value: field.value ? numberToString(field.value) : undefined,
-                        onChange: (ev: ChangeEvent<HTMLInputElement>) => {
-                          field.onChange(stringToNumber(ev.target.value));
-                        },
-                        onBlur: field.onBlur,
-                        type: "number",
-                      }}
+                    <ControlledRowNumericInput
+                      {...controller}
                       label={getLabelForExpense(name)}
                       hintText={
                         !hasTenant || bearer === undefined
@@ -192,6 +179,7 @@ function SiteYearlyExpensesForm({
                   );
                 }}
               />
+
               {bearer === undefined && !!watch(`${name}.amount`) && (
                 <RadioButtons
                   error={formState.errors[name]?.bearer ?? undefined}

--- a/apps/web/src/features/create-site/views/site-management/yearly-income/SiteYearlyIncomeForm.tsx
+++ b/apps/web/src/features/create-site/views/site-management/yearly-income/SiteYearlyIncomeForm.tsx
@@ -1,12 +1,7 @@
-import { ChangeEvent } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import {
-  numberToString,
-  stringToNumber,
-} from "@/shared/services/number-conversion/numberConversion";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
-import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
+import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
@@ -20,7 +15,7 @@ export type FormValues = {
 };
 
 function SiteYearlyIncomeForm({ onSubmit, onBack }: Props) {
-  const { control, handleSubmit, formState } = useForm<FormValues>();
+  const { control, handleSubmit } = useForm<FormValues>();
 
   return (
     <WizardFormLayout title="Recettes annuelles liées à l'exploitation du site">
@@ -34,20 +29,10 @@ function SiteYearlyIncomeForm({ onSubmit, onBack }: Props) {
               message: "Veuillez sélectionner un montant valide",
             },
           }}
-          render={({ field }) => {
+          render={(controller) => {
             return (
-              <RowNumericInput
-                state={formState.errors.operationsIncome ? "error" : "default"}
-                stateRelatedMessage={formState.errors.operationsIncome?.message ?? undefined}
-                nativeInputProps={{
-                  name: field.name,
-                  value: field.value ? numberToString(field.value) : undefined,
-                  onChange: (ev: ChangeEvent<HTMLInputElement>) => {
-                    field.onChange(stringToNumber(ev.target.value));
-                  },
-                  onBlur: field.onBlur,
-                  type: "number",
-                }}
+              <ControlledRowNumericInput
+                {...controller}
                 label="Recettes d'exploitation"
                 hintInputText="€ / an"
                 className="!tw-pt-4"
@@ -64,20 +49,10 @@ function SiteYearlyIncomeForm({ onSubmit, onBack }: Props) {
               message: "Veuillez sélectionner un montant valide",
             },
           }}
-          render={({ field }) => {
+          render={(controller) => {
             return (
-              <RowNumericInput
-                state={formState.errors.otherIncome ? "error" : "default"}
-                stateRelatedMessage={formState.errors.otherIncome?.message ?? undefined}
-                nativeInputProps={{
-                  name: field.name,
-                  value: field.value ? numberToString(field.value) : undefined,
-                  onChange: (ev: ChangeEvent<HTMLInputElement>) => {
-                    field.onChange(stringToNumber(ev.target.value));
-                  },
-                  onBlur: field.onBlur,
-                  type: "number",
-                }}
+              <ControlledRowNumericInput
+                {...controller}
                 label="Autres recettes"
                 hintInputText="€ / an"
                 className="!tw-pt-4"

--- a/apps/web/src/features/create-site/views/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
+++ b/apps/web/src/features/create-site/views/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useMemo } from "react";
+import { useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { SoilType } from "shared";
 
@@ -11,11 +11,8 @@ import {
   getLabelForSoilType,
   getPictogramForSoilType,
 } from "@/shared/services/label-mapping/soilTypeLabelMapping";
-import {
-  numberToString,
-  stringToNumber,
-} from "@/shared/services/number-conversion/numberConversion";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
+import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
 import FormWarning from "@/shared/views/layout/WizardFormLayout/FormWarning";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
@@ -40,7 +37,7 @@ function SiteSoilsDistributionBySquareMetersForm({
   onSubmit,
   onBack,
 }: Props) {
-  const { control, handleSubmit, watch, formState } = useForm<FormValues>();
+  const { control, handleSubmit, watch } = useForm<FormValues>();
   const _onSubmit = handleSubmit(onSubmit);
 
   const soilsValues = watch();
@@ -80,22 +77,10 @@ function SiteSoilsDistributionBySquareMetersForm({
                   "La surface de ce sol ne peut pas être supérieure à la surface totale du site",
               },
             }}
-            render={({ field }) => {
+            render={(controller) => {
               return (
-                <RowNumericInput
-                  state={formState.errors[soilType] ? "error" : "default"}
-                  stateRelatedMessage={
-                    formState.errors[soilType] ? formState.errors[soilType]?.message : undefined
-                  }
-                  nativeInputProps={{
-                    name: field.name,
-                    value: field.value ? numberToString(field.value) : undefined,
-                    onChange: (ev: ChangeEvent<HTMLInputElement>) => {
-                      field.onChange(stringToNumber(ev.target.value));
-                    },
-                    onBlur: field.onBlur,
-                    type: "number",
-                  }}
+                <ControlledRowNumericInput
+                  {...controller}
                   label={getLabelForSoilType(soilType)}
                   hintText={getDescriptionForSoilType(soilType)}
                   hintInputText="en m²"

--- a/apps/web/src/main.css
+++ b/apps/web/src/main.css
@@ -77,3 +77,24 @@
 .fr-stepper__steps[data-fr-current-step="13"] {
   --current-step: 13;
 }
+
+/* Ajout d’un statut warning sur le même modèle que error et success pour les inputs */
+
+.fr-message--warning::before,
+.fr-warning-text::before {
+  -webkit-mask-image: url("/dsfr/icons/system/fr--warning-fill.svg");
+  mask-image: url("/dsfr/icons/system/fr--warning-fill.svg");
+}
+
+.fr-select-group--warning label,
+.fr-input-group--warning label,
+.fr-range-group--warning label,
+.fr-upload-group--warning label,
+.fr-label--warning,
+.fr-warning-text {
+  color: var(--text-default-warning);
+}
+
+.fr-input-group--warning::before {
+  background-image: linear-gradient(0deg, var(--border-plain-warning), var(--border-plain-warning));
+}

--- a/apps/web/src/shared/views/components/form/NumericInput/ControlledRowNumericInput.tsx
+++ b/apps/web/src/shared/views/components/form/NumericInput/ControlledRowNumericInput.tsx
@@ -1,0 +1,46 @@
+import { ChangeEvent } from "react";
+import { FieldPath, FieldValues, UseControllerReturn } from "react-hook-form";
+import RowNumericInput, { RowNumericInputInputProps } from "./RowNumericInput";
+
+import {
+  numberToString,
+  stringToNumber,
+} from "@/shared/services/number-conversion/numberConversion";
+
+type Props<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = RowNumericInputInputProps & UseControllerReturn<TFieldValues, TName>;
+
+const ControlledRowNumericInput = <
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
+>({
+  field,
+  fieldState,
+  nativeInputProps = {},
+  stateRelatedMessage,
+  state,
+  ...props
+}: Props<TFieldValues, TName>) => {
+  const error = fieldState.error;
+
+  return (
+    <RowNumericInput
+      state={error ? "error" : state}
+      stateRelatedMessage={error?.message ?? stateRelatedMessage}
+      nativeInputProps={{
+        name: field.name,
+        value: field.value ? numberToString(field.value) : undefined,
+        onChange: (ev: ChangeEvent<HTMLInputElement>) => {
+          field.onChange(stringToNumber(ev.target.value));
+        },
+        onBlur: field.onBlur,
+        ...nativeInputProps,
+      }}
+      {...props}
+    />
+  );
+};
+
+export default ControlledRowNumericInput;

--- a/apps/web/src/shared/views/components/form/NumericInput/RowNumericInput.tsx
+++ b/apps/web/src/shared/views/components/form/NumericInput/RowNumericInput.tsx
@@ -19,7 +19,7 @@ export type RowNumericInputInputProps = {
   hintInputText?: ReactNode;
   hideLabel?: boolean;
   disabled?: boolean;
-  state?: "success" | "error" | "default";
+  state?: "success" | "error" | "default" | "warning";
   stateRelatedMessage?: ReactNode;
   nativeInputProps?: DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 };
@@ -55,11 +55,13 @@ const RowNumericInput = memo(
             "tw-items-start",
             "tw-mb-0",
             "tw-pt-7",
+            "fr-input-group",
             fr.cx(
               disabled && "fr-input-group--disabled",
               state === "error" && "fr-input-group--error",
               state === "success" && "fr-input-group--valid",
             ),
+            state === "warning" && "fr-input-group--info fr-input-group--warning",
             className,
           )}
           ref={ref}
@@ -78,16 +80,27 @@ const RowNumericInput = memo(
               />
             )}
             <label
-              className={classNames(
-                "tw-text-lg",
-                "tw-font-bold",
-                fr.cx("fr-label", hideLabel && "fr-sr-only"),
-              )}
+              className={classNames("tw-text-lg", fr.cx("fr-label", hideLabel && "fr-sr-only"))}
               htmlFor={inputId}
             >
               {label}
               {hintText && (
                 <span className="fr-hint-text tw-text-sm tw-font-normal">{hintText}</span>
+              )}
+              {state !== "default" && (
+                <p
+                  id={messageId}
+                  className={classNames(
+                    "tw-mt-0",
+                    fr.cx(
+                      state === "error" && "fr-error-text",
+                      state === "success" && "fr-valid-text",
+                    ),
+                    state === "warning" && "fr-info-text fr-warning-text",
+                  )}
+                >
+                  {stateRelatedMessage}
+                </p>
               )}
             </label>
           </div>
@@ -101,30 +114,14 @@ const RowNumericInput = memo(
                   state === "error" && "fr-input--error",
                   state === "success" && "fr-input--valid",
                 ),
+                state === "warning" && "fr-input--warning",
               )}
               disabled={disabled}
               aria-describedby={messageId}
               type="number"
               id={inputId}
             />
-            {state === "default" && hintInputText && (
-              <span className="fr-hint-text tw-mt-1">{hintInputText}</span>
-            )}
-
-            {state !== "default" && (
-              <p
-                id={messageId}
-                className={classNames(
-                  "tw-mt-0",
-                  fr.cx(
-                    state === "error" && "fr-error-text",
-                    state === "success" && "fr-valid-text",
-                  ),
-                )}
-              >
-                {stateRelatedMessage}
-              </p>
-            )}
+            {hintInputText && <span className="fr-hint-text tw-mt-1">{hintInputText}</span>}
           </div>
         </div>
       );


### PR DESCRIPTION
- Modification du composant `RowNumericInput` pour gérer visuellement les warnings
- Ne pas bloquer le formulaire si les max conseillés sont dépassés
- Création d’un composant `ControlledRowNumericInput` pour factoriser la logique de `numberToString` et `stringToNumber` 