### PR TITLE
feat: handle buildings project type design in impacts page and list

### DIFF
--- a/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.integration-spec.ts
+++ b/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.integration-spec.ts
@@ -179,6 +179,21 @@ describe("ReconversionProjects controller", () => {
 
       await sqlConnection("sites").insert([siteInDb1, siteInDb2, siteOfAnotherUser]);
       await sqlConnection("reconversion_projects").insert([projectInDb1, projectInDb2]);
+      await sqlConnection("reconversion_project_development_plans").insert([
+        {
+          id: uuid(),
+          reconversion_project_id: projectInDb1.id,
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+          features: {},
+        },
+        {
+          id: uuid(),
+          reconversion_project_id: projectInDb2.id,
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+          features: {},
+        },
+      ]);
+
       const response = await supertest(app.getHttpServer())
         .get("/reconversion-projects/list-by-site?userId=" + userId)
         .send();
@@ -190,8 +205,8 @@ describe("ReconversionProjects controller", () => {
           siteId: siteInDb1.id,
           isFriche: siteInDb1.is_friche,
           reconversionProjects: [
-            { id: projectInDb1.id, name: projectInDb1.name },
-            { id: projectInDb2.id, name: projectInDb2.name },
+            { id: projectInDb1.id, name: projectInDb1.name, type: "PHOTOVOLTAIC_POWER_PLANT" },
+            { id: projectInDb2.id, name: projectInDb2.name, type: "PHOTOVOLTAIC_POWER_PLANT" },
           ],
         },
         {

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.integration-spec.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.integration-spec.ts
@@ -73,7 +73,7 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
           reconversion_project_id: reconversionProjectId,
           schedule_start_date: new Date("2025-01-01"),
           schedule_end_date: new Date("2025-05-15"),
-          type: "any",
+          type: "PHOTOVOLTAIC_POWER_PLANT",
           developer_name: "Terre cuite d’occitanie",
           developer_structure_type: "company",
           features: {
@@ -178,6 +178,7 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
         developmentPlanElectricalPowerKWc: 300,
         developmentPlanSurfaceArea: 2000,
         developmentPlanDeveloperName: "Terre cuite d’occitanie",
+        developmentPlanType: "PHOTOVOLTAIC_POWER_PLANT",
       });
     });
     it("gets reconversion project when optional data does not exist", async () => {
@@ -218,7 +219,7 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
         {
           id: uuid(),
           reconversion_project_id: reconversionProjectId,
-          type: "any",
+          type: "PHOTOVOLTAIC_POWER_PLANT",
           features: {},
         },
       ]);
@@ -239,6 +240,7 @@ describe("SqlReconversionProjectImpactsRepository integration", () => {
         conversionSchedule: undefined,
         developmentPlanInstallationCosts: [],
         developmentPlanDeveloperName: undefined,
+        developmentPlanType: "PHOTOVOLTAIC_POWER_PLANT",
         futureOperatorName: undefined,
         futureSiteOwnerName: undefined,
         operationsFullTimeJobs: undefined,

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
@@ -47,6 +47,7 @@ export class SqlReconversionProjectImpactsRepository
       id: string;
       developer_structure_type: string;
       developer_name: string;
+      type: DevelopmentPlan["type"];
       schedule_start_date?: Date;
       schedule_end_date?: Date;
       features: unknown;
@@ -61,6 +62,7 @@ export class SqlReconversionProjectImpactsRepository
       )
       .select(
         "dp.id",
+        "dp.type",
         "dp.features",
         "dp.developer_structure_type",
         "dp.developer_name",
@@ -155,6 +157,7 @@ export class SqlReconversionProjectImpactsRepository
       financialAssistanceRevenues: sqlFinancialAssistanceRevenues,
       yearlyProjectedCosts: sqlExpenses,
       yearlyProjectedRevenues: sqlRevenues,
+      developmentPlanType: sqlDevelopmentPlan?.type ?? undefined,
       developmentPlanExpectedAnnualEnergyProductionMWh,
       developmentPlanSurfaceArea,
       developmentPlanElectricalPowerKWc,

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-projects-list-repository/SqlReconversionProjectsListRepository.integration-spec.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-projects-list-repository/SqlReconversionProjectsListRepository.integration-spec.ts
@@ -143,6 +143,27 @@ describe("ReconversionProjectsListRepository integration", () => {
         projectInDb3,
       ]);
 
+      await sqlConnection("reconversion_project_development_plans").insert([
+        {
+          id: uuid(),
+          reconversion_project_id: projectInDb1.id,
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+          features: {},
+        },
+        {
+          id: uuid(),
+          reconversion_project_id: projectInDb2.id,
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+          features: {},
+        },
+        {
+          id: uuid(),
+          reconversion_project_id: projectInDb3.id,
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+          features: {},
+        },
+      ]);
+
       const result = await reconversionProjectsListRepository.getGroupedBySite({ userId });
 
       expect(result).toHaveLength(2);
@@ -152,15 +173,17 @@ describe("ReconversionProjectsListRepository integration", () => {
           siteId: siteInDb2.id,
           isFriche: siteInDb2.is_friche,
           reconversionProjects: [
-            { id: projectInDb2.id, name: projectInDb2.name },
-            { id: projectInDb3.id, name: projectInDb3.name },
+            { id: projectInDb2.id, name: projectInDb2.name, type: "PHOTOVOLTAIC_POWER_PLANT" },
+            { id: projectInDb3.id, name: projectInDb3.name, type: "PHOTOVOLTAIC_POWER_PLANT" },
           ],
         },
         {
           siteName: siteInDb1.name,
           siteId: siteInDb1.id,
           isFriche: siteInDb1.is_friche,
-          reconversionProjects: [{ id: projectInDb1.id, name: projectInDb1.name }],
+          reconversionProjects: [
+            { id: projectInDb1.id, name: projectInDb1.name, type: "PHOTOVOLTAIC_POWER_PLANT" },
+          ],
         },
       ]);
     });

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-projects-list-repository/SqlReconversionProjectsListRepository.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-projects-list-repository/SqlReconversionProjectsListRepository.ts
@@ -1,5 +1,6 @@
 import { Inject } from "@nestjs/common";
 import { Knex } from "knex";
+import { DevelopmentPlan } from "src/reconversion-projects/core/model/reconversionProject";
 import {
   ReconversionProjectsGroupedBySite,
   ReconversionProjectsListRepository,
@@ -16,6 +17,12 @@ export class SqlReconversionProjectsListRepository implements ReconversionProjec
     const result = (await this.sqlConnection("sites")
       .where("sites.created_by", userId)
       .leftJoin("reconversion_projects as rp", "sites.id", "=", "rp.related_site_id")
+      .leftJoin(
+        "reconversion_project_development_plans as rpdp",
+        "rp.id",
+        "=",
+        "rpdp.reconversion_project_id",
+      )
       .select(
         "sites.id as siteId",
         "sites.name as siteName",
@@ -24,7 +31,7 @@ export class SqlReconversionProjectsListRepository implements ReconversionProjec
         this.sqlConnection.raw(`
         CASE 
           WHEN count(rp.id) = 0 THEN '[]'::json
-          ELSE json_agg(json_build_object('id', rp.id, 'name', rp.name)) 
+          ELSE json_agg(json_build_object('id', rp.id, 'name', rp.name, 'type', rpdp.type)) 
         END as "reconversionProjects"`),
       )
       .groupBy("sites.id")
@@ -33,7 +40,7 @@ export class SqlReconversionProjectsListRepository implements ReconversionProjec
       siteName: string;
       isFriche: boolean;
       fricheActivity: string | null;
-      reconversionProjects: { id: string; name: string; developmentsPlans: string[] }[];
+      reconversionProjects: { id: string; name: string; type: DevelopmentPlan["type"] }[];
     }[];
 
     return result.map((reconversionProjectsBySite) => {

--- a/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.spec.ts
@@ -100,6 +100,7 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
       developmentPlanInstallationCosts: [{ amount: 200000, purpose: "installation_works" }],
       developmentPlanElectricalPowerKWc: 258,
       developmentPlanSurfaceArea: 20000,
+      developmentPlanType: "PHOTOVOLTAIC_POWER_PLANT",
       developmentPlanDeveloperName: "Mairie de Blajan",
       financialAssistanceRevenues: [{ amount: 150000, source: "public_subsidies" }],
       yearlyProjectedCosts: [
@@ -171,6 +172,7 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
           developmentPlan: {
             electricalPowerKWc: 258,
             surfaceArea: 20000,
+            type: "PHOTOVOLTAIC_POWER_PLANT",
           },
         },
         siteData: {

--- a/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.ts
@@ -38,7 +38,11 @@ import {
   GetSoilsCarbonStoragePerSoilsService,
   SoilsCarbonStorageImpactResult,
 } from "../model/impacts/soils-carbon-storage/soilsCarbonStorageImpact";
-import { getDurationFromScheduleInYears, Schedule } from "../model/reconversionProject";
+import {
+  DevelopmentPlan,
+  getDurationFromScheduleInYears,
+  Schedule,
+} from "../model/reconversionProject";
 
 export type SiteImpactsDataView = {
   id: string;
@@ -82,6 +86,7 @@ export type ReconversionProjectImpactsDataView = {
   financialAssistanceRevenues: { amount: number; source: string }[];
   yearlyProjectedCosts: { amount: number; purpose: string }[];
   yearlyProjectedRevenues: { amount: number; source: string }[];
+  developmentPlanType?: DevelopmentPlan["type"];
   developmentPlanExpectedAnnualEnergyProductionMWh?: number;
   developmentPlanSurfaceArea?: number;
   developmentPlanElectricalPowerKWc?: number;
@@ -109,6 +114,7 @@ export type Result = {
     developmentPlan: {
       surfaceArea?: number;
       electricalPowerKWc?: number;
+      type?: DevelopmentPlan["type"];
     };
   };
   siteData: {
@@ -189,6 +195,7 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
         developmentPlan: {
           surfaceArea: reconversionProject.developmentPlanSurfaceArea,
           electricalPowerKWc: reconversionProject.developmentPlanElectricalPowerKWc,
+          type: reconversionProject.developmentPlanType,
         },
       },
       siteData: {

--- a/apps/api/src/reconversion-projects/core/usecases/getUserReconversionProjectsBySite.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/getUserReconversionProjectsBySite.usecase.spec.ts
@@ -28,8 +28,16 @@ describe("GetUserReconversionProjectsBySite Use Case", () => {
         isFriche: true,
         fricheActivity: "INDUSTRY",
         reconversionProjects: [
-          { id: "78330779-017d-49b3-bb3e-8b5724aaf56f", name: "ReconversionProject 1" },
-          { id: "b0f734d3-27f0-4876-a73a-637be27d12d2", name: "ReconversionProject 2" },
+          {
+            id: "78330779-017d-49b3-bb3e-8b5724aaf56f",
+            name: "ReconversionProject 1",
+            type: "PHOTOVOLTAIC_POWER_PLANT",
+          },
+          {
+            id: "b0f734d3-27f0-4876-a73a-637be27d12d2",
+            name: "ReconversionProject 2",
+            type: "PHOTOVOLTAIC_POWER_PLANT",
+          },
         ],
       },
     ];

--- a/apps/api/src/reconversion-projects/core/usecases/getUserReconversionProjectsBySite.usecase.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/getUserReconversionProjectsBySite.usecase.ts
@@ -1,11 +1,12 @@
 import { UseCase } from "src/shared-kernel/usecase";
+import { DevelopmentPlan } from "../model/reconversionProject";
 
 export type ReconversionProjectsGroupedBySite = {
   siteName: string;
   siteId: string;
   isFriche: boolean;
   fricheActivity?: string;
-  reconversionProjects: { id: string; name: string }[];
+  reconversionProjects: { id: string; name: string; type: DevelopmentPlan["type"] }[];
 }[];
 
 export interface ReconversionProjectsListRepository {

--- a/apps/web/src/app/views/theme.ts
+++ b/apps/web/src/app/views/theme.ts
@@ -46,9 +46,9 @@ export default {
       },
       warning: "#B34000",
       impacts: {
-        title: "var(--blue-ecume-sun-247-moon-675)",
-        main: "#ECF5FD",
-        dark: "#D9EBFC",
+        title: "var(--impacts-title-color)",
+        main: "var(--impacts-main-color)",
+        dark: "var(--impacts-dark-color)",
         positive: {
           main: "#18753C",
           light: "#51DB86",

--- a/apps/web/src/features/create-project/domain/project.types.ts
+++ b/apps/web/src/features/create-project/domain/project.types.ts
@@ -11,7 +11,7 @@ import {
 export type DevelopmentPlanCategory =
   | "RENEWABLE_ENERGY"
   | "URBAN_AGRICULTURE"
-  | "BUILDINGS"
+  | "MIXED_USE_NEIGHBOURHOOD"
   | "NATURAL_URBAN_SPACES"
   | "COMMERCIAL_ACTIVITY_AREA";
 

--- a/apps/web/src/features/create-project/domain/projectName.spec.ts
+++ b/apps/web/src/features/create-project/domain/projectName.spec.ts
@@ -21,7 +21,7 @@ describe("Project name generation", () => {
 
   it("should return 'Projet extension urbaine'", () => {
     const project: Omit<ProjectInfo, "renewableEnergyType"> = {
-      developmentPlanCategory: "BUILDINGS",
+      developmentPlanCategory: "MIXED_USE_NEIGHBOURHOOD",
     };
 
     // @ts-expect-error renewableEnergyType is missing

--- a/apps/web/src/features/create-project/domain/projectName.ts
+++ b/apps/web/src/features/create-project/domain/projectName.ts
@@ -20,7 +20,7 @@ const generateRenewableEnergyProjectName = (
 
 export const generateProjectName = (projectData: ProjectInfo): string => {
   switch (projectData.developmentPlanCategory) {
-    case "BUILDINGS":
+    case "MIXED_USE_NEIGHBOURHOOD":
     case "NATURAL_URBAN_SPACES":
     case "URBAN_AGRICULTURE":
     case "COMMERCIAL_ACTIVITY_AREA":

--- a/apps/web/src/features/create-project/views/project-types/ProjectTypesForm.tsx
+++ b/apps/web/src/features/create-project/views/project-types/ProjectTypesForm.tsx
@@ -18,7 +18,7 @@ type FormValues = {
 
 const options: Record<DevelopmentPlanCategory, { disabled: boolean }> = {
   RENEWABLE_ENERGY: { disabled: false },
-  BUILDINGS: { disabled: true },
+  MIXED_USE_NEIGHBOURHOOD: { disabled: true },
   NATURAL_URBAN_SPACES: { disabled: true },
   URBAN_AGRICULTURE: { disabled: true },
   COMMERCIAL_ACTIVITY_AREA: { disabled: true },

--- a/apps/web/src/features/create-project/views/projectTypeLabelMapping.ts
+++ b/apps/web/src/features/create-project/views/projectTypeLabelMapping.ts
@@ -5,7 +5,7 @@ import {
 
 export const getLabelForDevelopmentPlanCategory = (value: DevelopmentPlanCategory): string => {
   switch (value) {
-    case "BUILDINGS":
+    case "MIXED_USE_NEIGHBOURHOOD":
       return "Quartier";
     case "NATURAL_URBAN_SPACES":
       return "Espace de nature en ville";
@@ -22,7 +22,7 @@ export const getDescriptionForDevelopmentPlanCategory = (
   value: DevelopmentPlanCategory,
 ): string => {
   switch (value) {
-    case "BUILDINGS":
+    case "MIXED_USE_NEIGHBOURHOOD":
       return "Logements, bureaux, commerces, espaces verts, petite centrale EnR…";
     case "NATURAL_URBAN_SPACES":
       return "Parc ou forêt urbaine";
@@ -66,7 +66,7 @@ export const getDescriptionForRenewableEnergyType = (
 };
 
 const developmentPlanCategoryPictogramMap: Record<DevelopmentPlanCategory, string> = {
-  BUILDINGS: "mixed-used-neighborhood.svg",
+  MIXED_USE_NEIGHBOURHOOD: "mixed-used-neighborhood.svg",
   NATURAL_URBAN_SPACES: "natural-urban-space.svg",
   COMMERCIAL_ACTIVITY_AREA: "commercial-activity-area.svg",
   URBAN_AGRICULTURE: "urban-agriculture.svg",

--- a/apps/web/src/features/projects/application/fetchReconversionProjectImpacts.action.ts
+++ b/apps/web/src/features/projects/application/fetchReconversionProjectImpacts.action.ts
@@ -1,5 +1,6 @@
 import { SoilsDistribution } from "shared";
 import { ReconversionProjectImpacts } from "../domain/impacts.types";
+import { ProjectDevelopmentPlanType } from "../domain/projects.types";
 
 import { createAppAsyncThunk } from "@/app/application/appAsyncThunk";
 
@@ -21,6 +22,7 @@ export type ReconversionProjectImpactsResult = {
     developmentPlan: {
       surfaceArea?: number;
       electricalPowerKWc?: number;
+      type?: ProjectDevelopmentPlanType;
     };
   };
   siteData: {

--- a/apps/web/src/features/projects/application/projectImpacts.reducer.ts
+++ b/apps/web/src/features/projects/application/projectImpacts.reducer.ts
@@ -1,5 +1,6 @@
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { SoilsDistribution } from "shared";
+import { ProjectDevelopmentPlanType } from "../domain/projects.types";
 import {
   fetchReconversionProjectImpacts,
   ReconversionProjectImpactsResult,
@@ -27,6 +28,7 @@ export type ProjectImpactsState = {
     developmentPlan: {
       surfaceArea?: number;
       electricalPowerKWc?: number;
+      type?: ProjectDevelopmentPlanType;
     };
   };
   relatedSiteData?: {
@@ -100,6 +102,15 @@ const selectSelf = (state: RootState) => state.projectImpacts;
 export const getProjectName = createSelector(
   selectSelf,
   (state): string => state.projectData?.name ?? "Project",
+);
+
+export const getProjectContext = createSelector(
+  selectSelf,
+  (state): { name: string; siteName: string; type?: ProjectDevelopmentPlanType } => ({
+    name: state.projectData?.name ?? "Project",
+    siteName: state.relatedSiteData?.name ?? "",
+    type: state.projectData?.developmentPlan.type,
+  }),
 );
 
 export default projectImpactsSlice.reducer;

--- a/apps/web/src/features/projects/application/projectsList.reducer.spec.ts
+++ b/apps/web/src/features/projects/application/projectsList.reducer.spec.ts
@@ -17,8 +17,12 @@ describe("Projects list reducer", () => {
       siteName: "Site 2",
       isFriche: false,
       reconversionProjects: [
-        { id: reconversionProjectIdA, name: "Reconversion project A on site 2" },
-        { id: reconversionProjectIdB, name: "Reconversion project B on site 2" },
+        {
+          id: reconversionProjectIdA,
+          name: "Reconversion project A on site 2",
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+        },
+        { id: reconversionProjectIdB, name: "Reconversion project B on site 2", type: "BUILDINGS" },
       ],
     },
   ] as const;
@@ -77,6 +81,7 @@ describe("Projects list reducer", () => {
       expect(reconversionProject).toEqual({
         id: reconversionProjectIdB,
         name: "Reconversion project B on site 2",
+        type: "BUILDINGS",
         site: { id: reconversionProjects[1]?.siteId, name: "Site 2" },
       });
     });
@@ -103,7 +108,13 @@ describe("Projects list reducer", () => {
           siteId: uuid(),
           siteName: "Site 2",
           isFriche: false,
-          reconversionProjects: [{ id: rpId, name: "Reconversion project A on site 2" }],
+          reconversionProjects: [
+            {
+              id: rpId,
+              name: "Reconversion project A on site 2",
+              type: "PHOTOVOLTAIC_POWER_PLANT",
+            },
+          ],
         },
       ] as const;
       const store = createStore(getTestAppDependencies(), {
@@ -125,7 +136,11 @@ describe("Projects list reducer", () => {
       });
 
       expect(selectComparableProjects(store.getState(), reconversionProjectIdB)).toEqual([
-        { id: reconversionProjectIdA, name: "Reconversion project A on site 2" },
+        {
+          id: reconversionProjectIdA,
+          name: "Reconversion project A on site 2",
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+        },
       ]);
     });
   });

--- a/apps/web/src/features/projects/application/projectsList.reducer.spec.ts
+++ b/apps/web/src/features/projects/application/projectsList.reducer.spec.ts
@@ -22,7 +22,11 @@ describe("Projects list reducer", () => {
           name: "Reconversion project A on site 2",
           type: "PHOTOVOLTAIC_POWER_PLANT",
         },
-        { id: reconversionProjectIdB, name: "Reconversion project B on site 2", type: "BUILDINGS" },
+        {
+          id: reconversionProjectIdB,
+          name: "Reconversion project B on site 2",
+          type: "MIXED_USE_NEIGHBOURHOOD",
+        },
       ],
     },
   ] as const;
@@ -81,7 +85,7 @@ describe("Projects list reducer", () => {
       expect(reconversionProject).toEqual({
         id: reconversionProjectIdB,
         name: "Reconversion project B on site 2",
-        type: "BUILDINGS",
+        type: "MIXED_USE_NEIGHBOURHOOD",
         site: { id: reconversionProjects[1]?.siteId, name: "Site 2" },
       });
     });

--- a/apps/web/src/features/projects/application/projectsList.reducer.ts
+++ b/apps/web/src/features/projects/application/projectsList.reducer.ts
@@ -1,5 +1,8 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit";
-import { ReconversionProjectsGroupedBySite } from "../domain/projects.types";
+import {
+  ProjectDevelopmentPlanType,
+  ReconversionProjectsGroupedBySite,
+} from "../domain/projects.types";
 import { fetchReconversionProjects } from "./projectsList.actions";
 
 import { RootState } from "@/app/application/store";
@@ -39,6 +42,7 @@ const selectSelf = (state: RootState) => state.reconversionProjectsList;
 type ReconversionProjectWithSite = {
   id: string;
   name: string;
+  type: ProjectDevelopmentPlanType;
   site: {
     id: string;
     name: string;
@@ -57,6 +61,7 @@ export const selectReconversionProjectById = createSelector(
     return {
       id: project.id,
       name: project.name,
+      type: project.type,
       site: {
         id: projectsGroup.siteId,
         name: projectsGroup.siteName,

--- a/apps/web/src/features/projects/domain/projects.types.ts
+++ b/apps/web/src/features/projects/domain/projects.types.ts
@@ -97,3 +97,5 @@ export type Project = {
   yearlyProjectedCosts: Expense[];
   yearlyProjectedRevenues: Revenue[];
 };
+
+export type ProjectDevelopmentPlanType = "PHOTOVOLTAIC_POWER_PLANT" | "BUILDINGS";

--- a/apps/web/src/features/projects/domain/projects.types.ts
+++ b/apps/web/src/features/projects/domain/projects.types.ts
@@ -25,7 +25,7 @@ export type ProjectsGroup = {
   siteName: string;
   isFriche: boolean;
   fricheActivity?: FricheActivity;
-  reconversionProjects: { id: string; name: string }[];
+  reconversionProjects: { id: string; name: string; type: ProjectDevelopmentPlanType }[];
 };
 
 export type ReconversionProjectsGroupedBySite = ProjectsGroup[];

--- a/apps/web/src/features/projects/domain/projects.types.ts
+++ b/apps/web/src/features/projects/domain/projects.types.ts
@@ -98,4 +98,4 @@ export type Project = {
   yearlyProjectedRevenues: Revenue[];
 };
 
-export type ProjectDevelopmentPlanType = "PHOTOVOLTAIC_POWER_PLANT" | "BUILDINGS";
+export type ProjectDevelopmentPlanType = "PHOTOVOLTAIC_POWER_PLANT" | "MIXED_USE_NEIGHBOURHOOD";

--- a/apps/web/src/features/projects/infrastructure/projects-list-service/localStorageProjectsListApi.ts
+++ b/apps/web/src/features/projects/infrastructure/projects-list-service/localStorageProjectsListApi.ts
@@ -1,5 +1,8 @@
 import { ReconversionProjectsListGateway } from "../../application/projectsList.actions";
-import { ReconversionProjectsGroupedBySite } from "../../domain/projects.types";
+import {
+  ProjectDevelopmentPlanType,
+  ReconversionProjectsGroupedBySite,
+} from "../../domain/projects.types";
 
 import { ProjectSite } from "@/features/create-project/domain/project.types";
 import { SITES_LIST_STORAGE_KEY } from "@/features/create-site/infrastructure/create-site-service/localStorageCreateSiteApi";
@@ -10,6 +13,7 @@ export const PROJECTS_LIST_STORAGE_KEY = "benefriches/projects-list";
 type ProjectInLocalStorage = {
   id: string;
   name: string;
+  type?: ProjectDevelopmentPlanType;
   relatedSiteId: string;
 };
 
@@ -35,7 +39,11 @@ export class LocalStorageProjectsListApi implements ReconversionProjectsListGate
         siteId: site.id,
         siteName: site.name,
         isFriche: site.isFriche,
-        reconversionProjects: projects.map(({ name, id }) => ({ name, id })),
+        reconversionProjects: projects.map(({ name, id, type = "PHOTOVOLTAIC_POWER_PLANT" }) => ({
+          name,
+          id,
+          type,
+        })),
       };
     });
   }

--- a/apps/web/src/features/projects/views/my-projects-page/ScenariiList/ScenariiGroup.tsx
+++ b/apps/web/src/features/projects/views/my-projects-page/ScenariiList/ScenariiGroup.tsx
@@ -69,7 +69,7 @@ function ScenariiGroup({
                 selectedIds={selectedIds}
                 selectableIds={selectableIds}
                 onChangeSelectedProject={onChangeSelectedProject}
-                type="PHOTOVOLTAIC_POWER_PLANT"
+                type={project.type}
               />
             </GridColumn>
           );

--- a/apps/web/src/features/projects/views/my-projects-page/ScenariiList/getSelectionDetails.spec.ts
+++ b/apps/web/src/features/projects/views/my-projects-page/ScenariiList/getSelectionDetails.spec.ts
@@ -73,7 +73,7 @@ const MOCK_PROJECTS_LIST = [
     name: "Projet quartier",
     siteId: "22339455-2ca2-4e2f-ab6b-bb3e2709f3e0",
     siteName: "Friche d'habitat de Forcalquier",
-    type: "BUILDINGS",
+    type: "MIXED_USE_NEIGHBOURHOOD",
   },
 ];
 

--- a/apps/web/src/features/projects/views/my-projects-page/ScenariiList/index.tsx
+++ b/apps/web/src/features/projects/views/my-projects-page/ScenariiList/index.tsx
@@ -4,7 +4,10 @@ import { getProjectsInfosList, getSelectionInfos, getSitesInfosList } from "./ge
 import ScenariiGroup from "./ScenariiGroup";
 import ScenariiSelectionBar from "./ScenariiSelectionBar";
 
-import { ReconversionProjectsGroupedBySite } from "@/features/projects/domain/projects.types";
+import {
+  ProjectDevelopmentPlanType,
+  ReconversionProjectsGroupedBySite,
+} from "@/features/projects/domain/projects.types";
 
 type Props = {
   projectsList: ReconversionProjectsGroupedBySite;
@@ -13,6 +16,7 @@ type Props = {
 export type ReconversionProjectList = {
   id: string;
   name: string;
+  type: ProjectDevelopmentPlanType;
 }[];
 
 function ScenariiListContainer({ projectsList }: Props) {

--- a/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPage.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPage.tsx
@@ -1,36 +1,17 @@
 import { useState } from "react";
-import { SoilsDistribution } from "shared";
 import { ViewMode } from "../../application/projectImpacts.reducer";
-import {
-  ImpactDescriptionModalCategory,
-  ImpactDescriptionModalWizard,
-} from "./modals/ImpactDescriptionModalWizard";
+import { ImpactDescriptionModalCategory } from "./modals/ImpactDescriptionModalWizard";
 import AboutImpactsModal from "./AboutImpactsModal";
 import ImpactsChartsView from "./charts-view";
 import ImpactsListViewContainer from "./list-view";
+import ImpactDescriptionModalWizard from "./modals";
 
 type Props = {
   currentViewMode: ViewMode;
   evaluationPeriod: number;
-  project: {
-    name: string;
-    id: string;
-    soilsDistribution: SoilsDistribution;
-    contaminatedSoilSurface: 0;
-    developmentPlan: {
-      surfaceArea?: number;
-      electricalPowerKWc?: number;
-    };
-  };
-  relatedSite: {
-    name: string;
-    addressLabel: string;
-    soilsDistribution: SoilsDistribution;
-    contaminatedSoilSurface: number;
-  };
 };
 
-const ProjectImpactsPage = ({ project, relatedSite, currentViewMode }: Props) => {
+const ProjectImpactsPage = ({ currentViewMode }: Props) => {
   const [modalCategoryOpened, setModalCategoryOpened] =
     useState<ImpactDescriptionModalCategory>(undefined);
 
@@ -39,8 +20,6 @@ const ProjectImpactsPage = ({ project, relatedSite, currentViewMode }: Props) =>
       <ImpactDescriptionModalWizard
         modalCategory={modalCategoryOpened}
         onChangeModalCategoryOpened={setModalCategoryOpened}
-        projectData={project}
-        siteData={relatedSite}
       />
       {currentViewMode === "charts" && (
         <ImpactsChartsView openImpactDescriptionModal={setModalCategoryOpened} />

--- a/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageHeader.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageHeader.tsx
@@ -1,4 +1,5 @@
 import { fr } from "@codegouvfr/react-dsfr";
+import { ProjectDevelopmentPlanType } from "../../domain/projects.types";
 import { getScenarioPictoUrl } from "../shared/scenarioType";
 
 import classNames from "@/shared/views/clsx";
@@ -6,10 +7,16 @@ import classNames from "@/shared/views/clsx";
 type Props = {
   projectName: string;
   siteName: string;
+  projectType?: ProjectDevelopmentPlanType;
   isSmall?: boolean;
 };
 
-const ProjectsImpactsPageHeader = ({ projectName, siteName, isSmall = false }: Props) => {
+const ProjectsImpactsPageHeader = ({
+  projectName,
+  siteName,
+  projectType,
+  isSmall = false,
+}: Props) => {
   return (
     <div className={fr.cx("fr-container")}>
       <div
@@ -21,14 +28,17 @@ const ProjectsImpactsPageHeader = ({ projectName, siteName, isSmall = false }: P
         )}
       >
         <div className="tw-flex tw-items-center">
-          <img
-            className={fr.cx("fr-mr-3v")}
-            src={getScenarioPictoUrl("PHOTOVOLTAIC_POWER_PLANT")}
-            aria-hidden={true}
-            alt="Icône du type de scénario"
-            width={isSmall ? 60 : 76}
-            height={isSmall ? 60 : 76}
-          />
+          {projectType && (
+            <img
+              className={fr.cx("fr-mr-3v")}
+              src={getScenarioPictoUrl(projectType)}
+              aria-hidden={true}
+              alt="Icône du type de scénario"
+              width={isSmall ? 60 : 76}
+              height={isSmall ? 60 : 76}
+            />
+          )}
+
           <div>
             <h2
               className={classNames(

--- a/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageWrapper.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageWrapper.tsx
@@ -50,8 +50,8 @@ const ProjectImpactsPageTabs = () => {
 
 const getProjectTypeClassName = (type?: ProjectDevelopmentPlanType) => {
   switch (type) {
-    case "BUILDINGS":
-      return "building";
+    case "MIXED_USE_NEIGHBOURHOOD":
+      return "mixed-use-neighbourhood";
     case "PHOTOVOLTAIC_POWER_PLANT":
       return "photovoltaic";
     default:

--- a/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageWrapper.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/ProjectImpactsPageWrapper.tsx
@@ -5,6 +5,7 @@ import {
   ProjectImpactsState,
   ViewMode,
 } from "../../application/projectImpacts.reducer";
+import { ProjectDevelopmentPlanType } from "../../domain/projects.types";
 import ProjectImpactsActionBar from "./ProjectImpactsActionBar";
 import ProjectImpactsPage from "./ProjectImpactsPage";
 import ProjectsImpactsPageHeader from "./ProjectImpactsPageHeader";
@@ -12,7 +13,13 @@ import ProjectsImpactsPageHeader from "./ProjectImpactsPageHeader";
 import classNames from "@/shared/views/clsx";
 import LoadingSpinner from "@/shared/views/components/Spinner/LoadingSpinner";
 
-type Props = ProjectImpactsState & {
+type Props = {
+  dataLoadingState: ProjectImpactsState["dataLoadingState"];
+  projectContext: {
+    name: string;
+    siteName: string;
+    type?: ProjectDevelopmentPlanType;
+  };
   onEvaluationPeriodChange: (n: number) => void;
   evaluationPeriod: number;
   onCurrentCategoryFilterChange: (n: ImpactCategoryFilter) => void;
@@ -41,9 +48,19 @@ const ProjectImpactsPageTabs = () => {
   );
 };
 
+const getProjectTypeClassName = (type?: ProjectDevelopmentPlanType) => {
+  switch (type) {
+    case "BUILDINGS":
+      return "building";
+    case "PHOTOVOLTAIC_POWER_PLANT":
+      return "photovoltaic";
+    default:
+      return "";
+  }
+};
+
 function ProjectImpactsPageWrapper({
-  projectData,
-  relatedSiteData,
+  projectContext,
   dataLoadingState,
   onEvaluationPeriodChange,
   evaluationPeriod,
@@ -53,11 +70,19 @@ function ProjectImpactsPageWrapper({
   onCurrentCategoryFilterChange,
 }: Props) {
   return (
-    <div className="tw-bg-impacts-main dark:tw-bg-grey-dark">
+    <div
+      id="project-impacts-page"
+      className={classNames(
+        getProjectTypeClassName(projectContext.type),
+        "tw-bg-impacts-main",
+        "dark:tw-bg-grey-dark",
+      )}
+    >
       <div className={classNames(fr.cx("fr-py-8v"), "tw-bg-impacts-main", "dark:tw-bg-grey-dark")}>
         <ProjectsImpactsPageHeader
-          projectName={projectData?.name ?? "Centrale photovoltaïque"}
-          siteName={relatedSiteData?.name ?? ""}
+          projectType={projectContext.type}
+          projectName={projectContext.name}
+          siteName={projectContext.siteName}
         />
       </div>
 
@@ -72,8 +97,8 @@ function ProjectImpactsPageWrapper({
         >
           <div className={fr.cx("fr-container")}>
             <ProjectImpactsActionBar
-              projectName={projectData?.name ?? "Centrale photovoltaïque"}
-              siteName={relatedSiteData?.name ?? ""}
+              projectName={projectContext.name}
+              siteName={projectContext.siteName}
               selectedFilter={currentCategoryFilter}
               selectedViewMode={currentViewMode}
               evaluationPeriod={evaluationPeriod}
@@ -92,8 +117,6 @@ function ProjectImpactsPageWrapper({
             {dataLoadingState === "loading" && <LoadingSpinner />}
             {dataLoadingState === "success" && (
               <ProjectImpactsPage
-                project={projectData!}
-                relatedSite={relatedSiteData!}
                 evaluationPeriod={evaluationPeriod}
                 currentViewMode={currentViewMode}
               />

--- a/apps/web/src/features/projects/views/project-impacts-page/index.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { fetchReconversionProjectImpacts } from "../../application/fetchReconversionProjectImpacts.action";
 import {
+  getProjectContext,
   ImpactCategoryFilter,
   setCategoryFilter,
   setEvaluationPeriod,
@@ -18,14 +19,10 @@ type Props = {
 function ProjectsImpacts({ projectId }: Props) {
   const dispatch = useAppDispatch();
 
-  const {
-    projectData,
-    relatedSiteData,
-    dataLoadingState,
-    evaluationPeriod,
-    currentCategoryFilter,
-    currentViewMode,
-  } = useAppSelector((state) => state.projectImpacts);
+  const { dataLoadingState, evaluationPeriod, currentCategoryFilter, currentViewMode } =
+    useAppSelector((state) => state.projectImpacts);
+
+  const projectContext = useAppSelector(getProjectContext);
 
   useEffect(() => {
     void dispatch(fetchReconversionProjectImpacts({ projectId, evaluationPeriod }));
@@ -33,8 +30,7 @@ function ProjectsImpacts({ projectId }: Props) {
 
   return (
     <ProjectImpactsPageWrapper
-      projectData={projectData}
-      relatedSiteData={relatedSiteData}
+      projectContext={projectContext}
       dataLoadingState={dataLoadingState}
       evaluationPeriod={evaluationPeriod}
       currentViewMode={currentViewMode}

--- a/apps/web/src/features/projects/views/project-impacts-page/modals/index.tsx
+++ b/apps/web/src/features/projects/views/project-impacts-page/modals/index.tsx
@@ -1,0 +1,29 @@
+import {
+  ImpactDescriptionModalCategory,
+  ImpactDescriptionModalWizard,
+} from "./ImpactDescriptionModalWizard";
+
+import { useAppSelector } from "@/shared/views/hooks/store.hooks";
+
+type Props = {
+  modalCategory: ImpactDescriptionModalCategory;
+  onChangeModalCategoryOpened: (modalCategory: ImpactDescriptionModalCategory) => void;
+};
+
+function ImpactDescriptionModalWizardWrapper({
+  modalCategory,
+  onChangeModalCategoryOpened,
+}: Props) {
+  const { projectData, relatedSiteData } = useAppSelector((state) => state.projectImpacts);
+
+  return (
+    <ImpactDescriptionModalWizard
+      modalCategory={modalCategory}
+      onChangeModalCategoryOpened={onChangeModalCategoryOpened}
+      projectData={projectData!}
+      siteData={relatedSiteData!}
+    />
+  );
+}
+
+export default ImpactDescriptionModalWizardWrapper;

--- a/apps/web/src/features/projects/views/shared/scenarioType.ts
+++ b/apps/web/src/features/projects/views/shared/scenarioType.ts
@@ -2,7 +2,7 @@ export const getScenarioPictoUrl = (type: string) => {
   switch (type) {
     case "PHOTOVOLTAIC_POWER_PLANT":
       return "/img/pictograms/renewable-energy/photovoltaic.svg";
-    case "BUILDINGS":
+    case "MIXED_USE_NEIGHBOURHOOD":
       return "/img/pictograms/development-plans/mixed-used-neighborhood.svg";
     default:
       return undefined;

--- a/apps/web/src/features/projects/views/shared/scenarioType.ts
+++ b/apps/web/src/features/projects/views/shared/scenarioType.ts
@@ -1,6 +1,10 @@
 export const getScenarioPictoUrl = (type: string) => {
-  if (type === "PHOTOVOLTAIC_POWER_PLANT") {
-    return "/img/pictograms/renewable-energy/photovoltaic.svg";
+  switch (type) {
+    case "PHOTOVOLTAIC_POWER_PLANT":
+      return "/img/pictograms/renewable-energy/photovoltaic.svg";
+    case "BUILDINGS":
+      return "/img/pictograms/development-plans/mixed-used-neighborhood.svg";
+    default:
+      return undefined;
   }
-  return undefined;
 };

--- a/apps/web/src/main.css
+++ b/apps/web/src/main.css
@@ -4,6 +4,8 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Highcharts CSS override - pour les graphes avec le paramètre "styledMode": true */
+
 .highcharts-container {
   font-family: Marianne;
 }
@@ -32,52 +34,6 @@
   font-size: 0.875rem;
 }
 
-/* La librairie du DSFR ne va que jusqu’à 8 pour le Stepper */
-.fr-stepper__steps[data-fr-steps="9"] {
-  --steps: 9;
-  --step-width: calc(100% / 9);
-}
-
-.fr-stepper__steps[data-fr-steps="10"] {
-  --steps: 10;
-  --step-width: calc(100% / 10);
-}
-
-.fr-stepper__steps[data-fr-steps="11"] {
-  --steps: 11;
-  --step-width: calc(100% / 11);
-}
-
-.fr-stepper__steps[data-fr-steps="12"] {
-  --steps: 12;
-  --step-width: calc(100% / 12);
-}
-
-.fr-stepper__steps[data-fr-steps="13"] {
-  --steps: 13;
-  --step-width: calc(100% / 13);
-}
-
-.fr-stepper__steps[data-fr-current-step="9"] {
-  --current-step: 9;
-}
-
-.fr-stepper__steps[data-fr-current-step="10"] {
-  --current-step: 10;
-}
-
-.fr-stepper__steps[data-fr-current-step="11"] {
-  --current-step: 11;
-}
-
-.fr-stepper__steps[data-fr-current-step="12"] {
-  --current-step: 12;
-}
-
-.fr-stepper__steps[data-fr-current-step="13"] {
-  --current-step: 13;
-}
-
 /* Ajout d’un statut warning sur le même modèle que error et success pour les inputs */
 
 .fr-message--warning::before,
@@ -97,4 +53,31 @@
 
 .fr-input-group--warning::before {
   background-image: linear-gradient(0deg, var(--border-plain-warning), var(--border-plain-warning));
+}
+
+/* Page Impacts: couleurs par type de projet */
+
+#project-impacts-page.building {
+  --impacts-title-color: #931595;
+  --impacts-main-color: #fdedfd;
+  --impacts-dark-color: #ffe0ff;
+
+  --highcharts-color-0: #e221e5;
+  --highcharts-color-1: #eb64ed;
+  --highcharts-color-2: #ef85f1;
+  --highcharts-color-3: #f3a6f5;
+  --highcharts-color-4: #c01cc3;
+  --highcharts-color-5: #9e17a0;
+}
+#project-impacts-page.photovoltaic {
+  --impacts-title-color: #0c5399;
+  --impacts-main-color: #ecf5fd;
+  --impacts-dark-color: #d9ebfc;
+
+  --highcharts-color-0: #137feb;
+  --highcharts-color-1: #5aa5f1;
+  --highcharts-color-2: #7db9f4;
+  --highcharts-color-3: #a1ccf7;
+  --highcharts-color-4: #106cc8;
+  --highcharts-color-5: #0d59a5;
 }

--- a/apps/web/src/main.css
+++ b/apps/web/src/main.css
@@ -57,7 +57,13 @@
 
 /* Page Impacts: couleurs par type de projet */
 
-#project-impacts-page.building {
+:root {
+  --impacts-title-color: #0c5399;
+  --impacts-main-color: #ecf5fd;
+  --impacts-dark-color: #d9ebfc;
+}
+
+#project-impacts-page.mixed-use-neighbourhood {
   --impacts-title-color: #931595;
   --impacts-main-color: #fdedfd;
   --impacts-dark-color: #ffe0ff;


### PR DESCRIPTION
- Ajout du `type` de `developmentPlan` dans le retour des endpoints `list-by-site` et `:reconversionProjectId/impacts`
- Affichage de la bonne icône en fonction du type de projet dans la liste des projet et dans la page impacts
- Changement de `main` color dans la page impacts en fonction du type de projet

Pour tester, pour l’instant j’ai juste changé le type de projet de l’un de mes projets à `BUILDINGS` en db.
Pour l’instant, je n’ai pas du tout géré l’affichage des impacts.

![image](https://github.com/incubateur-ademe/benefriches/assets/25612600/8df8204e-ab13-4a0f-a2aa-4fd4b7b5f81f)
![image](https://github.com/incubateur-ademe/benefriches/assets/25612600/9b2336df-4d73-4c05-9a70-fabe8dbf648e)
![image](https://github.com/incubateur-ademe/benefriches/assets/25612600/63fcd126-e1e4-47b2-9154-686c91f47201)
