### PR TITLE
feat(api): create route and backend logic for express creation of mixed-use neighbourhood reconversion project

### DIFF
--- a/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.ts
+++ b/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.ts
@@ -6,6 +6,7 @@ import {
   photovoltaicPowerStationFeaturesSchema,
 } from "src/reconversion-projects/core/model/reconversionProject";
 import { ComputeReconversionProjectImpactsUseCase } from "src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase";
+import { CreateExpressReconversionProjectUseCase } from "src/reconversion-projects/core/usecases/createExpressReconversionProject.usecase";
 import {
   CreateReconversionProjectUseCase,
   reconversionProjectPropsSchema,
@@ -30,8 +31,14 @@ export const createReconversionProjectInputSchema = reconversionProjectPropsSche
   ]),
 });
 
-class CreateReconversionProjectInputDto extends createZodDto(
-  createReconversionProjectInputSchema,
+class CreateReconversionProjectBodyDto extends createZodDto(createReconversionProjectInputSchema) {}
+
+class CreateExpressReconversionProjectBodyDto extends createZodDto(
+  z.object({
+    reconversionProjectId: z.string(),
+    siteId: z.string(),
+    createdBy: z.string(),
+  }),
 ) {}
 
 class GetListGroupedBySiteQueryDto extends createZodDto(
@@ -50,15 +57,23 @@ export class ReconversionProjectController {
     private readonly createReconversionProjectUseCase: CreateReconversionProjectUseCase,
     private readonly getReconversionProjectsBySite: GetUserReconversionProjectsBySiteUseCase,
     private readonly getReconversionProjectImpactsUseCase: ComputeReconversionProjectImpactsUseCase,
+    private readonly createExpressReconversionProjectUseCase: CreateExpressReconversionProjectUseCase,
   ) {}
 
   @Post()
   async createReconversionProject(
-    @Body() createReconversionProjectDto: CreateReconversionProjectInputDto,
+    @Body() createReconversionProjectDto: CreateReconversionProjectBodyDto,
   ) {
     await this.createReconversionProjectUseCase.execute({
       reconversionProjectProps: createReconversionProjectDto,
     });
+  }
+
+  @Post("create-from-site")
+  async createExpressReconversionProject(
+    @Body() createReconversionProjectDto: CreateExpressReconversionProjectBodyDto,
+  ) {
+    await this.createExpressReconversionProjectUseCase.execute(createReconversionProjectDto);
   }
 
   @Get("list-by-site")

--- a/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.module.ts
+++ b/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.module.ts
@@ -3,6 +3,7 @@ import { CarbonStorageModule } from "src/carbon-storage/adapters/primary/carbonS
 import { SqlCarbonStorageRepository } from "src/carbon-storage/adapters/secondary/carbonStorageRepository/SqlCarbonStorageRepository";
 import { GetCityCarbonStoragePerSoilsCategoryUseCase } from "src/carbon-storage/core/usecases/getCityCarbonStoragePerSoilsCategory";
 import { ComputeReconversionProjectImpactsUseCase } from "src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase";
+import { CreateExpressReconversionProjectUseCase } from "src/reconversion-projects/core/usecases/createExpressReconversionProject.usecase";
 import {
   CreateReconversionProjectUseCase,
   ReconversionProjectRepository,
@@ -14,7 +15,9 @@ import {
 } from "src/reconversion-projects/core/usecases/getUserReconversionProjectsBySite.usecase";
 import { DateProvider } from "src/shared-kernel/adapters/date/DateProvider";
 import { IDateProvider } from "src/shared-kernel/adapters/date/IDateProvider";
+import { SqlSitesReadRepository } from "src/sites/adapters/secondary/site-repository/read/SqlSiteReadRepository";
 import { SqlSiteWriteRepository } from "src/sites/adapters/secondary/site-repository/write/SqlSiteWriteRepository";
+import { SitesReadRepository } from "src/sites/core/gateways/SitesReadRepository";
 import { SqlReconversionProjectImpactsRepository } from "../secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository";
 import { SqlReconversionProjectRepository } from "../secondary/reconversion-project-repository/SqlReconversionProjectRepository";
 import { SqlReconversionProjectsListRepository } from "../secondary/reconversion-projects-list-repository/SqlReconversionProjectsListRepository";
@@ -38,6 +41,20 @@ import { ReconversionProjectController } from "./reconversionProjects.controller
           reconversionProjectRepository,
         ),
       inject: [DateProvider, SqlSiteWriteRepository, SqlReconversionProjectRepository],
+    },
+    {
+      provide: CreateExpressReconversionProjectUseCase,
+      useFactory: (
+        dateProvider: IDateProvider,
+        siteRepository: SitesReadRepository,
+        reconversionProjectRepository: ReconversionProjectRepository,
+      ) =>
+        new CreateExpressReconversionProjectUseCase(
+          dateProvider,
+          siteRepository,
+          reconversionProjectRepository,
+        ),
+      inject: [DateProvider, SqlSitesReadRepository, SqlReconversionProjectRepository],
     },
     {
       provide: GetUserReconversionProjectsBySiteUseCase,
@@ -70,6 +87,7 @@ import { ReconversionProjectController } from "./reconversionProjects.controller
     SqlReconversionProjectRepository,
     SqlReconversionProjectsListRepository,
     SqlSiteWriteRepository,
+    SqlSitesReadRepository,
     SqlReconversionProjectImpactsRepository,
     SqlSiteImpactsRepository,
     DateProvider,

--- a/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository.ts
@@ -1,6 +1,9 @@
 import { Inject } from "@nestjs/common";
 import { Knex } from "knex";
-import { DevelopmentPlan } from "src/reconversion-projects/core/model/reconversionProject";
+import {
+  DevelopmentPlan,
+  PhotovoltaicPowerStationFeatures,
+} from "src/reconversion-projects/core/model/reconversionProject";
 import {
   ReconversionProjectImpactsDataView,
   ReconversionProjectImpactsRepository,
@@ -119,7 +122,7 @@ export class SqlReconversionProjectImpactsRepository
       expectedAnnualProduction: undefined,
       surfaceArea: undefined,
       electricalPowerKWc: undefined,
-    }) as DevelopmentPlan["features"];
+    }) as PhotovoltaicPowerStationFeatures;
     const developmentPlanExpectedAnnualEnergyProductionMWh =
       developmentPlanFeatures.expectedAnnualProduction;
     const developmentPlanSurfaceArea = developmentPlanFeatures.surfaceArea;

--- a/apps/api/src/reconversion-projects/core/model/createReconversionProjectFromSite.ts
+++ b/apps/api/src/reconversion-projects/core/model/createReconversionProjectFromSite.ts
@@ -1,0 +1,170 @@
+import { addYears } from "date-fns";
+import { IDateProvider } from "src/shared-kernel/adapters/date/IDateProvider";
+import { typedObjectEntries } from "src/shared-kernel/typedEntries";
+import { Address } from "src/sites/core/models/site";
+import { SoilsDistribution } from "src/soils/domain/soils";
+import { getSoilTypeForSpace, SpacesDistribution } from "./mixedUseNeighbourhood";
+import { ReconversionProject, reconversionProjectSchema, Schedule } from "./reconversionProject";
+
+type SiteData = {
+  id: string;
+  isFriche: boolean;
+  surfaceArea: number;
+  soilsDistribution: SoilsDistribution;
+  contaminatedSoilSurface?: number;
+  address: Address;
+};
+
+type Input = {
+  siteData: SiteData;
+  reconversionProjectId: string;
+  createdBy: string;
+};
+
+const computeRealEstateTransactionFromSiteSurfaceArea = (
+  surfaceArea: number,
+): { sellingPrice: number; propertyTransactionDuties: number } => {
+  const sellingPrice = surfaceArea * 72;
+  const propertyTransactionDuties = sellingPrice * 0.0581;
+  return { sellingPrice, propertyTransactionDuties };
+};
+
+const computeInstallationCostsFromSiteSurfaceArea = (
+  surfaceArea: number,
+): { technicalStudies: number; developmentWorks: number; other: number } => {
+  const technicalStudies = surfaceArea * 6;
+  const developmentWorks = surfaceArea * 54;
+  const other = (technicalStudies + developmentWorks) * 0.09;
+  return { technicalStudies, developmentWorks, other };
+};
+
+const computeReinstatementCostsFromSiteSoils = (
+  siteSoilsDistribution: SoilsDistribution,
+  contaminatedSoilSurface: number,
+) => {
+  const costs = [];
+
+  if (contaminatedSoilSurface > 0) {
+    costs.push({ amount: contaminatedSoilSurface * 0.75 * 66, purpose: "remediation" });
+  }
+
+  if (siteSoilsDistribution.BUILDINGS) {
+    costs.push({ amount: siteSoilsDistribution.BUILDINGS * 75, purpose: "demolition" });
+    costs.push({ amount: siteSoilsDistribution.BUILDINGS * 75, purpose: "absestos_removal" });
+  }
+
+  return costs;
+};
+
+const computeReinstatementSchedule = (dateProvider: IDateProvider): Schedule => {
+  const startDate = addYears(dateProvider.now(), 1);
+  const endDate = addYears(startDate, 1);
+  return { startDate, endDate };
+};
+
+const computeInstallationSchedule =
+  (dateProvider: IDateProvider) =>
+  (startFrom?: Date): Schedule => {
+    const startDate = startFrom ?? dateProvider.now();
+    const endDate = addYears(startDate, 1);
+    return { startDate, endDate };
+  };
+
+const computeOperationsFirstYear = (installationEndDate: Date): number => {
+  return installationEndDate.getFullYear();
+};
+
+const computeSpacesDistribution = (siteSurfaceArea: number): SpacesDistribution => {
+  return {
+    BUILDINGS_FOOTPRINT: 0.2 * siteSurfaceArea,
+    PRIVATE_PAVED_ALLEY_OR_PARKING_LOT: 0.05 * siteSurfaceArea,
+    PRIVATE_GRAVEL_ALLEY_OR_PARKING_LOT: 0.02 * siteSurfaceArea,
+    PRIVATE_GARDEN_AND_GRASS_ALLEYS: 0.37 * siteSurfaceArea,
+    PUBLIC_GREEN_SPACES: 0.19 * siteSurfaceArea,
+    PUBLIC_PARKING_LOT: 0.05 * siteSurfaceArea,
+    PUBLIC_PAVED_ROAD_OR_SQUARES_OR_SIDEWALKS: 0.04 * siteSurfaceArea,
+    PUBLIC_GRAVEL_ROAD_OR_SQUARES_OR_SIDEWALKS: 0.07 * siteSurfaceArea,
+    PUBLIC_GRASS_ROAD_OR_SQUARES_OR_SIDEWALKS: 0.01 * siteSurfaceArea,
+  };
+};
+
+const computeSoilsDistributionFromSpaces = (
+  spacesDistribution: SpacesDistribution,
+): SoilsDistribution => {
+  const soilsDistribution: SoilsDistribution = {};
+  typedObjectEntries(spacesDistribution).forEach(([space, surfaceArea]) => {
+    if (!surfaceArea) return;
+    const relatedSoilType = getSoilTypeForSpace(space);
+    const existingSurfaceArea = soilsDistribution[relatedSoilType];
+    soilsDistribution[relatedSoilType] = existingSurfaceArea
+      ? existingSurfaceArea + surfaceArea
+      : surfaceArea;
+  });
+  return soilsDistribution;
+};
+
+export class MixedUseNeighbourHoodReconversionProjectCreationService {
+  constructor(private readonly dateProvider: IDateProvider) {}
+
+  fromSiteData({ siteData, reconversionProjectId, createdBy }: Input): ReconversionProject {
+    const { sellingPrice, propertyTransactionDuties } =
+      computeRealEstateTransactionFromSiteSurfaceArea(siteData.surfaceArea);
+    const installationCosts = computeInstallationCostsFromSiteSurfaceArea(siteData.surfaceArea);
+    const reinstatementCosts = siteData.isFriche
+      ? computeReinstatementCostsFromSiteSoils(
+          siteData.soilsDistribution,
+          siteData.contaminatedSoilSurface ?? 0,
+        )
+      : undefined;
+    const reinstatementSchedule = computeReinstatementSchedule(this.dateProvider);
+    const installationSchedule = computeInstallationSchedule(this.dateProvider)(
+      reinstatementSchedule.endDate,
+    );
+    const spacesDistribution = computeSpacesDistribution(siteData.surfaceArea);
+    const soilsDistribution = computeSoilsDistributionFromSpaces(spacesDistribution);
+
+    const reconversionProject: ReconversionProject = {
+      id: reconversionProjectId,
+      createdBy,
+      createdAt: this.dateProvider.now(),
+      projectPhase: "planning",
+      soilsDistribution,
+      yearlyProjectedCosts: [],
+      yearlyProjectedRevenues: [],
+      name: "Quartir mixte",
+      relatedSiteId: siteData.id,
+      reinstatementCosts,
+      reinstatementSchedule,
+      operationsFirstYear: computeOperationsFirstYear(installationSchedule.endDate),
+      futureSiteOwner: {
+        name: siteData.address.city,
+        structureType: "local_or_regional_authority",
+      },
+      developmentPlan: {
+        developer: {
+          name: siteData.address.city,
+          structureType: "local_or_regional_authority",
+        },
+        features: {
+          spacesDistribution,
+          buildingsFloorAreaDistribution: {
+            RESIDENTIAL: 0.92 * 0.2 * siteData.surfaceArea,
+            GROUND_FLOOR_RETAIL: 0.08 * 0.2 * siteData.surfaceArea,
+          },
+        },
+        installationSchedule,
+        type: "MIXED_USE_NEIGHBOURHOOD",
+        costs: [
+          { amount: installationCosts.technicalStudies, purpose: "technical_studies" },
+          { amount: installationCosts.developmentWorks, purpose: "development_works" },
+          { amount: installationCosts.other, purpose: "other" },
+        ],
+      },
+      realEstateTransactionSellingPrice: sellingPrice,
+      realEstateTransactionPropertyTransferDuties: propertyTransactionDuties,
+    };
+    const parsed = reconversionProjectSchema.parse(reconversionProject);
+
+    return parsed;
+  }
+}

--- a/apps/api/src/reconversion-projects/core/model/mixedUseNeighbourhood.ts
+++ b/apps/api/src/reconversion-projects/core/model/mixedUseNeighbourhood.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { SoilType } from "src/soils/domain/soils";
+
+const mixedUseNeighbourHoodSpaceSchema = z.record(
+  z.enum([
+    // private spaces
+    "BUILDINGS_FOOTPRINT", // emprise au sol bâti = surface occupée au sol par les bâtiments
+    "PRIVATE_PAVED_ALLEY_OR_PARKING_LOT",
+    "PRIVATE_GRAVEL_ALLEY_OR_PARKING_LOT",
+    "PRIVATE_GARDEN_AND_GRASS_ALLEYS",
+    // public spaces
+    "PUBLIC_GREEN_SPACES",
+    "PUBLIC_PAVED_ROAD_OR_SQUARES_OR_SIDEWALKS",
+    "PUBLIC_GRAVEL_ROAD_OR_SQUARES_OR_SIDEWALKS",
+    "PUBLIC_GRASS_ROAD_OR_SQUARES_OR_SIDEWALKS",
+    "PUBLIC_PARKING_LOT",
+  ]),
+  z.number().nonnegative(),
+);
+
+export type SpacesDistribution = z.infer<typeof mixedUseNeighbourHoodSpaceSchema>;
+type Space = keyof SpacesDistribution;
+
+export const getSoilTypeForSpace = (space: Space): SoilType => {
+  switch (space) {
+    case "BUILDINGS_FOOTPRINT":
+      return "BUILDINGS";
+    case "PUBLIC_PARKING_LOT":
+    case "PRIVATE_PAVED_ALLEY_OR_PARKING_LOT":
+    case "PUBLIC_PAVED_ROAD_OR_SQUARES_OR_SIDEWALKS":
+      return "IMPERMEABLE_SOILS";
+    case "PRIVATE_GARDEN_AND_GRASS_ALLEYS":
+    case "PUBLIC_GRASS_ROAD_OR_SQUARES_OR_SIDEWALKS":
+      return "ARTIFICIAL_GRASS_OR_BUSHES_FILLED";
+    case "PRIVATE_GRAVEL_ALLEY_OR_PARKING_LOT":
+    case "PUBLIC_GRAVEL_ROAD_OR_SQUARES_OR_SIDEWALKS":
+      return "MINERAL_SOIL";
+    case "PUBLIC_GREEN_SPACES":
+      return "ARTIFICIAL_TREE_FILLED";
+  }
+};
+
+const buildingsFloorAreaUsageDistribution = z.record(
+  z.enum(["RESIDENTIAL", "GROUND_FLOOR_RETAIL"]),
+  z.number().nonnegative(),
+);
+
+export const mixedUseNeighbourhoodFeaturesSchema = z.object({
+  spacesDistribution: mixedUseNeighbourHoodSpaceSchema,
+  buildingsFloorAreaDistribution: buildingsFloorAreaUsageDistribution,
+});
+
+export type MixedUseNeighbourhoodFeatures = z.infer<typeof mixedUseNeighbourhoodFeaturesSchema>;

--- a/apps/api/src/reconversion-projects/core/model/reconversionProject.ts
+++ b/apps/api/src/reconversion-projects/core/model/reconversionProject.ts
@@ -1,6 +1,7 @@
 import { differenceInDays } from "date-fns";
 import { z } from "zod";
 import { soilTypeSchema } from "src/soils/domain/soils";
+import { mixedUseNeighbourhoodFeaturesSchema } from "./mixedUseNeighbourhood";
 
 export const photovoltaicPowerStationFeaturesSchema = z.object({
   surfaceArea: z.number().nonnegative(),
@@ -8,6 +9,10 @@ export const photovoltaicPowerStationFeaturesSchema = z.object({
   expectedAnnualProduction: z.number().nonnegative(),
   contractDuration: z.number().nonnegative(),
 });
+
+export type PhotovoltaicPowerStationFeatures = z.infer<
+  typeof photovoltaicPowerStationFeaturesSchema
+>;
 
 export const costSchema = z.object({ purpose: z.string(), amount: z.number().nonnegative() });
 const revenueSchema = z.object({ source: z.string(), amount: z.number().nonnegative() });
@@ -19,8 +24,10 @@ const scheduleSchema = z.object({
 
 export type Schedule = z.infer<typeof scheduleSchema>;
 
+const developmentPlanType = z.enum(["PHOTOVOLTAIC_POWER_PLANT", "MIXED_USE_NEIGHBOURHOOD"]);
+
 const baseDevelopmentPlanSchema = z.object({
-  type: z.string(),
+  type: developmentPlanType,
   developer: z.object({ name: z.string(), structureType: z.string() }),
   costs: costSchema.array(),
   installationSchedule: scheduleSchema.optional(),
@@ -30,6 +37,10 @@ const developmentPlanSchema = z.discriminatedUnion("type", [
   baseDevelopmentPlanSchema.extend({
     type: z.literal("PHOTOVOLTAIC_POWER_PLANT"),
     features: photovoltaicPowerStationFeaturesSchema,
+  }),
+  baseDevelopmentPlanSchema.extend({
+    type: z.literal("MIXED_USE_NEIGHBOURHOOD"),
+    features: mixedUseNeighbourhoodFeaturesSchema,
   }),
 ]);
 

--- a/apps/api/src/reconversion-projects/core/usecases/createExpressReconversionProject.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/createExpressReconversionProject.usecase.spec.ts
@@ -1,0 +1,385 @@
+import { v4 as uuid } from "uuid";
+import { InMemoryReconversionProjectRepository } from "src/reconversion-projects/adapters/secondary/reconversion-project-repository/InMemoryReconversionProjectRepository";
+import { DeterministicDateProvider } from "src/shared-kernel/adapters/date/DeterministicDateProvider";
+import { InMemorySiteReadRepository } from "src/sites/adapters/secondary/site-repository/read/InMemorySiteReadRepository";
+import { SoilsDistribution } from "src/soils/domain/soils";
+import { MixedUseNeighbourhoodFeatures, SpacesDistribution } from "../model/mixedUseNeighbourhood";
+import { ReconversionProject } from "../model/reconversionProject";
+import {
+  CreateExpressReconversionProjectUseCase,
+  DateProvider,
+} from "./createExpressReconversionProject.usecase";
+
+describe("CreateReconversionProject Use Case", () => {
+  let dateProvider: DateProvider;
+  let siteRepository: InMemorySiteReadRepository;
+  let reconversionProjectRepository: InMemoryReconversionProjectRepository;
+  const fakeNow = new Date("2024-01-05T13:00:00");
+
+  beforeEach(() => {
+    dateProvider = new DeterministicDateProvider(fakeNow);
+    siteRepository = new InMemorySiteReadRepository();
+    reconversionProjectRepository = new InMemoryReconversionProjectRepository();
+  });
+
+  describe("Error cases", () => {
+    it("cannot create an express reconversion project with a non-existing site", async () => {
+      const usecase = new CreateExpressReconversionProjectUseCase(
+        dateProvider,
+        siteRepository,
+        reconversionProjectRepository,
+      );
+
+      const siteId = uuid();
+      await expect(
+        usecase.execute({ reconversionProjectId: uuid(), siteId, createdBy: uuid() }),
+      ).rejects.toThrow(`Site with id ${siteId} does not exist`);
+    });
+  });
+
+  describe("Success cases", () => {
+    describe("Mixed-use neighbourhood", () => {
+      describe("On friche site", () => {
+        const site = {
+          id: uuid(),
+          name: "Base site",
+          isFriche: true,
+          surfaceArea: 10000,
+          soilsDistribution: {
+            ARTIFICIAL_GRASS_OR_BUSHES_FILLED: 5000,
+            IMPERMEABLE_SOILS: 3000,
+            MINERAL_SOIL: 2000,
+          },
+          contaminatedSoilSurface: 0,
+          owner: {
+            name: "Mairie de Montrouge",
+            structureType: "local_authority",
+          },
+          address: {
+            city: "Montrouge",
+            postalCode: "12345",
+            street: "Avenue Pierre Brossolette",
+            streetNumber: "155bis",
+            value: "155 bis Av. Pierre Brossolette, 92120 Montrouge",
+            banId: "92049_7161_00155_bis",
+            cityCode: "92049",
+            postCode: "92120",
+            long: 2.305116,
+            lat: 48.815679,
+          },
+          yearlyExpenses: [],
+        };
+
+        beforeEach(() => {
+          siteRepository._setSites([site]);
+        });
+
+        it("should create a mixed-use neighbourhood project with default name, given related site id, createdBy and createdAt", async () => {
+          const usecase = new CreateExpressReconversionProjectUseCase(
+            dateProvider,
+            siteRepository,
+            reconversionProjectRepository,
+          );
+
+          const reconversionProjectId = uuid();
+          const creatorId = uuid();
+          await usecase.execute({ reconversionProjectId, siteId: site.id, createdBy: creatorId });
+
+          const createdReconversionProjects: ReconversionProject[] =
+            reconversionProjectRepository._getReconversionProjects();
+          expect(createdReconversionProjects).toHaveLength(1);
+          const createdReconversionProject = createdReconversionProjects[0];
+          expect(createdReconversionProject?.name).toEqual("Quartir mixte");
+          expect(createdReconversionProject?.relatedSiteId).toEqual(site.id);
+          expect(createdReconversionProject?.createdBy).toEqual(creatorId);
+          expect(createdReconversionProject?.createdAt).toEqual(dateProvider.now());
+        });
+
+        it("should create a mixed-use neighbourhood project with reinstatement scheduled 1 year after current date, installation works 1 year after reinstatement and first operations 1 year after", async () => {
+          dateProvider = new DeterministicDateProvider(new Date("2024-09-01T13:00:00"));
+
+          const usecase = new CreateExpressReconversionProjectUseCase(
+            dateProvider,
+            siteRepository,
+            reconversionProjectRepository,
+          );
+
+          const reconversionProjectId = uuid();
+          const creatorId = uuid();
+          await usecase.execute({ reconversionProjectId, siteId: site.id, createdBy: creatorId });
+
+          const createdReconversionProjects: ReconversionProject[] =
+            reconversionProjectRepository._getReconversionProjects();
+          expect(createdReconversionProjects).toHaveLength(1);
+          const createdReconversionProject = createdReconversionProjects[0];
+          expect(createdReconversionProject?.reinstatementSchedule).toEqual({
+            startDate: new Date("2025-09-01T13:00:00"),
+            endDate: new Date("2026-09-01T13:00:00"),
+          });
+          expect(createdReconversionProject?.developmentPlan.installationSchedule).toEqual({
+            startDate: new Date("2026-09-01T13:00:00"),
+            endDate: new Date("2027-09-01T13:00:00"),
+          });
+          expect(createdReconversionProject?.operationsFirstYear).toEqual(2027);
+        });
+
+        it("should create a mixed-use neighbourhood project with site city as developer and owner", async () => {
+          const usecase = new CreateExpressReconversionProjectUseCase(
+            dateProvider,
+            siteRepository,
+            reconversionProjectRepository,
+          );
+
+          const reconversionProjectId = uuid();
+          const creatorId = uuid();
+          await usecase.execute({ reconversionProjectId, siteId: site.id, createdBy: creatorId });
+
+          const createdReconversionProjects: ReconversionProject[] =
+            reconversionProjectRepository._getReconversionProjects();
+          expect(createdReconversionProjects).toHaveLength(1);
+          const createdReconversionProject = createdReconversionProjects[0];
+          expect(createdReconversionProject?.futureSiteOwner).toEqual({
+            structureType: "local_or_regional_authority",
+            name: "Montrouge",
+          });
+          expect(createdReconversionProject?.developmentPlan.developer).toEqual({
+            structureType: "local_or_regional_authority",
+            name: "Montrouge",
+          });
+        });
+
+        it("should create a mixed-use neighbourhood project with right spaces, buildings floor area and soils distribution", async () => {
+          const usecase = new CreateExpressReconversionProjectUseCase(
+            dateProvider,
+            siteRepository,
+            reconversionProjectRepository,
+          );
+
+          const reconversionProjectId = uuid();
+          const creatorId = uuid();
+          await usecase.execute({ reconversionProjectId, siteId: site.id, createdBy: creatorId });
+
+          const expectedSpacesDistribution = {
+            BUILDINGS_FOOTPRINT: 0.2 * site.surfaceArea,
+            PRIVATE_PAVED_ALLEY_OR_PARKING_LOT: 0.05 * site.surfaceArea,
+            PRIVATE_GRAVEL_ALLEY_OR_PARKING_LOT: 0.02 * site.surfaceArea,
+            PRIVATE_GARDEN_AND_GRASS_ALLEYS: 0.37 * site.surfaceArea,
+            PUBLIC_GREEN_SPACES: 0.19 * site.surfaceArea,
+            PUBLIC_PARKING_LOT: 0.05 * site.surfaceArea,
+            PUBLIC_PAVED_ROAD_OR_SQUARES_OR_SIDEWALKS: 0.04 * site.surfaceArea,
+            PUBLIC_GRAVEL_ROAD_OR_SQUARES_OR_SIDEWALKS: 0.07 * site.surfaceArea,
+            PUBLIC_GRASS_ROAD_OR_SQUARES_OR_SIDEWALKS: 0.01 * site.surfaceArea,
+          } as const satisfies SpacesDistribution;
+
+          const expectedBuildingsFloorAreaDistribution = {
+            RESIDENTIAL: 0.92 * 0.2 * site.surfaceArea,
+            GROUND_FLOOR_RETAIL: 0.08 * 0.2 * site.surfaceArea,
+          };
+
+          const expectedSoilsDistribution: SoilsDistribution = {
+            BUILDINGS: expectedSpacesDistribution.BUILDINGS_FOOTPRINT,
+            ARTIFICIAL_TREE_FILLED: expectedSpacesDistribution.PUBLIC_GREEN_SPACES,
+            ARTIFICIAL_GRASS_OR_BUSHES_FILLED:
+              expectedSpacesDistribution.PRIVATE_GARDEN_AND_GRASS_ALLEYS +
+              expectedSpacesDistribution.PUBLIC_GRASS_ROAD_OR_SQUARES_OR_SIDEWALKS,
+            IMPERMEABLE_SOILS:
+              expectedSpacesDistribution.PUBLIC_PARKING_LOT +
+              expectedSpacesDistribution.PRIVATE_PAVED_ALLEY_OR_PARKING_LOT +
+              expectedSpacesDistribution.PUBLIC_PAVED_ROAD_OR_SQUARES_OR_SIDEWALKS,
+            MINERAL_SOIL:
+              expectedSpacesDistribution.PRIVATE_GRAVEL_ALLEY_OR_PARKING_LOT +
+              expectedSpacesDistribution.PUBLIC_GRAVEL_ROAD_OR_SQUARES_OR_SIDEWALKS,
+          };
+
+          const createdReconversionProjects: ReconversionProject[] =
+            reconversionProjectRepository._getReconversionProjects();
+          expect(createdReconversionProjects).toHaveLength(1);
+          const createdReconversionProject = createdReconversionProjects[0];
+          expect(createdReconversionProject?.developmentPlan.type).toEqual(
+            "MIXED_USE_NEIGHBOURHOOD",
+          );
+          expect(
+            (createdReconversionProject?.developmentPlan.features as MixedUseNeighbourhoodFeatures)
+              .spacesDistribution,
+          ).toEqual(expectedSpacesDistribution);
+          expect(
+            (createdReconversionProject?.developmentPlan.features as MixedUseNeighbourhoodFeatures)
+              .buildingsFloorAreaDistribution,
+          ).toEqual(expectedBuildingsFloorAreaDistribution);
+          expect(createdReconversionProject?.soilsDistribution).toEqual(expectedSoilsDistribution);
+        });
+
+        describe("with non-polluted soils and no buildings", () => {
+          const nonPollutedFricheWithNoBuildings = {
+            ...site,
+            contaminatedSoilSurface: 0,
+          };
+          it("should create a mixed-use neighbourhood with reinstatement costs, real estate sale transaction and development installation costs", async () => {
+            siteRepository._setSites([nonPollutedFricheWithNoBuildings]);
+
+            const usecase = new CreateExpressReconversionProjectUseCase(
+              dateProvider,
+              siteRepository,
+              reconversionProjectRepository,
+            );
+
+            const reconversionProjectId = uuid();
+            const creatorId = uuid();
+            await usecase.execute({
+              reconversionProjectId,
+              siteId: nonPollutedFricheWithNoBuildings.id,
+              createdBy: creatorId,
+            });
+
+            const createdReconversionProjects: ReconversionProject[] =
+              reconversionProjectRepository._getReconversionProjects();
+            expect(createdReconversionProjects).toHaveLength(1);
+            const createdReconversionProject = createdReconversionProjects[0];
+            // real estate sale transaction
+            expect(createdReconversionProject?.realEstateTransactionSellingPrice).toEqual(720000);
+            expect(createdReconversionProject?.realEstateTransactionPropertyTransferDuties).toEqual(
+              41832,
+            );
+            // development installation cost
+            expect(createdReconversionProject?.developmentPlan.costs).toEqual([
+              { purpose: "technical_studies", amount: 60000 },
+              { purpose: "development_works", amount: 540000 },
+              { purpose: "other", amount: 54000 },
+            ]);
+            // reinstatement costs
+            expect(createdReconversionProject?.reinstatementCosts).toEqual([]);
+          });
+        });
+        describe("with polluted soils and buildings", () => {
+          const pollutedFricheWithBuildings = {
+            ...site,
+            surfaceArea: 100000,
+            name: "Base site with polluted soils and buildings",
+            soilsDistribution: {
+              BUILDINGS: 50000,
+              IMPERMEABLE_SOILS: 30000,
+              MINERAL_SOIL: 20000,
+            },
+            contaminatedSoilSurface: 50000,
+          };
+          it("should create a mixed-use neighbourhood with reinstatement costs, real estate sale transaction and development installation costs based on site data", async () => {
+            siteRepository._setSites([pollutedFricheWithBuildings]);
+
+            const usecase = new CreateExpressReconversionProjectUseCase(
+              dateProvider,
+              siteRepository,
+              reconversionProjectRepository,
+            );
+
+            const reconversionProjectId = uuid();
+            const creatorId = uuid();
+            await usecase.execute({
+              reconversionProjectId,
+              siteId: pollutedFricheWithBuildings.id,
+              createdBy: creatorId,
+            });
+
+            const createdReconversionProjects: ReconversionProject[] =
+              reconversionProjectRepository._getReconversionProjects();
+            expect(createdReconversionProjects).toHaveLength(1);
+            const createdReconversionProject = createdReconversionProjects[0];
+            // real estate sale transaction
+            expect(createdReconversionProject?.realEstateTransactionSellingPrice).toEqual(7200000);
+            expect(createdReconversionProject?.realEstateTransactionPropertyTransferDuties).toEqual(
+              418320,
+            );
+            // development installation cost
+            expect(createdReconversionProject?.developmentPlan.costs).toEqual([
+              { purpose: "technical_studies", amount: 600000 },
+              { purpose: "development_works", amount: 5400000 },
+              { purpose: "other", amount: 540000 },
+            ]);
+            // reinstatement costs
+            expect(createdReconversionProject?.reinstatementCosts).toHaveLength(3);
+            expect(createdReconversionProject?.reinstatementCosts).toContainEqual({
+              purpose: "absestos_removal",
+              amount: 3750000,
+            });
+            expect(createdReconversionProject?.reinstatementCosts).toContainEqual({
+              purpose: "demolition",
+              amount: 3750000,
+            });
+            expect(createdReconversionProject?.reinstatementCosts).toContainEqual({
+              purpose: "remediation",
+              amount: 2475000,
+            });
+          });
+        });
+      });
+      describe("On non-friche site", () => {
+        describe("with polluted soils and buildings", () => {
+          const site = {
+            id: uuid(),
+            name: "Base site",
+            isFriche: false,
+            surfaceArea: 50000,
+            soilsDistribution: {
+              PRAIRIE_GRASS: 30000,
+              FOREST_MIXED: 18900,
+              WATER: 600,
+              MINERAL_SOIL: 500,
+            },
+            contaminatedSoilSurface: 0,
+            owner: {
+              name: "Monsieur Dupont",
+              structureType: "private_individual",
+            },
+            address: {
+              city: "Montrouge",
+              postalCode: "12345",
+              street: "Avenue Pierre Brossolette",
+              streetNumber: "155bis",
+              value: "155 bis Av. Pierre Brossolette, 92120 Montrouge",
+              banId: "92049_7161_00155_bis",
+              cityCode: "92049",
+              postCode: "92120",
+              long: 2.305116,
+              lat: 48.815679,
+            },
+            yearlyExpenses: [],
+          };
+          it("should create a mixed-use neighbourhood with real estate sale transaction and development installation costs based on site", async () => {
+            siteRepository._setSites([site]);
+
+            const usecase = new CreateExpressReconversionProjectUseCase(
+              dateProvider,
+              siteRepository,
+              reconversionProjectRepository,
+            );
+
+            const reconversionProjectId = uuid();
+            const creatorId = uuid();
+            await usecase.execute({
+              reconversionProjectId,
+              siteId: site.id,
+              createdBy: creatorId,
+            });
+
+            const createdReconversionProjects: ReconversionProject[] =
+              reconversionProjectRepository._getReconversionProjects();
+            expect(createdReconversionProjects).toHaveLength(1);
+            const createdReconversionProject = createdReconversionProjects[0];
+            // real estate sale transaction
+            expect(createdReconversionProject?.realEstateTransactionSellingPrice).toEqual(3600000);
+            expect(createdReconversionProject?.realEstateTransactionPropertyTransferDuties).toEqual(
+              209160,
+            );
+            // development installation cost
+            expect(createdReconversionProject?.developmentPlan.costs).toEqual([
+              { purpose: "technical_studies", amount: 300000 },
+              { purpose: "development_works", amount: 2700000 },
+              { purpose: "other", amount: 270000 },
+            ]);
+            // reinstatement costs
+            expect(createdReconversionProject?.reinstatementCosts).toEqual(undefined);
+          });
+        });
+      });
+    });
+  });
+});

--- a/apps/api/src/reconversion-projects/core/usecases/createExpressReconversionProject.usecase.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/createExpressReconversionProject.usecase.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { UseCase } from "src/shared-kernel/usecase";
+import { Address } from "src/sites/core/models/site";
+import { SoilsDistribution } from "src/soils/domain/soils";
+import { MixedUseNeighbourHoodReconversionProjectCreationService } from "../model/createReconversionProjectFromSite";
+import { ReconversionProject, reconversionProjectSchema } from "../model/reconversionProject";
+
+export type SiteView = {
+  id: string;
+  isFriche: boolean;
+  surfaceArea: number;
+  soilsDistribution: SoilsDistribution;
+  contaminatedSoilSurface?: number;
+  address: Address;
+};
+
+export interface SiteRepository {
+  getById(id: string): Promise<SiteView | undefined>;
+}
+export interface ReconversionProjectRepository {
+  existsWithId(id: string): Promise<boolean>;
+  save(reconversionProject: ReconversionProject): Promise<void>;
+}
+
+export interface DateProvider {
+  now(): Date;
+}
+
+export const reconversionProjectPropsSchema = reconversionProjectSchema.omit({ createdAt: true });
+export type ReconversionProjectProps = z.infer<typeof reconversionProjectPropsSchema>;
+
+type Request = {
+  reconversionProjectId: string;
+  siteId: string;
+  createdBy: string;
+};
+
+export class CreateExpressReconversionProjectUseCase implements UseCase<Request, void> {
+  constructor(
+    private readonly dateProvider: DateProvider,
+    private readonly siteRepository: SiteRepository,
+    private readonly reconversionProjectRepository: ReconversionProjectRepository,
+  ) {}
+
+  async execute(props: Request): Promise<void> {
+    const siteData = await this.siteRepository.getById(props.siteId);
+    if (!siteData) {
+      throw new Error(`Site with id ${props.siteId} does not exist`);
+    }
+
+    const creationService = new MixedUseNeighbourHoodReconversionProjectCreationService(
+      this.dateProvider,
+    );
+    const reconversionProject = creationService.fromSiteData({
+      createdBy: props.createdBy,
+      reconversionProjectId: props.reconversionProjectId,
+      siteData,
+    });
+
+    await this.reconversionProjectRepository.save(reconversionProject);
+  }
+}


### PR DESCRIPTION
J'ai isolé la logique de création avec les valeurs en dur dans un service `MixedUseNeighbourHoodReconversionProjectCreationService`, le reste n'est pas très intéressant.

Par rapport aux données du tableur il manque les coûts de désimperméabilisation et de réstauration écologique des sols ainsi que les recettes.
Je m'en occupe dans un deuxième temps pour que tu puisses t'appuyer sur la base.