### PR TITLE
feat(web): make it impossible to enter a photovoltaic plant surface area bigger than site

### DIFF
--- a/apps/web/src/features/create-project/application/pvFeatures.selectors.ts
+++ b/apps/web/src/features/create-project/application/pvFeatures.selectors.ts
@@ -37,12 +37,15 @@ export const selectRecommendedPowerKWcFromSiteSurfaceArea = createSelector(
 );
 
 export const selectRecommendedPhotovoltaicPlantSurfaceFromElectricalPower = createSelector(
-  selectProjectCreationData,
-  (projectData): number => {
-    if (!projectData.photovoltaicInstallationElectricalPowerKWc) return 0;
-    return Math.round(
+  [selectProjectCreationData, selectProjectCreationSiteData],
+  (projectData, siteData): number => {
+    if (!projectData.photovoltaicInstallationElectricalPowerKWc || !siteData?.surfaceArea) return 0;
+
+    const computedFromElectricalPower = Math.round(
       projectData.photovoltaicInstallationElectricalPowerKWc * PHOTOVOLTAIC_RATIO_M2_PER_KWC,
     );
+    // photovoltaic plant can't be bigger than site
+    return Math.min(computedFromElectricalPower, siteData.surfaceArea);
   },
 );
 

--- a/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceForm.tsx
@@ -1,6 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
 
-import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
+import { formatSurfaceArea } from "@/shared/services/format-number/formatNumber";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
@@ -19,17 +19,13 @@ type FormValues = {
 };
 
 function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
-  const { control, handleSubmit, watch } = useForm<FormValues>();
+  const { control, handleSubmit } = useForm<FormValues>();
 
-  const hintText = `Maximum : ${formatNumberFr(siteSurfaceArea)} m²`;
+  const hintText = `Maximum : ${formatSurfaceArea(siteSurfaceArea)}`;
 
-  const maxErrorMessage = `La superficie des panneaux ne peut pas être supérieure à la superficie totale du site (${formatNumberFr(
+  const maxErrorMessage = `La superficie des panneaux ne peut pas être supérieure à la superficie total du site (${formatSurfaceArea(
     siteSurfaceArea,
-  )} m²).`;
-
-  const surface = watch("photovoltaicInstallationSurfaceSquareMeters");
-
-  const displayTooHighValueWarning = surface > siteSurfaceArea;
+  )}).`;
 
   return (
     <WizardFormLayout
@@ -39,7 +35,7 @@ function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
           <FormInfo>
             <p>
               La superficie d'installation des panneaux ne peut être supérieure à la superficie
-              totale de la friche (<strong>{formatNumberFr(siteSurfaceArea)}</strong> m²).
+              totale de la friche (<strong>{formatSurfaceArea(siteSurfaceArea)}</strong>).
             </p>
           </FormInfo>
 
@@ -67,13 +63,15 @@ function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
           rules={{
             min: 0,
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
+            max: {
+              value: siteSurfaceArea,
+              message: maxErrorMessage,
+            },
           }}
           render={(controller) => {
             return (
               <ControlledRowNumericInput
                 {...controller}
-                stateRelatedMessage={displayTooHighValueWarning ? maxErrorMessage : undefined}
-                state={displayTooHighValueWarning ? "warning" : "default"}
                 label={<RequiredLabel label="Superficie de l'installation" />}
                 hintText={hintText}
                 hintInputText="en m²"

--- a/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceFromPowerForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceFromPowerForm.tsx
@@ -1,7 +1,7 @@
 import { Controller, useForm } from "react-hook-form";
 
 import { PHOTOVOLTAIC_RATIO_M2_PER_KWC } from "@/features/create-project/domain/photovoltaic";
-import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
+import { formatNumberFr, formatSurfaceArea } from "@/shared/services/format-number/formatNumber";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
@@ -28,21 +28,17 @@ function PhotovoltaicSurfaceFromPowerForm({
   recommendedSurface,
   siteSurfaceArea,
 }: Props) {
-  const { control, handleSubmit, watch } = useForm<FormValues>({
+  const { control, handleSubmit } = useForm<FormValues>({
     defaultValues: {
       photovoltaicInstallationSurfaceSquareMeters: recommendedSurface,
     },
   });
 
-  const hintText = `en m² (maximum conseillé : ${formatNumberFr(siteSurfaceArea)} m²)`;
+  const hintText = `en m² (maximum : ${formatSurfaceArea(siteSurfaceArea)})`;
 
-  const maxErrorMessage = `La superficie des panneaux ne peut pas être supérieure à la superficie totale du site (${formatNumberFr(
+  const maxErrorMessage = `La superficie des panneaux ne peut pas être supérieure à la superficie totale du site (${formatSurfaceArea(
     siteSurfaceArea,
-  )} m²).`;
-
-  const surface = watch("photovoltaicInstallationSurfaceSquareMeters");
-
-  const displayTooHighValueWarning = surface > siteSurfaceArea;
+  )}).`;
 
   return (
     <WizardFormLayout
@@ -53,20 +49,19 @@ function PhotovoltaicSurfaceFromPowerForm({
             <p>
               Le ratio superficie / puissance d'installation considéré est de{" "}
               <strong>
-                {formatNumberFr(PHOTOVOLTAIC_RATIO_M2_PER_KWC * 1000)}&nbsp;m² pour 1 000 kWc.
+                {formatSurfaceArea(PHOTOVOLTAIC_RATIO_M2_PER_KWC * 1000)} pour 1 000 kWc.
               </strong>
             </p>
             <p>
               Pour la puissance que vous avez renseigné ({formatNumberFr(electricalPowerKWc)}
               &nbsp;kWc), la superficie occupée par les panneaux devrait donc être de{" "}
-              {formatNumberFr(recommendedSurface)}
-              &nbsp;m².
+              {formatSurfaceArea(recommendedSurface)}.
             </p>
             <p>Vous pouvez modifier cette superficie.</p>
 
             <p>
               La superficie d'installation des panneaux ne peut être supérieure à la superficie
-              totale de la friche ({formatNumberFr(siteSurfaceArea)} m²).
+              totale de la friche ({formatSurfaceArea(siteSurfaceArea)}).
             </p>
           </FormInfo>
 
@@ -94,13 +89,15 @@ function PhotovoltaicSurfaceFromPowerForm({
           rules={{
             min: 0,
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
+            max: {
+              value: siteSurfaceArea,
+              message: maxErrorMessage,
+            },
           }}
           render={(controller) => {
             return (
               <ControlledRowNumericInput
                 {...controller}
-                stateRelatedMessage={displayTooHighValueWarning ? maxErrorMessage : undefined}
-                state={displayTooHighValueWarning ? "warning" : "default"}
                 label={<RequiredLabel label="Superficie de l'installation" />}
                 hintText={hintText}
                 hintInputText="en m²"


### PR DESCRIPTION
Les textes d'aide deviennent un maladroit car on explique calculer une surface à partir d'un ratio mais lorsque cette surface calculée est supérieure à la surface du site, on utilise la surface du site dans l'input.

Je vais demander à Chloë de retravailler ça.