### PR TITLE
feat(api): split SiteRepository into read and write repositories + add fields to returned site data

### DIFF
--- a/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.module.ts
+++ b/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.module.ts
@@ -14,7 +14,7 @@ import {
 } from "src/reconversion-projects/core/usecases/getUserReconversionProjectsBySite.usecase";
 import { DateProvider } from "src/shared-kernel/adapters/date/DateProvider";
 import { IDateProvider } from "src/shared-kernel/adapters/date/IDateProvider";
-import { SqlSiteRepository } from "src/sites/adapters/secondary/site-repository/SqlSiteRepository";
+import { SqlSiteWriteRepository } from "src/sites/adapters/secondary/site-repository/write/SqlSiteWriteRepository";
 import { SqlReconversionProjectImpactsRepository } from "../secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository";
 import { SqlReconversionProjectRepository } from "../secondary/reconversion-project-repository/SqlReconversionProjectRepository";
 import { SqlReconversionProjectsListRepository } from "../secondary/reconversion-projects-list-repository/SqlReconversionProjectsListRepository";
@@ -37,7 +37,7 @@ import { ReconversionProjectController } from "./reconversionProjects.controller
           siteRepository,
           reconversionProjectRepository,
         ),
-      inject: [DateProvider, SqlSiteRepository, SqlReconversionProjectRepository],
+      inject: [DateProvider, SqlSiteWriteRepository, SqlReconversionProjectRepository],
     },
     {
       provide: GetUserReconversionProjectsBySiteUseCase,
@@ -69,7 +69,7 @@ import { ReconversionProjectController } from "./reconversionProjects.controller
     },
     SqlReconversionProjectRepository,
     SqlReconversionProjectsListRepository,
-    SqlSiteRepository,
+    SqlSiteWriteRepository,
     SqlReconversionProjectImpactsRepository,
     SqlSiteImpactsRepository,
     DateProvider,

--- a/apps/api/src/reconversion-projects/core/usecases/createReconversionProject.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/createReconversionProject.usecase.spec.ts
@@ -2,7 +2,7 @@
 import { z } from "zod";
 import { InMemoryReconversionProjectRepository } from "src/reconversion-projects/adapters/secondary/reconversion-project-repository/InMemoryReconversionProjectRepository";
 import { DeterministicDateProvider } from "src/shared-kernel/adapters/date/DeterministicDateProvider";
-import { InMemorySitesRepository } from "src/sites/adapters/secondary/site-repository/InMemorySiteRepository";
+import { InMemorySitesWriteRepository } from "src/sites/adapters/secondary/site-repository/write/InMemorySiteRepository";
 import { buildMinimalSite } from "src/sites/core/models/site.mock";
 import {
   buildExhaustiveReconversionProjectProps,
@@ -16,7 +16,7 @@ import {
 
 describe("CreateReconversionProject Use Case", () => {
   let dateProvider: DateProvider;
-  let siteRepository: InMemorySitesRepository;
+  let siteRepository: InMemorySitesWriteRepository;
   let reconversionProjectRepository: InMemoryReconversionProjectRepository;
   const fakeNow = new Date("2024-01-05T13:00:00");
 
@@ -29,7 +29,7 @@ describe("CreateReconversionProject Use Case", () => {
 
   beforeEach(() => {
     dateProvider = new DeterministicDateProvider(fakeNow);
-    siteRepository = new InMemorySitesRepository();
+    siteRepository = new InMemorySitesWriteRepository();
     reconversionProjectRepository = new InMemoryReconversionProjectRepository();
   });
 

--- a/apps/api/src/sites/adapters/primary/sites.controller.integration-spec.ts
+++ b/apps/api/src/sites/adapters/primary/sites.controller.integration-spec.ts
@@ -216,6 +216,10 @@ describe("Sites controller", () => {
         friche_activity: "INDUSTRY",
         friche_has_contaminated_soils: true,
         friche_contaminated_soil_surface_area: 230,
+        friche_accidents_deaths: 1,
+        friche_accidents_minor_injuries: 2,
+        friche_accidents_severe_injuries: 3,
+        full_time_jobs_involved: 2.3,
       });
 
       await sqlConnection("addresses").insert({
@@ -235,6 +239,16 @@ describe("Sites controller", () => {
       await sqlConnection("site_soils_distributions").insert([
         { id: uuid(), site_id: siteId, soil_type: "FOREST_MIXED", surface_area: 1200 },
         { id: uuid(), site_id: siteId, soil_type: "PRAIRIE_GRASS", surface_area: 12800 },
+      ]);
+      await sqlConnection("site_expenses").insert([
+        {
+          id: uuid(),
+          site_id: siteId,
+          amount: 3300,
+          purpose: "security",
+          bearer: "owner",
+          purpose_category: "security",
+        },
       ]);
       const response = await supertest(app.getHttpServer()).get(`/sites/${siteId}`).send();
 
@@ -263,6 +277,13 @@ describe("Sites controller", () => {
           FOREST_MIXED: 1200,
           PRAIRIE_GRASS: 12800,
         },
+        description: "Description of site",
+        fricheActivity: "INDUSTRY",
+        yearlyExpenses: [{ amount: 3300, purpose: "security" }],
+        accidentsDeaths: 1,
+        accidentsMinorInjuries: 2,
+        accidentsSevereInjuries: 3,
+        fullTimeJobsInvolved: 2.3,
       });
     });
   });

--- a/apps/api/src/sites/adapters/primary/sites.module.ts
+++ b/apps/api/src/sites/adapters/primary/sites.module.ts
@@ -1,10 +1,12 @@
 import { Module } from "@nestjs/common";
 import { DateProvider } from "src/shared-kernel/adapters/date/DateProvider";
 import { IDateProvider } from "src/shared-kernel/adapters/date/IDateProvider";
-import { SitesRepository } from "src/sites/core/gateways/SitesRepository";
+import { SitesReadRepository } from "src/sites/core/gateways/SitesReadRepository";
+import { SitesWriteRepository } from "src/sites/core/gateways/SitesWriteRepository";
 import { CreateNewSiteUseCase } from "src/sites/core/usecases/createNewSite.usecase";
 import { GetSiteByIdUseCase } from "src/sites/core/usecases/getSiteById.usecase";
-import { SqlSiteRepository } from "../secondary/site-repository/SqlSiteRepository";
+import { SqlSitesReadRepository } from "../secondary/site-repository/read/SqlSiteReadRepository";
+import { SqlSiteWriteRepository } from "../secondary/site-repository/write/SqlSiteWriteRepository";
 import { SitesController } from "./sites.controller";
 
 @Module({
@@ -12,16 +14,17 @@ import { SitesController } from "./sites.controller";
   providers: [
     {
       provide: CreateNewSiteUseCase,
-      useFactory: (siteRepository: SitesRepository, dateProvider: IDateProvider) =>
+      useFactory: (siteRepository: SitesWriteRepository, dateProvider: IDateProvider) =>
         new CreateNewSiteUseCase(siteRepository, dateProvider),
-      inject: [SqlSiteRepository, DateProvider],
+      inject: [SqlSiteWriteRepository, DateProvider],
     },
     {
       provide: GetSiteByIdUseCase,
-      useFactory: (siteRepository: SitesRepository) => new GetSiteByIdUseCase(siteRepository),
-      inject: [SqlSiteRepository],
+      useFactory: (siteRepository: SitesReadRepository) => new GetSiteByIdUseCase(siteRepository),
+      inject: [SqlSitesReadRepository],
     },
-    SqlSiteRepository,
+    SqlSiteWriteRepository,
+    SqlSitesReadRepository,
     DateProvider,
   ],
 })

--- a/apps/api/src/sites/adapters/secondary/site-repository/read/InMemorySiteReadRepository.ts
+++ b/apps/api/src/sites/adapters/secondary/site-repository/read/InMemorySiteReadRepository.ts
@@ -1,0 +1,14 @@
+import { SitesReadRepository } from "src/sites/core/gateways/SitesReadRepository";
+import { SiteViewModel } from "src/sites/core/usecases/getSiteById.usecase";
+
+export class InMemorySiteReadRepository implements SitesReadRepository {
+  sites: SiteViewModel[] = [];
+
+  _setSites(sites: SiteViewModel[]) {
+    this.sites = sites;
+  }
+
+  getById(siteId: string): Promise<SiteViewModel | undefined> {
+    return Promise.resolve(this.sites.find(({ id }) => id === siteId));
+  }
+}

--- a/apps/api/src/sites/adapters/secondary/site-repository/read/SqlSiteReadRepository.integration-spec.ts
+++ b/apps/api/src/sites/adapters/secondary/site-repository/read/SqlSiteReadRepository.integration-spec.ts
@@ -1,0 +1,238 @@
+import knex, { Knex } from "knex";
+import { v4 as uuid } from "uuid";
+import knexConfig from "src/shared-kernel/adapters/sql-knex/knexConfig";
+import { SiteViewModel } from "src/sites/core/usecases/getSiteById.usecase";
+import { SqlSitesReadRepository } from "./SqlSiteReadRepository";
+
+describe("SqlSitesReadRepository integration", () => {
+  let sqlConnection: Knex;
+  let siteRepository: SqlSitesReadRepository;
+  const now = new Date();
+
+  beforeAll(() => {
+    sqlConnection = knex(knexConfig);
+  });
+
+  afterAll(async () => {
+    await sqlConnection.destroy();
+  });
+
+  beforeEach(() => {
+    siteRepository = new SqlSitesReadRepository(sqlConnection);
+  });
+
+  describe("getById", () => {
+    it("gets site with exhaustive data and address, soils distribution and yearly expenses", async () => {
+      const siteId = uuid();
+      await sqlConnection("sites").insert({
+        id: siteId,
+        created_by: "d185b43f-e54a-4dd4-9c60-ba85775a01e7",
+        name: "Site 123",
+        description: "Description of site",
+        surface_area: 14000,
+        owner_name: "Owner name",
+        owner_structure_type: "company",
+        tenant_name: "Tenant name",
+        tenant_structure_type: "company",
+        created_at: now,
+        is_friche: true,
+        friche_activity: "INDUSTRIAL",
+        friche_has_contaminated_soils: true,
+        friche_contaminated_soil_surface_area: 1200,
+        full_time_jobs_involved: 1.3,
+        friche_accidents_deaths: 0,
+        friche_accidents_minor_injuries: 1,
+        friche_accidents_severe_injuries: 2,
+      });
+
+      await sqlConnection("addresses").insert({
+        id: uuid(),
+        site_id: siteId,
+        city: "Paris",
+        city_code: "75109",
+        post_code: "75009",
+        ban_id: "123abc",
+        lat: 48.876517,
+        long: 2.330785,
+        value: "1 rue de Londres, 75009 Paris",
+        street_name: "rue de Londres",
+        street_number: "1",
+      });
+
+      await sqlConnection("site_soils_distributions").insert([
+        { id: uuid(), site_id: siteId, soil_type: "FOREST_MIXED", surface_area: 1200 },
+        { id: uuid(), site_id: siteId, soil_type: "PRAIRIE_GRASS", surface_area: 12800 },
+      ]);
+
+      await sqlConnection("site_expenses").insert([
+        {
+          id: uuid(),
+          site_id: siteId,
+          purpose: "rent",
+          bearer: "tenant",
+          purpose_category: "rent",
+          amount: 45000,
+        },
+        {
+          id: uuid(),
+          site_id: siteId,
+          purpose: "maintenance",
+          bearer: "tenant",
+          purpose_category: "site_management",
+          amount: 55000,
+        },
+      ]);
+
+      const result = await siteRepository.getById(siteId);
+
+      const expectedResult: Required<SiteViewModel> = {
+        id: siteId,
+        name: "Site 123",
+        description: "Description of site",
+        surfaceArea: 14000,
+        owner: { name: "Owner name", structureType: "company" },
+        tenant: { name: "Tenant name", structureType: "company" },
+        isFriche: true,
+        hasContaminatedSoils: true,
+        yearlyExpenses: [
+          { amount: 45000, purpose: "rent" },
+          { amount: 55000, purpose: "maintenance" },
+        ],
+        contaminatedSoilSurface: 1200,
+        address: {
+          city: "Paris",
+          cityCode: "75109",
+          postCode: "75009",
+          banId: "123abc",
+          lat: 48.876517,
+          long: 2.330785,
+          value: "1 rue de Londres, 75009 Paris",
+          streetName: "rue de Londres",
+          streetNumber: "1",
+        },
+        soilsDistribution: {
+          FOREST_MIXED: 1200,
+          PRAIRIE_GRASS: 12800,
+        },
+        accidentsDeaths: 0,
+        accidentsMinorInjuries: 1,
+        accidentsSevereInjuries: 2,
+        fricheActivity: "INDUSTRIAL",
+        fullTimeJobsInvolved: 1.3,
+      };
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("gets site with only required data", async () => {
+      const siteId = uuid();
+      await sqlConnection("sites").insert({
+        id: siteId,
+        created_by: "d185b43f-e54a-4dd4-9c60-ba85775a01e7",
+        name: "Site 456",
+        surface_area: 14000,
+        owner_structure_type: "company",
+        created_at: now,
+        is_friche: false,
+      });
+
+      await sqlConnection("addresses").insert({
+        id: uuid(),
+        site_id: siteId,
+        city: "Paris",
+        city_code: "75109",
+        post_code: "75009",
+        lat: 48.876517,
+        long: 2.330785,
+        ban_id: "123abc",
+        value: "1 rue de Londres, 75009 Paris",
+      });
+
+      await sqlConnection("site_soils_distributions").insert([
+        { id: uuid(), site_id: siteId, soil_type: "FOREST_MIXED", surface_area: 1200 },
+        { id: uuid(), site_id: siteId, soil_type: "PRAIRIE_GRASS", surface_area: 12800 },
+      ]);
+
+      await sqlConnection("site_expenses").insert([
+        {
+          id: uuid(),
+          site_id: siteId,
+          amount: 3300,
+          purpose: "security",
+          bearer: "owner",
+          purpose_category: "security",
+        },
+      ]);
+
+      const result = await siteRepository.getById(siteId);
+
+      const expectedResult: SiteViewModel = {
+        id: siteId,
+        name: "Site 456",
+        surfaceArea: 14000,
+        owner: { structureType: "company" },
+        isFriche: false,
+        yearlyExpenses: [{ amount: 3300, purpose: "security" }],
+        address: {
+          city: "Paris",
+          cityCode: "75109",
+          postCode: "75009",
+          banId: "123abc",
+          lat: 48.876517,
+          long: 2.330785,
+          value: "1 rue de Londres, 75009 Paris",
+        },
+        soilsDistribution: {
+          FOREST_MIXED: 1200,
+          PRAIRIE_GRASS: 12800,
+        },
+      };
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("gets site when no expenses, no soils_distribution, no address", async () => {
+      const siteId = uuid();
+      await sqlConnection("sites").insert({
+        id: siteId,
+        created_by: "d185b43f-e54a-4dd4-9c60-ba85775a01e7",
+        name: "Site 456",
+        surface_area: 14000,
+        owner_structure_type: "company",
+        created_at: now,
+        is_friche: false,
+      });
+
+      const result = await siteRepository.getById(siteId);
+
+      expect(result?.id).toEqual(siteId);
+      expect(result?.yearlyExpenses).toEqual([]);
+      expect(result?.soilsDistribution).toEqual({});
+      expect(result?.address.banId).toBeNull();
+    });
+
+    it("returns undefined when site does not exist", async () => {
+      const nonExistingSiteId = uuid();
+      await sqlConnection("sites").insert({
+        id: uuid(),
+        created_by: "d185b43f-e54a-4dd4-9c60-ba85775a01e7",
+        name: "Site 123",
+        description: "Description of site",
+        surface_area: 14000,
+        owner_name: "Owner name",
+        owner_structure_type: "company",
+        tenant_name: "Tenant name",
+        tenant_structure_type: "company",
+        created_at: now,
+        is_friche: true,
+        friche_activity: "HOUSING",
+        friche_has_contaminated_soils: true,
+        friche_contaminated_soil_surface_area: 230,
+      });
+
+      const result = await siteRepository.getById(nonExistingSiteId);
+
+      expect(result).toEqual(undefined);
+    });
+  });
+});

--- a/apps/api/src/sites/adapters/secondary/site-repository/read/SqlSiteReadRepository.ts
+++ b/apps/api/src/sites/adapters/secondary/site-repository/read/SqlSiteReadRepository.ts
@@ -1,0 +1,212 @@
+import { Inject } from "@nestjs/common";
+import { Knex } from "knex";
+import { SqlConnection } from "src/shared-kernel/adapters/sql-knex/sqlConnection.module";
+import { SitesReadRepository } from "src/sites/core/gateways/SitesReadRepository";
+import { SiteViewModel } from "src/sites/core/usecases/getSiteById.usecase";
+import { SoilType } from "src/soils/domain/soils";
+
+declare module "knex/types/tables" {
+  interface Tables {
+    sites: SqlSite;
+    addresses: SqlAddress;
+    site_soils_distributions: SqlSoilsDistribution;
+    site_expenses: SqlSiteExpense;
+    site_incomes: SqlSiteIncome;
+  }
+}
+
+type SqlSite = {
+  id: string;
+  name: string;
+  created_by: string;
+  description: string | null;
+  surface_area: number;
+  is_friche: boolean;
+  full_time_jobs_involved: number | null;
+  owner_structure_type: string;
+  owner_name: string | null;
+  tenant_structure_type: string | null;
+  tenant_name: string | null;
+  // friche related
+  friche_activity: string | null;
+  friche_has_contaminated_soils: boolean | null;
+  friche_contaminated_soil_surface_area: number | null;
+  friche_accidents_minor_injuries: number | null;
+  friche_accidents_severe_injuries: number | null;
+  friche_accidents_deaths: number | null;
+  // dates
+  created_at: Date;
+};
+
+type SqlAddress = {
+  id: string;
+  ban_id: string;
+  value: string;
+  city: string;
+  city_code: string;
+  post_code: string;
+  lat: number;
+  long: number;
+  street_name: string | null;
+  street_number: string | null;
+  site_id: string;
+};
+
+type SqlSoilsDistribution = {
+  id: string;
+  soil_type: SoilType;
+  surface_area: number;
+  site_id: string;
+};
+
+type SqlSiteExpense = {
+  id: string;
+  site_id: string;
+  purpose: string;
+  bearer: string;
+  purpose_category: string;
+  amount: number;
+};
+
+type SqlSiteIncome = {
+  id: string;
+  site_id: string;
+  source: string;
+  amount: number;
+};
+
+export class SqlSitesReadRepository implements SitesReadRepository {
+  constructor(@Inject(SqlConnection) private readonly sqlConnection: Knex) {}
+
+  async getById(siteId: string): Promise<SiteViewModel | undefined> {
+    const sqlResult = (await this.sqlConnection("sites")
+      .where("sites.id", siteId)
+      .leftJoin("addresses as address", "sites.id", "address.site_id")
+      .leftJoin("site_expenses as expenses", "sites.id", "expenses.site_id")
+      .leftJoin(
+        "site_soils_distributions as soils_distribution",
+        "sites.id",
+        "soils_distribution.site_id",
+      )
+      .select(
+        "sites.id",
+        "sites.name",
+        "sites.friche_activity",
+        "sites.full_time_jobs_involved",
+        "sites.description",
+        "sites.is_friche",
+        "sites.owner_name",
+        "sites.owner_structure_type",
+        "sites.tenant_name",
+        "sites.tenant_structure_type",
+        "sites.surface_area",
+        "sites.friche_has_contaminated_soils",
+        "sites.friche_contaminated_soil_surface_area",
+        "sites.friche_accidents_minor_injuries",
+        "sites.friche_accidents_severe_injuries",
+        "sites.friche_accidents_deaths",
+        "address.ban_id as address_ban_id",
+        "address.value as address_value",
+        "address.city as address_city",
+        "address.city_code as address_city_code",
+        "address.post_code as address_post_code",
+        "address.lat as address_lat",
+        "address.long as address_long",
+        "address.street_name as address_street_name",
+        "address.street_number as address_street_number",
+        this.sqlConnection.raw(`
+          jsonb_agg(
+            distinct jsonb_build_object(
+              'amount', expenses.amount,
+              'purpose', expenses.purpose
+            ) 
+          ) FILTER (WHERE expenses.id IS NOT NULL) AS "yearly_expenses"
+    `),
+        this.sqlConnection.raw(`
+          jsonb_agg(
+            distinct jsonb_build_object(
+              'soil_type', soils_distribution.soil_type,
+              'surface_area', soils_distribution.surface_area
+            )
+          ) FILTER (WHERE soils_distribution.id IS NOT NULL) AS "soils_distribution"
+    `),
+      )
+      .groupBy("sites.id", "address.id")) as
+      | undefined
+      | {
+          id: SqlSite["id"];
+          name: SqlSite["name"];
+          description: SqlSite["description"];
+          friche_activity: SqlSite["friche_activity"];
+          full_time_jobs_involved: SqlSite["full_time_jobs_involved"];
+          is_friche: SqlSite["is_friche"];
+          surface_area: SqlSite["surface_area"];
+          owner_name: SqlSite["owner_name"];
+          owner_structure_type: SqlSite["owner_structure_type"];
+          tenant_name: SqlSite["tenant_name"];
+          tenant_structure_type: SqlSite["tenant_structure_type"];
+          friche_has_contaminated_soils: SqlSite["friche_has_contaminated_soils"];
+          friche_contaminated_soil_surface_area: SqlSite["friche_contaminated_soil_surface_area"];
+          friche_accidents_minor_injuries: SqlSite["friche_accidents_minor_injuries"];
+          friche_accidents_severe_injuries: SqlSite["friche_accidents_severe_injuries"];
+          friche_accidents_deaths: SqlSite["friche_accidents_deaths"];
+          address_ban_id: SqlAddress["ban_id"];
+          address_value: SqlAddress["value"];
+          address_city: SqlAddress["city"];
+          address_city_code: SqlAddress["city_code"];
+          address_post_code: SqlAddress["post_code"];
+          address_lat: SqlAddress["lat"];
+          address_long: SqlAddress["long"];
+          address_street_name: SqlAddress["street_name"];
+          address_street_number: SqlAddress["street_number"];
+          soils_distribution: Pick<SqlSoilsDistribution, "soil_type" | "surface_area">[] | null;
+          yearly_expenses: Pick<SqlSiteExpense, "amount" | "purpose">[] | null;
+        }[];
+
+    const sqlSite = sqlResult?.[0];
+    if (!sqlSite) return undefined;
+
+    return {
+      id: sqlSite.id,
+      name: sqlSite.name,
+      description: sqlSite.description ?? undefined,
+      fricheActivity: sqlSite.friche_activity ?? undefined,
+      fullTimeJobsInvolved: sqlSite.full_time_jobs_involved ?? undefined,
+      isFriche: sqlSite.is_friche,
+      owner: {
+        name: sqlSite.owner_name ?? undefined,
+        structureType: sqlSite.owner_structure_type,
+      },
+      tenant: sqlSite.tenant_structure_type
+        ? { name: sqlSite.tenant_name ?? undefined, structureType: sqlSite.tenant_structure_type }
+        : undefined,
+      hasContaminatedSoils: sqlSite.friche_has_contaminated_soils ?? undefined,
+      contaminatedSoilSurface: sqlSite.friche_contaminated_soil_surface_area ?? undefined,
+      surfaceArea: sqlSite.surface_area,
+      address: {
+        banId: sqlSite.address_ban_id,
+        value: sqlSite.address_value,
+        city: sqlSite.address_city,
+        cityCode: sqlSite.address_city_code,
+        postCode: sqlSite.address_post_code,
+        lat: sqlSite.address_lat,
+        long: sqlSite.address_long,
+        streetName: sqlSite.address_street_name ?? undefined,
+        streetNumber: sqlSite.address_street_number ?? undefined,
+      },
+      soilsDistribution: (sqlSite.soils_distribution ?? []).reduce(
+        (acc, { soil_type, surface_area }) => {
+          return {
+            ...acc,
+            [soil_type]: surface_area,
+          };
+        },
+        {},
+      ),
+      accidentsMinorInjuries: sqlSite.friche_accidents_minor_injuries ?? undefined,
+      accidentsSevereInjuries: sqlSite.friche_accidents_severe_injuries ?? undefined,
+      accidentsDeaths: sqlSite.friche_accidents_deaths ?? undefined,
+      yearlyExpenses: sqlSite.yearly_expenses ?? [],
+    };
+  }
+}

--- a/apps/api/src/sites/adapters/secondary/site-repository/write/InMemorySiteRepository.ts
+++ b/apps/api/src/sites/adapters/secondary/site-repository/write/InMemorySiteRepository.ts
@@ -1,8 +1,7 @@
-import { SitesRepository } from "src/sites/core/gateways/SitesRepository";
+import { SitesWriteRepository } from "src/sites/core/gateways/SitesWriteRepository";
 import { Site } from "src/sites/core/models/site";
-import { SiteViewModel } from "src/sites/core/usecases/getSiteById.usecase";
 
-export class InMemorySitesRepository implements SitesRepository {
+export class InMemorySitesWriteRepository implements SitesWriteRepository {
   private sites: Site[] = [];
 
   async save(site: Site) {
@@ -13,10 +12,6 @@ export class InMemorySitesRepository implements SitesRepository {
   existsWithId(siteId: string): Promise<boolean> {
     const foundSite = this.sites.find(({ id }) => id === siteId);
     return Promise.resolve(!!foundSite);
-  }
-
-  getById(siteId: string): Promise<SiteViewModel | undefined> {
-    return Promise.resolve(this.sites.find(({ id }) => id === siteId));
   }
 
   _getSites() {

--- a/apps/api/src/sites/adapters/secondary/site-repository/write/SqlSiteRepository.integration-spec.ts
+++ b/apps/api/src/sites/adapters/secondary/site-repository/write/SqlSiteRepository.integration-spec.ts
@@ -3,12 +3,11 @@ import { v4 as uuid } from "uuid";
 import knexConfig from "src/shared-kernel/adapters/sql-knex/knexConfig";
 import { FricheSite, NonFricheSite } from "src/sites/core/models/site";
 import { buildMinimalSite } from "src/sites/core/models/site.mock";
-import { SiteViewModel } from "src/sites/core/usecases/getSiteById.usecase";
-import { SqlSiteRepository } from "./SqlSiteRepository";
+import { SqlSiteWriteRepository } from "./SqlSiteWriteRepository";
 
-describe("SqlSiteRepository integration", () => {
+describe("SqlSiteWriteRepository integration", () => {
   let sqlConnection: Knex;
-  let siteRepository: SqlSiteRepository;
+  let siteRepository: SqlSiteWriteRepository;
   const now = new Date();
 
   beforeAll(() => {
@@ -20,7 +19,7 @@ describe("SqlSiteRepository integration", () => {
   });
 
   beforeEach(() => {
-    siteRepository = new SqlSiteRepository(sqlConnection);
+    siteRepository = new SqlSiteWriteRepository(sqlConnection);
   });
 
   describe("existsWithId", () => {
@@ -225,156 +224,6 @@ describe("SqlSiteRepository integration", () => {
 
       const soilsDistributionResult = await sqlConnection("site_soils_distributions").select("id");
       expect(soilsDistributionResult).toEqual([]);
-    });
-  });
-
-  describe("getById", () => {
-    it("gets site with address and soils distribution", async () => {
-      const siteId = uuid();
-      await sqlConnection("sites").insert({
-        id: siteId,
-        created_by: "d185b43f-e54a-4dd4-9c60-ba85775a01e7",
-        name: "Site 123",
-        description: "Description of site",
-        surface_area: 14000,
-        owner_name: "Owner name",
-        owner_structure_type: "company",
-        tenant_name: "Tenant name",
-        tenant_structure_type: "company",
-        created_at: now,
-        is_friche: true,
-        friche_activity: "HOUSING",
-        friche_has_contaminated_soils: true,
-        friche_contaminated_soil_surface_area: 230,
-      });
-
-      await sqlConnection("addresses").insert({
-        id: uuid(),
-        site_id: siteId,
-        city: "Paris",
-        city_code: "75109",
-        post_code: "75009",
-        ban_id: "123abc",
-        lat: 48.876517,
-        long: 2.330785,
-        value: "1 rue de Londres, 75009 Paris",
-        street_name: "rue de Londres",
-        street_number: "1",
-      });
-
-      await sqlConnection("site_soils_distributions").insert([
-        { id: uuid(), site_id: siteId, soil_type: "FOREST_MIXED", surface_area: 1200 },
-        { id: uuid(), site_id: siteId, soil_type: "PRAIRIE_GRASS", surface_area: 12800 },
-      ]);
-
-      const result = await siteRepository.getById(siteId);
-
-      const expectedResult: SiteViewModel = {
-        id: siteId,
-        name: "Site 123",
-        surfaceArea: 14000,
-        owner: { name: "Owner name", structureType: "company" },
-        tenant: { name: "Tenant name", structureType: "company" },
-        isFriche: true,
-        hasContaminatedSoils: true,
-        contaminatedSoilSurface: 230,
-        address: {
-          city: "Paris",
-          cityCode: "75109",
-          postCode: "75009",
-          banId: "123abc",
-          lat: 48.876517,
-          long: 2.330785,
-          value: "1 rue de Londres, 75009 Paris",
-          streetName: "rue de Londres",
-          streetNumber: "1",
-        },
-        soilsDistribution: {
-          FOREST_MIXED: 1200,
-          PRAIRIE_GRASS: 12800,
-        },
-      };
-
-      expect(result).toEqual(expectedResult);
-    });
-
-    it("gets site with address and soils distribution when optional data not defined", async () => {
-      const siteId = uuid();
-      await sqlConnection("sites").insert({
-        id: siteId,
-        created_by: "d185b43f-e54a-4dd4-9c60-ba85775a01e7",
-        name: "Site 456",
-        surface_area: 14000,
-        owner_structure_type: "company",
-        created_at: now,
-        is_friche: false,
-      });
-
-      await sqlConnection("addresses").insert({
-        id: uuid(),
-        site_id: siteId,
-        city: "Paris",
-        city_code: "75109",
-        post_code: "75009",
-        lat: 48.876517,
-        long: 2.330785,
-        ban_id: "123abc",
-        value: "1 rue de Londres, 75009 Paris",
-      });
-
-      await sqlConnection("site_soils_distributions").insert([
-        { id: uuid(), site_id: siteId, soil_type: "FOREST_MIXED", surface_area: 1200 },
-        { id: uuid(), site_id: siteId, soil_type: "PRAIRIE_GRASS", surface_area: 12800 },
-      ]);
-
-      const result = await siteRepository.getById(siteId);
-
-      const expectedResult: SiteViewModel = {
-        id: siteId,
-        name: "Site 456",
-        surfaceArea: 14000,
-        owner: { structureType: "company" },
-        isFriche: false,
-        address: {
-          city: "Paris",
-          cityCode: "75109",
-          postCode: "75009",
-          banId: "123abc",
-          lat: 48.876517,
-          long: 2.330785,
-          value: "1 rue de Londres, 75009 Paris",
-        },
-        soilsDistribution: {
-          FOREST_MIXED: 1200,
-          PRAIRIE_GRASS: 12800,
-        },
-      };
-
-      expect(result).toEqual(expectedResult);
-    });
-
-    it("returns undefined when site does not exist", async () => {
-      const nonExistingSiteId = uuid();
-      await sqlConnection("sites").insert({
-        id: uuid(),
-        created_by: "d185b43f-e54a-4dd4-9c60-ba85775a01e7",
-        name: "Site 123",
-        description: "Description of site",
-        surface_area: 14000,
-        owner_name: "Owner name",
-        owner_structure_type: "company",
-        tenant_name: "Tenant name",
-        tenant_structure_type: "company",
-        created_at: now,
-        is_friche: true,
-        friche_activity: "HOUSING",
-        friche_has_contaminated_soils: true,
-        friche_contaminated_soil_surface_area: 230,
-      });
-
-      const result = await siteRepository.getById(nonExistingSiteId);
-
-      expect(result).toEqual(undefined);
     });
   });
 });

--- a/apps/api/src/sites/adapters/secondary/site-repository/write/SqlSiteWriteRepository.ts
+++ b/apps/api/src/sites/adapters/secondary/site-repository/write/SqlSiteWriteRepository.ts
@@ -2,9 +2,8 @@ import { Inject } from "@nestjs/common";
 import { Knex } from "knex";
 import { v4 as uuid } from "uuid";
 import { SqlConnection } from "src/shared-kernel/adapters/sql-knex/sqlConnection.module";
-import { SitesRepository } from "src/sites/core/gateways/SitesRepository";
+import { SitesWriteRepository } from "src/sites/core/gateways/SitesWriteRepository";
 import { Site } from "src/sites/core/models/site";
-import { SiteViewModel } from "src/sites/core/usecases/getSiteById.usecase";
 import { SoilType } from "src/soils/domain/soils";
 
 declare module "knex/types/tables" {
@@ -77,7 +76,7 @@ type SqlSiteIncome = {
   amount: number;
 };
 
-export class SqlSiteRepository implements SitesRepository {
+export class SqlSiteWriteRepository implements SitesWriteRepository {
   constructor(@Inject(SqlConnection) private readonly sqlConnection: Knex) {}
 
   async save(site: Site): Promise<void> {
@@ -173,94 +172,5 @@ export class SqlSiteRepository implements SitesRepository {
       .where({ id: siteId })
       .first();
     return !!exists;
-  }
-
-  async getById(siteId: string): Promise<SiteViewModel | undefined> {
-    const sqlSite = (await this.sqlConnection("sites")
-      .leftJoin("addresses as address", "sites.id", "=", "address.site_id")
-      .select(
-        "sites.id",
-        "sites.name",
-        "sites.is_friche",
-        "sites.owner_name",
-        "sites.owner_structure_type",
-        "sites.tenant_name",
-        "sites.tenant_structure_type",
-        "sites.friche_has_contaminated_soils",
-        "sites.friche_contaminated_soil_surface_area",
-        "sites.surface_area",
-        "address.ban_id as address_ban_id",
-        "address.value as address_value",
-        "address.city as address_city",
-        "address.city_code as address_city_code",
-        "address.post_code as address_post_code",
-        "address.lat as address_lat",
-        "address.long as address_long",
-        "address.street_name as address_street_name",
-        "address.street_number as address_street_number",
-      )
-      .where("sites.id", siteId)
-      .first()) as
-      | undefined
-      | {
-          id: SqlSite["id"];
-          name: SqlSite["name"];
-          is_friche: SqlSite["is_friche"];
-          surface_area: SqlSite["surface_area"];
-          owner_name: SqlSite["owner_name"];
-          owner_structure_type: SqlSite["owner_structure_type"];
-          tenant_name: SqlSite["tenant_name"];
-          tenant_structure_type: SqlSite["tenant_structure_type"];
-          friche_has_contaminated_soils: SqlSite["friche_has_contaminated_soils"];
-          friche_contaminated_soil_surface_area: SqlSite["friche_contaminated_soil_surface_area"];
-          address_ban_id: SqlAddress["ban_id"];
-          address_value: SqlAddress["value"];
-          address_city: SqlAddress["city"];
-          address_city_code: SqlAddress["city_code"];
-          address_post_code: SqlAddress["post_code"];
-          address_lat: SqlAddress["lat"];
-          address_long: SqlAddress["long"];
-          address_street_name: SqlAddress["street_name"];
-          address_street_number: SqlAddress["street_number"];
-        };
-
-    if (!sqlSite) return undefined;
-
-    const sqlSoilDistributions = await this.sqlConnection("site_soils_distributions")
-      .select("soil_type", "surface_area")
-      .where("site_id", siteId);
-
-    return {
-      id: sqlSite.id,
-      name: sqlSite.name,
-      isFriche: sqlSite.is_friche,
-      owner: {
-        name: sqlSite.owner_name ?? undefined,
-        structureType: sqlSite.owner_structure_type,
-      },
-      tenant: sqlSite.tenant_structure_type
-        ? { name: sqlSite.tenant_name ?? undefined, structureType: sqlSite.tenant_structure_type }
-        : undefined,
-      hasContaminatedSoils: sqlSite.friche_has_contaminated_soils ?? undefined,
-      contaminatedSoilSurface: sqlSite.friche_contaminated_soil_surface_area ?? undefined,
-      surfaceArea: sqlSite.surface_area,
-      address: {
-        banId: sqlSite.address_ban_id,
-        value: sqlSite.address_value,
-        city: sqlSite.address_city,
-        cityCode: sqlSite.address_city_code,
-        postCode: sqlSite.address_post_code,
-        lat: sqlSite.address_lat,
-        long: sqlSite.address_long,
-        streetName: sqlSite.address_street_name ?? undefined,
-        streetNumber: sqlSite.address_street_number ?? undefined,
-      },
-      soilsDistribution: sqlSoilDistributions.reduce((acc, { soil_type, surface_area }) => {
-        return {
-          ...acc,
-          [soil_type]: surface_area,
-        };
-      }, {}),
-    };
   }
 }

--- a/apps/api/src/sites/core/gateways/SitesReadRepository.ts
+++ b/apps/api/src/sites/core/gateways/SitesReadRepository.ts
@@ -1,0 +1,5 @@
+import { SiteViewModel } from "../usecases/getSiteById.usecase";
+
+export interface SitesReadRepository {
+  getById(siteId: SiteViewModel["id"]): Promise<SiteViewModel | undefined>;
+}

--- a/apps/api/src/sites/core/gateways/SitesRepository.ts
+++ b/apps/api/src/sites/core/gateways/SitesRepository.ts
@@ -1,8 +1,0 @@
-import { Site } from "../models/site";
-import { SiteViewModel } from "../usecases/getSiteById.usecase";
-
-export interface SitesRepository {
-  save(site: Site): Promise<void>;
-  existsWithId(siteId: Site["id"]): Promise<boolean>;
-  getById(siteId: Site["id"]): Promise<SiteViewModel | undefined>;
-}

--- a/apps/api/src/sites/core/gateways/SitesWriteRepository.ts
+++ b/apps/api/src/sites/core/gateways/SitesWriteRepository.ts
@@ -1,0 +1,6 @@
+import { Site } from "../models/site";
+
+export interface SitesWriteRepository {
+  save(site: Site): Promise<void>;
+  existsWithId(siteId: Site["id"]): Promise<boolean>;
+}

--- a/apps/api/src/sites/core/usecases/createNewSite.usecase.spec.ts
+++ b/apps/api/src/sites/core/usecases/createNewSite.usecase.spec.ts
@@ -1,12 +1,12 @@
 /* eslint-disable jest/no-conditional-expect */
 import { z } from "zod";
 import { DeterministicDateProvider } from "src/shared-kernel/adapters/date/DeterministicDateProvider";
-import { InMemorySitesRepository } from "src/sites/adapters/secondary/site-repository/InMemorySiteRepository";
+import { InMemorySitesWriteRepository } from "src/sites/adapters/secondary/site-repository/write/InMemorySiteRepository";
 import { buildFricheProps, buildMinimalSiteProps } from "../models/site.mock";
 import { CreateNewSiteUseCase, DateProvider } from "./createNewSite.usecase";
 
 describe("CreateNewSite Use Case", () => {
-  let siteRepository: InMemorySitesRepository;
+  let siteRepository: InMemorySitesWriteRepository;
   let dateProvider: DateProvider;
   const fakeNow = new Date("2024-01-03T13:50:45");
 
@@ -18,7 +18,7 @@ describe("CreateNewSite Use Case", () => {
   };
 
   beforeEach(() => {
-    siteRepository = new InMemorySitesRepository();
+    siteRepository = new InMemorySitesWriteRepository();
     dateProvider = new DeterministicDateProvider(fakeNow);
   });
 

--- a/apps/api/src/sites/core/usecases/createNewSite.usecase.ts
+++ b/apps/api/src/sites/core/usecases/createNewSite.usecase.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { UseCase } from "src/shared-kernel/usecase";
-import { SitesRepository } from "../gateways/SitesRepository";
+import { SitesWriteRepository } from "../gateways/SitesWriteRepository";
 import { fricheSchema, nonFricheSiteSchema, Site } from "../models/site";
 
 // we can't use .omit method on siteSchema because zod doesn not allow it on discrimnated union
@@ -26,14 +26,14 @@ export interface DateProvider {
 
 export class CreateNewSiteUseCase implements UseCase<Request, void> {
   constructor(
-    private readonly siteRepository: SitesRepository,
+    private readonly siteWriteRepository: SitesWriteRepository,
     private readonly dateProvider: DateProvider,
   ) {}
 
   async execute({ siteProps }: Request): Promise<void> {
     const parsedSite = await sitePropsSchema.parseAsync(siteProps);
 
-    if (await this.siteRepository.existsWithId(parsedSite.id)) {
+    if (await this.siteWriteRepository.existsWithId(parsedSite.id)) {
       throw new Error(`Site with id ${parsedSite.id} already exists`);
     }
 
@@ -42,6 +42,6 @@ export class CreateNewSiteUseCase implements UseCase<Request, void> {
       createdAt: this.dateProvider.now(),
     };
 
-    await this.siteRepository.save(site);
+    await this.siteWriteRepository.save(site);
   }
 }

--- a/apps/api/src/sites/core/usecases/getSideById.usecase.spec.ts
+++ b/apps/api/src/sites/core/usecases/getSideById.usecase.spec.ts
@@ -1,75 +1,82 @@
-import { InMemorySitesRepository } from "src/sites/adapters/secondary/site-repository/InMemorySiteRepository";
-import { Site } from "../models/site";
-import { GetSiteByIdUseCase } from "./getSiteById.usecase";
+import { InMemorySiteReadRepository } from "src/sites/adapters/secondary/site-repository/read/InMemorySiteReadRepository";
+import { GetSiteByIdUseCase, SiteViewModel } from "./getSiteById.usecase";
 
 describe("GetSiteById Use Case", () => {
-  let siteRepository: InMemorySitesRepository;
+  let siteRepository: InMemorySiteReadRepository;
 
   beforeEach(() => {
-    siteRepository = new InMemorySitesRepository();
+    siteRepository = new InMemorySiteReadRepository();
   });
 
-  describe("Mandatory data", () => {
-    it("cannot get a non-existing site", async () => {
-      const siteId = "fdc94bb2-ec2c-49f8-92ea-19bd91160027";
-      const usecase = new GetSiteByIdUseCase(siteRepository);
-      await expect(usecase.execute({ siteId })).rejects.toThrow(`Site with ID ${siteId} not found`);
-    });
+  it("cannot get a non-existing site", async () => {
+    const siteId = "fdc94bb2-ec2c-49f8-92ea-19bd91160027";
+    const usecase = new GetSiteByIdUseCase(siteRepository);
+    await expect(usecase.execute({ siteId })).rejects.toThrow(`Site with ID ${siteId} not found`);
+  });
 
-    it("Can get an existing site", async () => {
-      const site: Site = {
-        id: "4550d9f0-ce28-43ae-a319-94851ae033db",
-        createdBy: "74ac340f-0654-4887-9449-3dbb43ce35b5",
-        name: "My existing site",
-        isFriche: true,
-        surfaceArea: 140000,
-        fricheActivity: "ADMINISTRATION",
-        owner: {
-          structureType: "department",
-          name: "Le département Paris",
-        },
-        tenant: {
-          structureType: "company",
-          name: "Tenant company name",
-        },
-        soilsDistribution: {
-          BUILDINGS: 3000,
-          ARTIFICIAL_TREE_FILLED: 5000,
-          FOREST_MIXED: 60000,
-          MINERAL_SOIL: 5000,
-          IMPERMEABLE_SOILS: 1300,
-        },
-        yearlyExpenses: [],
-        yearlyIncomes: [],
-        address: {
-          city: "Paris",
-          cityCode: "75109",
-          postCode: "75009",
-          banId: "123abc",
-          lat: 48.876517,
-          long: 2.330785,
-          value: "1 rue de Londres, 75009 Paris",
-          streetName: "rue de Londres",
-        },
-        createdAt: new Date(),
-      };
-      siteRepository._setSites([site]);
+  it("Can get an existing site", async () => {
+    const site: SiteViewModel = {
+      id: "4550d9f0-ce28-43ae-a319-94851ae033db",
+      name: "My existing site",
+      isFriche: true,
+      surfaceArea: 140000,
+      fricheActivity: "ADMINISTRATION",
+      owner: {
+        structureType: "department",
+        name: "Le département Paris",
+      },
+      tenant: {
+        structureType: "company",
+        name: "Tenant company name",
+      },
+      soilsDistribution: {
+        BUILDINGS: 3000,
+        ARTIFICIAL_TREE_FILLED: 5000,
+        FOREST_MIXED: 60000,
+        MINERAL_SOIL: 5000,
+        IMPERMEABLE_SOILS: 1300,
+      },
+      yearlyExpenses: [{ amount: 10999, purpose: "rent" }],
+      address: {
+        city: "Paris",
+        cityCode: "75109",
+        postCode: "75009",
+        banId: "123abc",
+        lat: 48.876517,
+        long: 2.330785,
+        value: "1 rue de Londres, 75009 Paris",
+        streetName: "rue de Londres",
+      },
+      contaminatedSoilSurface: 1000,
+      description: "Description of the site",
+      fullTimeJobsInvolved: 2.3,
+      accidentsDeaths: 0,
+      accidentsMinorInjuries: 2,
+      accidentsSevereInjuries: 1,
+    };
+    siteRepository._setSites([site]);
 
-      const usecase = new GetSiteByIdUseCase(siteRepository);
+    const usecase = new GetSiteByIdUseCase(siteRepository);
 
-      const result = await usecase.execute({ siteId: site.id });
+    const result = await usecase.execute({ siteId: site.id });
 
-      expect(result).toMatchObject({
-        id: site.id,
-        createdBy: site.createdBy,
-        name: site.name,
-        isFriche: site.isFriche,
-        owner: site.owner,
-        tenant: site.tenant,
-        soilsDistribution: site.soilsDistribution,
-        surfaceArea: site.surfaceArea,
-        address: site.address,
-      });
+    expect(result).toEqual({
+      id: site.id,
+      name: site.name,
+      description: site.description,
+      isFriche: site.isFriche,
+      owner: site.owner,
+      tenant: site.tenant,
+      soilsDistribution: site.soilsDistribution,
+      surfaceArea: site.surfaceArea,
+      contaminatedSoilSurface: site.contaminatedSoilSurface,
+      address: site.address,
+      fullTimeJobsInvolved: site.fullTimeJobsInvolved,
+      accidentsDeaths: 0,
+      accidentsMinorInjuries: 2,
+      accidentsSevereInjuries: 1,
+      yearlyExpenses: [{ amount: 10999, purpose: "rent" }],
+      fricheActivity: site.fricheActivity,
     });
   });
 });

--- a/apps/api/src/sites/core/usecases/getSiteById.usecase.ts
+++ b/apps/api/src/sites/core/usecases/getSiteById.usecase.ts
@@ -1,6 +1,6 @@
 import { UseCase } from "src/shared-kernel/usecase";
 import { SoilType } from "src/soils/domain/soils";
-import { SitesRepository } from "../gateways/SitesRepository";
+import { SitesReadRepository } from "../gateways/SitesReadRepository";
 import { Address } from "../models/site";
 
 type Request = {
@@ -24,6 +24,13 @@ export type SiteViewModel = {
   soilsDistribution: Partial<Record<SoilType, number>>;
   surfaceArea: number;
   address: Address;
+  fullTimeJobsInvolved?: number;
+  accidentsMinorInjuries?: number;
+  accidentsSevereInjuries?: number;
+  accidentsDeaths?: number;
+  yearlyExpenses: { amount: number; purpose: string }[];
+  fricheActivity?: string;
+  description?: string;
 };
 
 export class SiteNotFoundError extends Error {
@@ -34,7 +41,7 @@ export class SiteNotFoundError extends Error {
 }
 
 export class GetSiteByIdUseCase implements UseCase<Request, SiteViewModel> {
-  constructor(private readonly sitesRepository: SitesRepository) {}
+  constructor(private readonly sitesRepository: SitesReadRepository) {}
 
   async execute({ siteId }: Request): Promise<SiteViewModel> {
     const site = await this.sitesRepository.getById(siteId);


### PR DESCRIPTION
* Ajout des dépenses, emplois temps plein, description et accidents pour la page "caractéristiques du site"
* Refacto de la query SQL pour récupérer le site et les données liées en une seule requête, preneur de ton avis là-dessus !
* J'ai split le repository pour une version write et une autre read car ils n'utilisent plus la même structure de données