### PR TITLE
chore: make Typescript stricter by enabling noUncheckedIndexedAccess and noFallthroughCasesInSwitch in api and shared package

### DIFF
--- a/apps/api/src/carbon-storage/adapters/secondary/carbonStorageRepository/SqlCarbonStorageRepository.ts
+++ b/apps/api/src/carbon-storage/adapters/secondary/carbonStorageRepository/SqlCarbonStorageRepository.ts
@@ -34,11 +34,12 @@ const filterCarbonStorageByLocalisationPriority = (carbonStorage: CarbonStorage[
     const existingIndex = result.findIndex(
       (element) => element.soilCategory === entry.soilCategory,
     );
-    if (existingIndex === -1) {
+    const existingEntry = result[existingIndex];
+    if (!existingEntry) {
       return [...result, entry];
     }
 
-    const { localisationCategory } = result[existingIndex];
+    const { localisationCategory } = existingEntry;
     const currentPosition = localisationPriorityOrder.indexOf(localisationCategory);
     const elemPosition = localisationPriorityOrder.indexOf(entry.localisationCategory);
     if (elemPosition < currentPosition) {
@@ -46,7 +47,7 @@ const filterCarbonStorageByLocalisationPriority = (carbonStorage: CarbonStorage[
       newResult[existingIndex] = entry;
       return newResult;
     }
-    return [...result];
+    return result;
   }, []);
 };
 

--- a/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.integration-spec.ts
+++ b/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.integration-spec.ts
@@ -67,7 +67,7 @@ describe("ReconversionProjects controller", () => {
 
         const responseErrors = (response.body as BadRequestResponseBody).errors;
         expect(responseErrors).toHaveLength(1);
-        expect(responseErrors[0].path).toContain(mandatoryField);
+        expect(responseErrors[0]?.path).toContain(mandatoryField);
       },
     );
 

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-repository/SqlReconversionProjectRepository.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-repository/SqlReconversionProjectRepository.ts
@@ -131,6 +131,8 @@ export class SqlReconversionProjectRepository implements ReconversionProjectRepo
         "id",
       );
 
+      if (!insertedReconversionProject) throw new Error("Failed to insert reconversion project");
+
       // soils distribution
       const soilsDistributionToInsert: SqlSoilsDistribution[] = Object.entries(
         reconversionProject.soilsDistribution,

--- a/apps/api/src/reconversion-projects/core/usecases/createReconversionProject.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/createReconversionProject.usecase.spec.ts
@@ -62,8 +62,8 @@ describe("CreateReconversionProject Use Case", () => {
         } catch (err) {
           const zIssues = getZodIssues(err);
           expect(zIssues.length).toEqual(1);
-          expect(zIssues[0].path).toEqual([mandatoryField]);
-          expect(zIssues[0].code).toEqual("invalid_type");
+          expect(zIssues[0]?.path).toEqual([mandatoryField]);
+          expect(zIssues[0]?.code).toEqual("invalid_type");
         }
       });
     });

--- a/apps/api/src/shared-kernel/adapters/sql-knex/seeds/carbonStorage.ts
+++ b/apps/api/src/shared-kernel/adapters/sql-knex/seeds/carbonStorage.ts
@@ -41,7 +41,7 @@ const readCsvData = async () => {
       reject(error);
     });
     rl.on("close", () => {
-      console.log(`Data parsing completed: ${data.length} lines found`);
+      console.log(`Carbon storage data parsing completed: ${data.length} lines found`);
       resolve(data);
     });
   });
@@ -60,7 +60,7 @@ exports.seed = async function (knex: Knex): Promise<void> {
         console.log(`${ids.length} lines inserted`);
       })
       .catch(function (error: unknown) {
-        console.warn(`Error while inserting cities`);
+        console.warn(`Error while inserting carbon storage`);
         console.error(error);
       });
   } catch (error) {

--- a/apps/api/src/shared-kernel/adapters/sql-knex/seeds/cities.ts
+++ b/apps/api/src/shared-kernel/adapters/sql-knex/seeds/cities.ts
@@ -34,7 +34,18 @@ const readCsvData = async () => {
         codeSerGroup,
         codeSer,
         codePoplarPool,
-      ] = line.split(";");
+      ] = line.split(";") as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
       const city = City.create({
         insee,
         name,

--- a/apps/api/src/sites/adapters/primary/sites.controller.integration-spec.ts
+++ b/apps/api/src/sites/adapters/primary/sites.controller.integration-spec.ts
@@ -87,7 +87,7 @@ describe("Sites controller", () => {
 
         const responseErrors = (response.body as BadRequestResponseBody).errors;
         expect(responseErrors).toHaveLength(1);
-        expect(responseErrors[0].path).toContain(mandatoryField);
+        expect(responseErrors[0]?.path).toContain(mandatoryField);
       },
     );
 

--- a/apps/api/src/sites/adapters/secondary/site-repository/SqlSiteRepository.ts
+++ b/apps/api/src/sites/adapters/secondary/site-repository/SqlSiteRepository.ts
@@ -110,6 +110,8 @@ export class SqlSiteRepository implements SitesRepository {
         "id",
       );
 
+      if (!insertedSite) throw new Error("Failed to insert site");
+
       await trx<SqlAddress>("addresses").insert({
         id: uuid(),
         ban_id: site.address.banId,

--- a/apps/api/src/sites/core/usecases/createNewSite.usecase.spec.ts
+++ b/apps/api/src/sites/core/usecases/createNewSite.usecase.spec.ts
@@ -47,7 +47,7 @@ describe("CreateNewSite Use Case", () => {
       } catch (err) {
         const zIssues = getZodIssues(err);
         expect(zIssues.length).toEqual(1);
-        expect(zIssues[0].path).toEqual([mandatoryField]);
+        expect(zIssues[0]?.path).toEqual([mandatoryField]);
       }
     });
   });
@@ -62,7 +62,7 @@ describe("CreateNewSite Use Case", () => {
     } catch (err) {
       const zIssues = getZodIssues(err);
       expect(zIssues.length).toEqual(1);
-      expect(zIssues[0].path).toEqual(["surfaceArea"]);
+      expect(zIssues[0]?.path).toEqual(["surfaceArea"]);
     }
   });
 

--- a/apps/api/src/users/adapters/primary/users.controller.integration-spec.ts
+++ b/apps/api/src/users/adapters/primary/users.controller.integration-spec.ts
@@ -51,7 +51,7 @@ describe("Users controller", () => {
 
       const responseErrors = (response.body as BadRequestResponseBody).errors;
       expect(responseErrors).toHaveLength(1);
-      expect(responseErrors[0].path).toContain(mandatoryField);
+      expect(responseErrors[0]?.path).toContain(mandatoryField);
     });
 
     it.each([

--- a/apps/api/src/users/adapters/secondary/user-repository/SqlUserRepository.integration-spec.ts
+++ b/apps/api/src/users/adapters/secondary/user-repository/SqlUserRepository.integration-spec.ts
@@ -24,17 +24,20 @@ describe("SqlSiteRepository integration", () => {
 
     await userRepository.save(user);
 
-    const [result] = await sqlConnection("users").select().where({ id: user.id });
-    expect(result.id).toEqual(user.id);
-    expect(result.email).toEqual(user.email);
-    expect(result.personal_data_storage_consented_at).toEqual(user.personalDataStorageConsentedAt);
-    expect(result.firstname).toEqual(null);
-    expect(result.lastname).toEqual(null);
-    expect(result.structure_name).toEqual(null);
-    expect(result.structure_type).toEqual(user.structureType);
-    expect(result.structure_activity).toEqual(user.structureActivity);
-    expect(result.personal_data_analytics_use_consented_at).toEqual(null);
-    expect(result.personal_data_communication_use_consented_at).toEqual(null);
+    const result = await sqlConnection("users").select().where({ id: user.id });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toEqual(user.id);
+    expect(result[0]?.email).toEqual(user.email);
+    expect(result[0]?.personal_data_storage_consented_at).toEqual(
+      user.personalDataStorageConsentedAt,
+    );
+    expect(result[0]?.firstname).toEqual(null);
+    expect(result[0]?.lastname).toEqual(null);
+    expect(result[0]?.structure_name).toEqual(null);
+    expect(result[0]?.structure_type).toEqual(user.structureType);
+    expect(result[0]?.structure_activity).toEqual(user.structureActivity);
+    expect(result[0]?.personal_data_analytics_use_consented_at).toEqual(null);
+    expect(result[0]?.personal_data_communication_use_consented_at).toEqual(null);
   });
 
   it("Saves user with full props", async () => {

--- a/apps/api/src/users/core/usecases/createUser.usecase.spec.ts
+++ b/apps/api/src/users/core/usecases/createUser.usecase.spec.ts
@@ -40,8 +40,8 @@ describe("CreateUser Use Case", () => {
           } catch (err) {
             const zIssues = getZodIssues(err);
             expect(zIssues.length).toEqual(1);
-            expect(zIssues[0].path).toEqual([mandatoryField]);
-            expect(zIssues[0].code).toEqual("invalid_type");
+            expect(zIssues[0]?.path).toEqual([mandatoryField]);
+            expect(zIssues[0]?.code).toEqual("invalid_type");
           }
         },
       );

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -30,6 +30,8 @@
     "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* When type checking, take into account 'null' and 'undefined'. */,
     "noImplicitOverride": true /* Ensure overriding members in derived classes are marked with an override modifier. */,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
 
     /* Completeness */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -25,6 +25,8 @@
     "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* When type checking, take into account 'null' and 'undefined'. */,
     "noImplicitOverride": true /* Ensure overriding members in derived classes are marked with an override modifier. */,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
 
     /* Completeness */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */


### PR DESCRIPTION
`noUncheckedIndexedAccess` permet de s'assurer qu'un élément existe bien lorsqu'on y accède via index (array ou objet), par exemple :
```
const myArray: string[] = [];
myArray[0].split(",") // pas d'erreur TS sans la noUncheckedIndexedAccess activée alors qu'il y aura une erreur au runtime
```

`noFallthroughCasesInSwitch ` assure que chaque `case` dans un switch soit "indépendant" et que plusieurs case ne puissent être traversés.

Ces règles étaient activées dans le front mais j'avais oublié de les mettre dans l'API !