### PR TITLE
feat: store and display reinstatement costs as detailed list + let webapp handle negative values of costs + rename 'expenses' to costs in economic balance impact

### DIFF
--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.integration-spec.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.integration-spec.ts
@@ -47,7 +47,6 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
         future_operator_name: "Mairie de Blajan",
         future_site_owner_name: "Mairie de Blajan",
         reinstatement_contract_owner_name: "Mairie de Blajan",
-        reinstatement_cost: 15000,
         real_estate_transaction_selling_price: 100000,
         real_estate_transaction_property_transfer_duties: 8000,
         operations_first_year: 2025,
@@ -83,6 +82,20 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
           },
         },
       ]);
+      await sqlConnection("reconversion_project_reinstatement_costs").insert([
+        {
+          id: uuid(),
+          reconversion_project_id: reconversionProjectId,
+          amount: 1000,
+          purpose: "waste_collection",
+        },
+        {
+          id: uuid(),
+          reconversion_project_id: reconversionProjectId,
+          amount: 500,
+          purpose: "deimpermeabilization",
+        },
+      ]);
 
       const result = await repository.getById(reconversionProjectId);
 
@@ -105,11 +118,14 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
           startDate: new Date("2024-07-01"),
           endDate: new Date("2024-12-31"),
         },
+        reinstatementCosts: [
+          { purpose: "waste_collection", amount: 1000 },
+          { purpose: "deimpermeabilization", amount: 500 },
+        ],
         futureOperatorName: "Mairie de Blajan",
         futureSiteOwnerName: "Mairie de Blajan",
         reinstatementContractOwnerName: "Mairie de Blajan",
         realEstateTransactionTotalCost: 108000,
-        reinstatementCost: 15000,
         developmentPlanInstallationCost: 0,
         reinstatementFinancialAssistanceAmount: 0,
         yearlyProjectedCosts: [],
@@ -186,7 +202,7 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
         operationsFullTimeJobs: undefined,
         realEstateTransactionTotalCost: undefined,
         reinstatementContractOwnerName: undefined,
-        reinstatementCost: 0,
+        reinstatementCosts: [],
         reinstatementFinancialAssistanceAmount: 0,
         reinstatementFullTimeJobs: undefined,
         reinstatementSchedule: undefined,

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
@@ -31,7 +31,6 @@ export class SqlReconversionProjectImpactsRepository
         "real_estate_transaction_selling_price",
         "real_estate_transaction_property_transfer_duties",
         "reinstatement_financial_assistance_amount",
-        "reinstatement_cost",
         "operations_first_year",
       )
       .where({ id: reconversionProjectId })
@@ -73,6 +72,12 @@ export class SqlReconversionProjectImpactsRepository
       .select("amount", "source")
       .where("reconversion_project_id", reconversionProjectId);
 
+    const sqlReinstatementCosts = await this.sqlConnection(
+      "reconversion_project_reinstatement_costs",
+    )
+      .select("amount", "purpose")
+      .where("reconversion_project_id", reconversionProjectId);
+
     const developmentPlanFeatures = (sqlDevelopmentPlan?.features ?? {
       expectedAnnualProduction: undefined,
       surfaceArea: undefined,
@@ -111,7 +116,7 @@ export class SqlReconversionProjectImpactsRepository
       realEstateTransactionTotalCost,
       realEstateTransactionPropertyTransferDutiesAmount:
         reconversionProject.real_estate_transaction_property_transfer_duties ?? undefined,
-      reinstatementCost: reconversionProject.reinstatement_cost ?? 0,
+      reinstatementCosts: sqlReinstatementCosts,
       developmentPlanInstallationCost: sqlDevelopmentPlan?.cost ?? 0,
       reinstatementFinancialAssistanceAmount:
         reconversionProject.reinstatement_financial_assistance_amount ?? 0,

--- a/apps/api/src/reconversion-projects/domain/model/impacts/economic-balance/economicBalanceImpact.spec.ts
+++ b/apps/api/src/reconversion-projects/domain/model/impacts/economic-balance/economicBalanceImpact.spec.ts
@@ -6,11 +6,14 @@ import {
 
 describe("EconomicBalance impact", () => {
   describe("getEconomicResultsOfProjectInstallation", () => {
-    it("should return use all expenses and revenues in balance if operator is new site owner and reinstatement cost owner", () => {
+    it("should return all costs and revenues in balance if operator is new site owner and reinstatement cost owner", () => {
       expect(
         getEconomicResultsOfProjectInstallation({
           reinstatementFinancialAssistanceAmount: 50000,
-          reinstatementCost: 1000000,
+          reinstatementCosts: [
+            { amount: 10000, purpose: "waste_collection" },
+            { amount: 39999, purpose: "deimpermebilization" },
+          ],
           developmentPlanInstallationCost: 150000,
           realEstateTransactionTotalCost: 100000,
           futureOperatorName: "Mairie de Blajan",
@@ -19,12 +22,18 @@ describe("EconomicBalance impact", () => {
           reinstatementContractOwnerName: "Mairie de Blajan",
         }),
       ).toEqual({
-        total: 50000 - 1000000 - 150000 - 100000,
+        total: 50000 - (49999 + 150000 + 100000),
         costs: {
-          total: -1250000,
-          siteReinstatement: -1000000,
-          developmentPlanInstallation: -150000,
-          realEstateTransaction: -100000,
+          total: 49999 + 150000 + 100000,
+          siteReinstatement: {
+            total: 49999,
+            costs: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
+          },
+          developmentPlanInstallation: 150000,
+          realEstateTransaction: 100000,
         },
         revenues: {
           total: 50000,
@@ -37,7 +46,10 @@ describe("EconomicBalance impact", () => {
       expect(
         getEconomicResultsOfProjectInstallation({
           reinstatementFinancialAssistanceAmount: 50000,
-          reinstatementCost: 1000000,
+          reinstatementCosts: [
+            { amount: 10000, purpose: "waste_collection" },
+            { amount: 39999, purpose: "deimpermebilization" },
+          ],
           developmentPlanInstallationCost: 150000,
           realEstateTransactionTotalCost: 100000,
           futureOperatorName: "Mairie de Blajan",
@@ -46,11 +58,17 @@ describe("EconomicBalance impact", () => {
           reinstatementContractOwnerName: "Mairie de Blajan",
         }),
       ).toEqual({
-        total: 50000 - 1000000 - 150000,
+        total: 50000 - (49999 + 150000),
         costs: {
-          total: -1150000,
-          siteReinstatement: -1000000,
-          developmentPlanInstallation: -150000,
+          total: 49999 + 150000,
+          siteReinstatement: {
+            total: 49999,
+            costs: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
+          },
+          developmentPlanInstallation: 150000,
         },
         revenues: {
           total: 50000,
@@ -63,7 +81,10 @@ describe("EconomicBalance impact", () => {
       expect(
         getEconomicResultsOfProjectInstallation({
           reinstatementFinancialAssistanceAmount: 50000,
-          reinstatementCost: 1000000,
+          reinstatementCosts: [
+            { amount: 10000, purpose: "waste_collection" },
+            { amount: 39999, purpose: "deimpermebilization" },
+          ],
           developmentPlanInstallationCost: 150000,
           realEstateTransactionTotalCost: 100000,
           futureOperatorName: "Mairie de Blajan",
@@ -74,8 +95,8 @@ describe("EconomicBalance impact", () => {
       ).toEqual({
         total: -150000,
         costs: {
-          total: -150000,
-          developmentPlanInstallation: -150000,
+          total: 150000,
+          developmentPlanInstallation: 150000,
         },
         revenues: {
           total: 0,
@@ -85,12 +106,12 @@ describe("EconomicBalance impact", () => {
   });
 
   describe("getEconomicResultsOfProjectExploitationForDuration", () => {
-    it("should return 0 for a project with no expenses and costs filled", () => {
+    it("should return 0 for a project with no costs", () => {
       expect(getEconomicResultsOfProjectExploitationForDuration([], [], 10)).toEqual({
         total: 0,
         operationsCosts: {
           total: 0,
-          expenses: [],
+          costs: [],
         },
         operationsRevenues: {
           total: 0,
@@ -116,10 +137,10 @@ describe("EconomicBalance impact", () => {
       ).toEqual({
         total: -25500,
         operationsCosts: {
-          total: -60500,
-          expenses: [
-            { amount: -60000, purpose: "taxes" },
-            { amount: -500, purpose: "maintenance" },
+          total: 60500,
+          costs: [
+            { amount: 60000, purpose: "taxes" },
+            { amount: 500, purpose: "maintenance" },
           ],
         },
         operationsRevenues: {
@@ -143,10 +164,10 @@ describe("EconomicBalance impact", () => {
       ).toEqual({
         total: -181500,
         operationsCosts: {
-          total: -181500,
-          expenses: [
-            { amount: -180000, purpose: "taxes" },
-            { amount: -1500, purpose: "maintenance" },
+          total: 181500,
+          costs: [
+            { amount: 180000, purpose: "taxes" },
+            { amount: 1500, purpose: "maintenance" },
           ],
         },
         operationsRevenues: {
@@ -156,13 +177,17 @@ describe("EconomicBalance impact", () => {
       });
     });
   });
+
   describe("computeEconomicBalanceImpact", () => {
     it("should sum installation result and operation result if projectDeveloper is futureOperator", () => {
       expect(
         computeEconomicBalanceImpact(
           {
             reinstatementFinancialAssistanceAmount: 50000,
-            reinstatementCost: 1000000,
+            reinstatementCosts: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
             developmentPlanInstallationCost: 150000,
             realEstateTransactionTotalCost: 100000,
             futureOperatorName: "Mairie de Blajan",
@@ -178,12 +203,12 @@ describe("EconomicBalance impact", () => {
         total: -150000,
         bearer: "Mairie de Blajan",
         costs: {
-          total: -150000,
+          total: 150000,
           operationsCosts: {
             total: 0,
-            expenses: [],
+            costs: [],
           },
-          developmentPlanInstallation: -150000,
+          developmentPlanInstallation: 150000,
         },
         revenues: {
           total: 0,
@@ -198,7 +223,10 @@ describe("EconomicBalance impact", () => {
         computeEconomicBalanceImpact(
           {
             reinstatementFinancialAssistanceAmount: 50000,
-            reinstatementCost: 1000000,
+            reinstatementCosts: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
             developmentPlanInstallationCost: 150000,
             realEstateTransactionTotalCost: 100000,
             futureOperatorName: "Mairie de Blajan",
@@ -218,19 +246,25 @@ describe("EconomicBalance impact", () => {
           20,
         ),
       ).toEqual({
-        total: 50000 + 700000 - 150000 - 1000000 - 1210000,
+        total: 750000 - (1210000 + 49999 + 150000),
         bearer: "Mairie de Blajan",
         costs: {
-          total: -2360000,
+          total: 1210000 + 49999 + 150000,
           operationsCosts: {
-            total: -1210000,
-            expenses: [
-              { amount: -1200000, purpose: "taxes" },
-              { amount: -10000, purpose: "maintenance" },
+            total: 1210000,
+            costs: [
+              { amount: 1200000, purpose: "taxes" },
+              { amount: 10000, purpose: "maintenance" },
             ],
           },
-          siteReinstatement: -1000000,
-          developmentPlanInstallation: -150000,
+          siteReinstatement: {
+            total: 49999,
+            costs: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
+          },
+          developmentPlanInstallation: 150000,
         },
         revenues: {
           total: 750000,
@@ -252,7 +286,10 @@ describe("EconomicBalance impact", () => {
         computeEconomicBalanceImpact(
           {
             reinstatementFinancialAssistanceAmount: 50000,
-            reinstatementCost: 1000000,
+            reinstatementCosts: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
             developmentPlanInstallationCost: 150000,
             realEstateTransactionTotalCost: 100000,
             futureOperatorName: "Exploitant",
@@ -268,8 +305,8 @@ describe("EconomicBalance impact", () => {
         total: -150000,
         bearer: "Mairie de Blajan",
         costs: {
-          total: -150000,
-          developmentPlanInstallation: -150000,
+          total: 150000,
+          developmentPlanInstallation: 150000,
         },
         revenues: {
           total: 0,
@@ -280,7 +317,10 @@ describe("EconomicBalance impact", () => {
         computeEconomicBalanceImpact(
           {
             reinstatementFinancialAssistanceAmount: 50000,
-            reinstatementCost: 1000000,
+            reinstatementCosts: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
             developmentPlanInstallationCost: 150000,
             realEstateTransactionTotalCost: 100000,
             futureOperatorName: "Exploitant",
@@ -300,12 +340,18 @@ describe("EconomicBalance impact", () => {
           20,
         ),
       ).toEqual({
-        total: 50000 - 1150000,
+        total: 50000 - (49999 + 150000),
         bearer: "Mairie de Blajan",
         costs: {
-          total: -1150000,
-          siteReinstatement: -1000000,
-          developmentPlanInstallation: -150000,
+          total: 49999 + 150000,
+          siteReinstatement: {
+            total: 49999,
+            costs: [
+              { amount: 10000, purpose: "waste_collection" },
+              { amount: 39999, purpose: "deimpermebilization" },
+            ],
+          },
+          developmentPlanInstallation: 150000,
         },
         revenues: {
           total: 50000,

--- a/apps/api/src/reconversion-projects/domain/model/reconversionProject.mock.ts
+++ b/apps/api/src/reconversion-projects/domain/model/reconversionProject.mock.ts
@@ -83,7 +83,12 @@ export const buildExhaustiveReconversionProjectProps = (): Required<Reconversion
       name: "Reinstatement company",
       structureType: "company",
     },
-    reinstatementCost: 90000,
+    reinstatementCosts: [
+      { amount: 120000, purpose: "waste_collection" },
+      { amount: 33333, purpose: "deimpermeabilization" },
+      { amount: 44444, purpose: "sustainable_soils_reinstatement" },
+      { amount: 1, purpose: "other_reinstatement_costs" },
+    ],
     realEstateTransactionSellingPrice: 150000,
     realEstateTransactionPropertyTransferDuties: 12000,
     reinstatementFinancialAssistanceAmount: 14999.99,

--- a/apps/api/src/reconversion-projects/domain/model/reconversionProject.ts
+++ b/apps/api/src/reconversion-projects/domain/model/reconversionProject.ts
@@ -32,6 +32,8 @@ const developmentPlanSchema = z.discriminatedUnion("type", [
 
 export type DevelopmentPlan = z.infer<typeof developmentPlanSchema>;
 
+const costSchema = z.object({ purpose: z.string(), amount: z.number().nonnegative() });
+
 export const reconversionProjectSchema = z.object({
   id: z.string().uuid(),
   createdBy: z.string().uuid(),
@@ -48,9 +50,9 @@ export const reconversionProjectSchema = z.object({
   operationsFullTimeJobsInvolved: z.number().nonnegative().optional(),
   realEstateTransactionSellingPrice: z.number().nonnegative().optional(),
   realEstateTransactionPropertyTransferDuties: z.number().nonnegative().optional(),
-  reinstatementCost: z.number().nonnegative().optional(),
+  reinstatementCosts: z.array(costSchema).optional(),
   reinstatementFinancialAssistanceAmount: z.number().nonnegative().optional(),
-  yearlyProjectedCosts: z.object({ purpose: z.string(), amount: z.number().nonnegative() }).array(),
+  yearlyProjectedCosts: z.array(costSchema),
   yearlyProjectedRevenues: z
     .object({ source: z.string(), amount: z.number().nonnegative() })
     .array(),

--- a/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.spec.ts
@@ -48,8 +48,7 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
         relatedSiteId: siteId,
         soilsDistribution: {},
         realEstateTransactionTotalCost: 0,
-        reinstatementCost: 0,
-        developmentPlanInstallationCost: 0,
+        reinstatementCosts: [],
         reinstatementFinancialAssistanceAmount: 0,
         yearlyProjectedCosts: [],
         yearlyProjectedRevenues: [],
@@ -96,7 +95,7 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
       futureSiteOwnerName: "Mairie de Blajan",
       reinstatementContractOwnerName: "Mairie de Blajan",
       realEstateTransactionTotalCost: 150000,
-      reinstatementCost: 500000,
+      reinstatementCosts: [{ amount: 500000, purpose: "demolition" }],
       developmentPlanInstallationCost: 200000,
       developmentPlanElectricalPowerKWc: 258,
       developmentPlanSurfaceArea: 20000,
@@ -261,17 +260,20 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
             total: -500000,
             bearer: "Mairie de Blajan",
             costs: {
-              total: -960000,
+              total: 960000,
               operationsCosts: {
-                total: -110000,
-                expenses: [
-                  { amount: -10000, purpose: "taxes" },
-                  { amount: -100000, purpose: "maintenance" },
+                total: 110000,
+                costs: [
+                  { amount: 10000, purpose: "taxes" },
+                  { amount: 100000, purpose: "maintenance" },
                 ],
               },
-              siteReinstatement: -500000,
-              developmentPlanInstallation: -200000,
-              realEstateTransaction: -150000,
+              siteReinstatement: {
+                total: 500000,
+                costs: [{ amount: 500000, purpose: "demolition" }],
+              },
+              developmentPlanInstallation: 200000,
+              realEstateTransaction: 150000,
             },
             revenues: {
               total: 460000,

--- a/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.ts
+++ b/apps/api/src/reconversion-projects/domain/usecases/computeReconversionProjectImpacts.usecase.ts
@@ -77,7 +77,7 @@ export type ReconversionProjectImpactsDataView = {
   reinstatementContractOwnerName?: string;
   realEstateTransactionTotalCost?: number;
   realEstateTransactionPropertyTransferDutiesAmount?: number;
-  reinstatementCost?: number;
+  reinstatementCosts: { amount: number; purpose: string }[];
   developmentPlanInstallationCost?: number;
   reinstatementFinancialAssistanceAmount?: number;
   yearlyProjectedCosts: { amount: number; purpose: string }[];
@@ -203,7 +203,7 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
             futureOperatorName: reconversionProject.futureOperatorName,
             futureSiteOwnerName: reconversionProject.futureSiteOwnerName,
             reinstatementContractOwnerName: reconversionProject.reinstatementContractOwnerName,
-            reinstatementCost: reconversionProject.reinstatementCost,
+            reinstatementCosts: reconversionProject.reinstatementCosts,
             yearlyProjectedCosts: reconversionProject.yearlyProjectedCosts,
             yearlyProjectedRevenues: reconversionProject.yearlyProjectedRevenues,
             realEstateTransactionTotalCost: reconversionProject.realEstateTransactionTotalCost,

--- a/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240530132340_extract-reconversion-project-reinstatement-costs-to-table.ts
+++ b/apps/api/src/shared-kernel/adapters/sql-knex/migrations/20240530132340_extract-reconversion-project-reinstatement-costs-to-table.ts
@@ -1,0 +1,52 @@
+import type { Knex } from "knex";
+import { v4 as uuid } from "uuid";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    // create reconversion_project_reinstatement_costs table
+    await trx.schema.createTable("reconversion_project_reinstatement_costs", function (table) {
+      table.uuid("id").unique().primary().notNullable();
+      table.string("purpose").notNullable();
+      table.decimal("amount", 15, 2);
+      table
+        .uuid("reconversion_project_id")
+        .references("id")
+        .inTable("reconversion_projects")
+        .notNullable();
+    });
+
+    // retrieve all non-null, non-zero reinstatement costs in reconversion_projects
+    const result = (await trx("reconversion_projects")
+      .select("id", "reinstatement_cost")
+      .whereNotNull("reinstatement_cost")
+      .where("reinstatement_cost", ">", 0)) as { id: string; reinstatement_cost: number }[];
+
+    // insert in created reconversion_project_reinstatement_costs table
+    const reinstatementCostsToInsert = result.map(({ id, reinstatement_cost }) => {
+      return {
+        id: uuid(),
+        purpose: "other_reinstatement_costs",
+        amount: reinstatement_cost,
+        reconversion_project_id: id,
+      };
+    });
+    if (reinstatementCostsToInsert.length > 0)
+      await trx("reconversion_project_reinstatement_costs").insert(reinstatementCostsToInsert);
+
+    // delete reinstatement_cost column from reconversion_projects table
+    await trx.schema.table("reconversion_projects", function (table) {
+      table.dropColumn("reinstatement_cost");
+    });
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    await trx.schema.table("reconversion_projects", function (table) {
+      table.decimal("reinstatement_cost", 15, 2);
+    });
+
+    // delete reconversion_project_reinstatement_costs table
+    await trx.schema.dropTableIfExists("reconversion_project_reinstatement_costs");
+  });
+}

--- a/apps/api/test/integration-tests-global-hooks.ts
+++ b/apps/api/test/integration-tests-global-hooks.ts
@@ -7,6 +7,7 @@ global.afterEach(async () => {
   const tablesToDelete = [
     "reconversion_project_yearly_expenses",
     "reconversion_project_yearly_revenues",
+    "reconversion_project_reinstatement_costs",
     "reconversion_project_soils_distributions",
     "reconversion_project_development_plans",
     "reconversion_projects",

--- a/apps/web/src/features/create-project/application/createProject.selectors.ts
+++ b/apps/web/src/features/create-project/application/createProject.selectors.ts
@@ -227,7 +227,7 @@ export const getDefaultValuesForFullTimeConversionJobsInvolved = createSelector(
 
     const reinstatementFullTimeJobs =
       siteData?.isFriche && reinstatementCosts
-        ? computeDefaultReinstatementFullTimeJobs(reinstatementCosts.expenses)
+        ? computeDefaultReinstatementFullTimeJobs(reinstatementCosts.costs)
         : undefined;
 
     return {

--- a/apps/web/src/features/create-project/application/saveReconversionProject.action.ts
+++ b/apps/web/src/features/create-project/application/saveReconversionProject.action.ts
@@ -28,6 +28,8 @@ const developmentPlanSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
+const costSchema = z.object({ amount: z.number().nonnegative(), purpose: z.string() });
+
 const saveProjectSchema = z.object({
   id: z.string().uuid(),
   createdBy: z.string().uuid(),
@@ -43,9 +45,9 @@ const saveProjectSchema = z.object({
   operationsFullTimeJobsInvolved: z.number().nonnegative().optional(),
   realEstateTransactionSellingPrice: z.number().nonnegative().optional(),
   realEstateTransactionPropertyTransferDuties: z.number().nonnegative().optional(),
-  reinstatementCost: z.number().nonnegative().optional(),
+  reinstatementCosts: costSchema.array().optional(),
   reinstatementFinancialAssistanceAmount: z.number().nonnegative().optional(),
-  yearlyProjectedCosts: z.object({ amount: z.number().nonnegative(), purpose: z.string() }).array(),
+  yearlyProjectedCosts: costSchema.array(),
   yearlyProjectedRevenues: z
     .object({ amount: z.number().nonnegative(), source: z.string() })
     .array(),
@@ -80,7 +82,7 @@ export const saveReconversionProject = createAppAsyncThunk(
       reinstatementFullTimeJobsInvolved: projectData.reinstatementFullTimeJobsInvolved,
       reinstatementContractOwner: projectData.reinstatementContractOwner,
       operationsFullTimeJobsInvolved: projectData.operationsFullTimeJobsInvolved,
-      reinstatementCost: projectData.reinstatementCosts?.total,
+      reinstatementCosts: projectData.reinstatementCosts?.costs,
       realEstateTransactionSellingPrice: projectData.realEstateTransactionSellingPrice,
       realEstateTransactionPropertyTransferDuties:
         projectData.realEstateTransactionPropertyTransferDuties,

--- a/apps/web/src/features/create-project/domain/project.types.ts
+++ b/apps/web/src/features/create-project/domain/project.types.ts
@@ -52,7 +52,7 @@ export type ReinstatementCostsPurpose =
 
 export type ReinstatementCosts = {
   total: number;
-  expenses: { purpose: ReinstatementCostsPurpose; amount: number }[];
+  costs: { purpose: ReinstatementCostsPurpose; amount: number }[];
 };
 
 export type FinancialAssistanceRevenue = {

--- a/apps/web/src/features/create-project/domain/reinstatement.ts
+++ b/apps/web/src/features/create-project/domain/reinstatement.ts
@@ -16,14 +16,11 @@ const FULL_TIME_JOBS_RATIO_FOR_BUDGET_PER_EURO_PER_YEAR: Record<
 };
 
 export const computeDefaultReinstatementFullTimeJobs = (
-  reinstatementExpenses: ReinstatementCosts["expenses"],
+  reinstatementCosts: ReinstatementCosts["costs"],
 ) => {
-  const reinstatementFullTimeJobs = reinstatementExpenses.reduce(
-    (totalJobs, { purpose, amount }) => {
-      const ratio = FULL_TIME_JOBS_RATIO_FOR_BUDGET_PER_EURO_PER_YEAR[purpose];
-      return ratio === "unknown" ? totalJobs : totalJobs + amount * ratio;
-    },
-    0,
-  );
+  const reinstatementFullTimeJobs = reinstatementCosts.reduce((totalJobs, { purpose, amount }) => {
+    const ratio = FULL_TIME_JOBS_RATIO_FOR_BUDGET_PER_EURO_PER_YEAR[purpose];
+    return ratio === "unknown" ? totalJobs : totalJobs + amount * ratio;
+  }, 0);
   return roundTo1Digit(reinstatementFullTimeJobs);
 };

--- a/apps/web/src/features/create-project/views/costs/reinstatement-costs/index.tsx
+++ b/apps/web/src/features/create-project/views/costs/reinstatement-costs/index.tsx
@@ -16,39 +16,45 @@ const hasImpermeableSoils = (soilsDistribution: ProjectSite["soilsDistribution"]
 const hasMineralSoils = (soilsDistribution: ProjectSite["soilsDistribution"]) =>
   soilsDistribution.MINERAL_SOIL ? soilsDistribution.MINERAL_SOIL > 0 : false;
 
-const convertFormValuesToExpenses = (amounts: FormValues) => {
-  const expenses: ReinstatementCosts["expenses"] = [];
+const convertFormValuesToCosts = (amounts: FormValues): ReinstatementCosts["costs"] => {
+  const reinstatementCosts: ReinstatementCosts["costs"] = [];
   if (amounts.asbestosRemovalAmount) {
-    expenses.push({ purpose: "asbestos_removal", amount: amounts.asbestosRemovalAmount });
+    reinstatementCosts.push({ purpose: "asbestos_removal", amount: amounts.asbestosRemovalAmount });
   }
 
   if (amounts.deimpermeabilizationAmount) {
-    expenses.push({ purpose: "deimpermeabilization", amount: amounts.deimpermeabilizationAmount });
+    reinstatementCosts.push({
+      purpose: "deimpermeabilization",
+      amount: amounts.deimpermeabilizationAmount,
+    });
   }
 
   if (amounts.demolitionAmount) {
-    expenses.push({ purpose: "demolition", amount: amounts.demolitionAmount });
+    reinstatementCosts.push({ purpose: "demolition", amount: amounts.demolitionAmount });
   }
 
   if (amounts.otherReinstatementCostAmount) {
-    expenses.push({ purpose: "other_reinstatement", amount: amounts.otherReinstatementCostAmount });
+    reinstatementCosts.push({
+      purpose: "other_reinstatement",
+      amount: amounts.otherReinstatementCostAmount,
+    });
   }
 
   if (amounts.remediationAmount) {
-    expenses.push({ purpose: "remediation", amount: amounts.remediationAmount });
+    reinstatementCosts.push({ purpose: "remediation", amount: amounts.remediationAmount });
   }
 
   if (amounts.sustainableSoilsReinstatementAmount) {
-    expenses.push({
+    reinstatementCosts.push({
       purpose: "sustainable_soils_reinstatement",
       amount: amounts.sustainableSoilsReinstatementAmount,
     });
   }
 
   if (amounts.wasteCollectionAmount) {
-    expenses.push({ purpose: "waste_collection", amount: amounts.wasteCollectionAmount });
+    reinstatementCosts.push({ purpose: "waste_collection", amount: amounts.wasteCollectionAmount });
   }
-  return expenses;
+  return reinstatementCosts;
 };
 
 const mapProps = (dispatch: AppDispatch, siteData?: ProjectSite) => {
@@ -59,9 +65,9 @@ const mapProps = (dispatch: AppDispatch, siteData?: ProjectSite) => {
       hasImpermeableSoils(soilsDistribution) || hasMineralSoils(soilsDistribution),
     hasContaminatedSoils: siteData?.hasContaminatedSoils ?? false,
     onSubmit: (amounts: FormValues) => {
-      const expenses = convertFormValuesToExpenses(amounts);
-      const total = sumList(expenses.map(({ amount }) => amount));
-      dispatch(completeReinstatementCost({ expenses, total }));
+      const costs = convertFormValuesToCosts(amounts);
+      const total = sumList(costs.map(({ amount }) => amount));
+      dispatch(completeReinstatementCost({ costs, total }));
     },
     onBack: () => {
       dispatch(revertReinstatementCost());

--- a/apps/web/src/features/projects/domain/impacts.types.ts
+++ b/apps/web/src/features/projects/domain/impacts.types.ts
@@ -1,7 +1,14 @@
 import { SoilType } from "shared";
 
-type PurposeCost = "rent" | "maintenance" | "taxes" | "other";
 type SourceRevenue = "operations" | "other";
+
+type OperationsCost = { purpose: "rent" | "maintenance" | "taxes" | "other"; amount: number };
+type GenericCost = { purpose: string; amount: number };
+
+type CostsTotalAndDetails<TCost> = {
+  total: number;
+  costs: TCost[];
+};
 
 type BaseEconomicImpact = { actor: string; amount: number };
 type RentalIncomeImpact = BaseEconomicImpact & {
@@ -96,11 +103,8 @@ export type ReconversionProjectImpacts = {
     bearer?: string;
     costs: {
       total: number;
-      operationsCosts?: {
-        total: number;
-        expenses: { purpose: PurposeCost; amount: number }[];
-      };
-      siteReinstatement?: number;
+      operationsCosts?: CostsTotalAndDetails<OperationsCost>;
+      siteReinstatement?: CostsTotalAndDetails<GenericCost>;
       developmentPlanInstallation: number;
       realEstateTransaction?: number;
     };

--- a/apps/web/src/features/projects/views/project-impacts-page/charts-view/impacts/economic-balance/EconomicBalanceImpactCard.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/charts-view/impacts/economic-balance/EconomicBalanceImpactCard.tsx
@@ -49,6 +49,7 @@ const getCostsValues = ({
   realEstateTransaction: Props["costs"]["realEstateTransaction"];
   operationsCosts: Props["costs"]["operationsCosts"];
 }) => {
+  const operationsCostsDetailledList = operationsCosts?.costs ?? [];
   return [
     {
       name: "Installation des panneaux photovoltaïque",
@@ -56,13 +57,13 @@ const getCostsValues = ({
     },
     {
       name: "Remise en état de la friche",
-      value: siteReinstatement,
+      value: siteReinstatement?.total ?? 0,
     },
     {
       name: "Transaction immobilière",
       value: realEstateTransaction,
     },
-    ...(operationsCosts?.expenses ?? []).map(({ amount, purpose }) => ({
+    ...operationsCostsDetailledList.map(({ amount, purpose }) => ({
       name: getYearlyCostPurposeLabel(purpose),
       value: amount,
     })),
@@ -97,7 +98,7 @@ function EconomicBalanceImpactCard({ revenues, costs, onTitleClick }: Props) {
     ...baseColumnChartConfig,
     xAxis: {
       categories: [
-        `<strong>Dépenses</strong><br>${formatMonetaryImpact(costs.total)}`,
+        `<strong>Dépenses</strong><br>${formatMonetaryImpact(-costs.total)}`,
         `<strong>Recettes</strong><br>${formatMonetaryImpact(revenues.total)}`,
       ],
       opposite: true,
@@ -126,7 +127,7 @@ function EconomicBalanceImpactCard({ revenues, costs, onTitleClick }: Props) {
         siteReinstatement,
       }).map(({ name, value }) => ({
         name,
-        data: [roundTo2Digits(value), 0],
+        data: [-roundTo2Digits(value), 0],
         type: "column",
       })) as Array<Highcharts.SeriesOptionsType>),
     ],

--- a/apps/web/src/features/projects/views/project-impacts-page/list-view/sections/EconomicBalance.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/list-view/sections/EconomicBalance.tsx
@@ -1,3 +1,6 @@
+import ImpactDetailLabel from "../ImpactDetailLabel";
+import ImpactDetailRow from "../ImpactItemDetailRow";
+import ImpactItemGroup from "../ImpactItemGroup";
 import ImpactItemRow from "../ImpactItemRow";
 import ImpactLabel from "../ImpactLabel";
 import ImpactMainTitle from "../ImpactMainTitle";
@@ -5,6 +8,25 @@ import ImpactValue from "../ImpactValue";
 
 import { ReconversionProjectImpacts } from "@/features/projects/domain/impacts.types";
 import { ImpactDescriptionModalCategory } from "@/features/projects/views/project-impacts-page/modals/ImpactDescriptionModalWizard";
+
+const getLabelForReinstatementCostPurpose = (costPurpose: string): string => {
+  switch (costPurpose) {
+    case "asbestos_removal":
+      return "☣️ Désamiantage";
+    case "sustainable_soils_reinstatement":
+      return "🌱 Restauration écologique";
+    case "deimpermeabilization":
+      return "🌧 Désimperméabilisation";
+    case "remediation":
+      return "✨ Dépollution des sols";
+    case "demolition":
+      return "🧱 Déconstruction";
+    case "waste_collection":
+      return "♻️ Évacuation et traitement des déchets";
+    default:
+      return "🏗 Autres dépenses de remise en état";
+  }
+};
 
 type Props = {
   impact: ReconversionProjectImpacts["economicBalance"];
@@ -27,19 +49,28 @@ const EconomicBalanceListSection = ({ impact, openImpactDescriptionModal }: Prop
           }}
         >
           <ImpactLabel>🏠 Acquisition du site</ImpactLabel>
-          <ImpactValue value={impact.costs.realEstateTransaction} type="monetary" />
+          <ImpactValue value={-impact.costs.realEstateTransaction} type="monetary" />
         </ImpactItemRow>
       )}
       {!!impact.costs.siteReinstatement && (
-        <ImpactItemRow>
-          <ImpactLabel>🏗 Remise en état de la friche</ImpactLabel>
-          <ImpactValue value={impact.costs.siteReinstatement} type="monetary" />
-        </ImpactItemRow>
+        <ImpactItemGroup>
+          <ImpactLabel>🚧 Remise en état de la friche</ImpactLabel>
+          <ImpactDetailRow>
+            <ImpactDetailLabel>{impact.bearer ?? "Aménageur"}</ImpactDetailLabel>
+            <ImpactValue isTotal value={-impact.costs.siteReinstatement.total} type="monetary" />
+          </ImpactDetailRow>
+          {impact.costs.siteReinstatement.costs.map(({ amount, purpose }) => (
+            <ImpactDetailRow key={purpose}>
+              <ImpactDetailLabel>{getLabelForReinstatementCostPurpose(purpose)}</ImpactDetailLabel>
+              <ImpactValue value={-amount} type="monetary" />
+            </ImpactDetailRow>
+          ))}
+        </ImpactItemGroup>
       )}
       {!!impact.costs.developmentPlanInstallation && (
         <ImpactItemRow>
           <ImpactLabel>⚡️ Installation des panneaux photovoltaïques</ImpactLabel>
-          <ImpactValue value={impact.costs.developmentPlanInstallation} type="monetary" />
+          <ImpactValue value={-impact.costs.developmentPlanInstallation} type="monetary" />
         </ImpactItemRow>
       )}
       {!!impact.revenues.financialAssistance && (
@@ -51,7 +82,7 @@ const EconomicBalanceListSection = ({ impact, openImpactDescriptionModal }: Prop
       {!!impact.costs.operationsCosts && (
         <ImpactItemRow>
           <ImpactLabel>💸️ Charges d'exploitation</ImpactLabel>
-          <ImpactValue value={impact.costs.operationsCosts.total} type="monetary" />
+          <ImpactValue value={-impact.costs.operationsCosts.total} type="monetary" />
         </ImpactItemRow>
       )}
       {!!impact.revenues.operationsRevenues && (


### PR DESCRIPTION
J'aurais sûrement du split en 3 PR car ça comprend :
* Migration pour sauvegarder les coûts de remise en état de manière détaillée
* Affichage du détail des coûts de remise en état dans la vue liste des impacts
* Renommage de `expenses` à `costs` dans le code de l'impact bilan de l'opération (à généraliser dans l'appli au fil du temps)
* Utilisation de valeurs positives pour les coûts, qui sont par nature négatifs dans le bilan. J'ai trouvé ça plus cohérent, c'est donc au front de les affiches en tant que -xxx € si besoin (preneur de ton avis là-dessus et de ta review)