### PR TITLE
feat (web) : update identity form to specify local authority

### DIFF
--- a/apps/web/src/features/create-project/application/stakeholders.selector.spec.ts
+++ b/apps/web/src/features/create-project/application/stakeholders.selector.spec.ts
@@ -123,7 +123,7 @@ describe("Project Stakeholders selector", () => {
       expect(stakeholders).toContainEqual(
         expect.objectContaining({
           name: USER.structureName,
-          role: "user_company",
+          role: "user_structure",
           structureType: USER.structureType,
         }),
       );
@@ -180,7 +180,7 @@ describe("Project Stakeholders selector", () => {
       expect(stakeholders).not.toContainEqual(
         expect.objectContaining({
           name: USER.structureName,
-          role: "user_company",
+          role: "user_structure",
           structureType: USER.structureType,
         }),
       );
@@ -215,7 +215,7 @@ describe("Project Stakeholders selector", () => {
       expect(stakeholders).toContainEqual(
         expect.objectContaining({
           name: USER.structureName,
-          role: "user_company",
+          role: "user_structure",
           structureType: USER.structureType,
         }),
       );
@@ -261,7 +261,7 @@ describe("Project Stakeholders selector", () => {
       expect(stakeholders).toContainEqual(
         expect.objectContaining({
           name: USER.structureName,
-          role: "user_company",
+          role: "user_structure",
           structureType: USER.structureType,
         }),
       );
@@ -291,19 +291,20 @@ describe("Project Stakeholders selector", () => {
           projectData: {
             ...projectWithMinimalData,
             projectDeveloper: {
-              name: "Métropole",
+              name: "Grenoble-Alpes-Métropole",
               structureType: "epci",
             },
             futureOperator: {
-              name: "Région",
+              name: "Région Auvergne-Rhône-Alpes",
               structureType: "region",
             },
             futureSiteOwner: {
-              name: "Future site owner",
+              name: "Département Isère",
               structureType: "department",
             },
           },
         },
+        MOCK_STATES.currentUser,
       );
 
       expect(localAuthorities).toEqual([]);
@@ -316,6 +317,7 @@ describe("Project Stakeholders selector", () => {
           ...MOCK_STATES.projectCreation,
           siteData: { ...siteData, owner: { structureType: "company", name: "" } },
         } as ProjectCreationState,
+        MOCK_STATES.currentUser,
       );
 
       expect(localAuthorities).toEqual([
@@ -333,9 +335,11 @@ describe("Project Stakeholders selector", () => {
           localAuthorities: undefined,
         },
         MOCK_STATES.projectCreation,
+        MOCK_STATES.currentUser,
       );
 
       expect(localAuthorities).toEqual([
+        { type: "municipality", name: "Mairie" },
         { type: "epci", name: "Établissement public de coopération intercommunale" },
         { type: "department", name: "Département" },
         { type: "region", name: "Région" },
@@ -360,10 +364,54 @@ describe("Project Stakeholders selector", () => {
           },
         },
         MOCK_STATES.projectCreation,
+        MOCK_STATES.currentUser,
       );
 
       expect(localAuthoritiesWithNoEpci).toEqual([
         { type: "epci", name: "Établissement public de coopération intercommunale" },
+        { type: "department", name: "Département Isère" },
+        { type: "region", name: "Région Auvergne-Rhône-Alpes" },
+      ]);
+    });
+
+    it("should return local authorities without current user if it is local_authority", () => {
+      const localAuthorities = getAvailableLocalAuthoritiesStakeholders.resultFunc(
+        MOCK_STATES.projectSiteLocalAuthorities,
+        MOCK_STATES.projectCreation,
+        {
+          ...MOCK_STATES.currentUser,
+          currentUser: {
+            ...MOCK_STATES.currentUser.currentUser,
+            structureActivity: "department",
+            structureType: "local_authority",
+            structureName: "Département Isère",
+          },
+        },
+      );
+
+      expect(localAuthorities).toEqual([
+        { type: "epci", name: "Grenoble-Alpes-Métropole" },
+        { type: "region", name: "Région Auvergne-Rhône-Alpes" },
+      ]);
+    });
+
+    it("should return local authorities with current user if it is local_authority but not related to the site address", () => {
+      const localAuthorities = getAvailableLocalAuthoritiesStakeholders.resultFunc(
+        MOCK_STATES.projectSiteLocalAuthorities,
+        MOCK_STATES.projectCreation,
+        {
+          ...MOCK_STATES.currentUser,
+          currentUser: {
+            ...MOCK_STATES.currentUser.currentUser,
+            structureActivity: "department",
+            structureType: "local_authority",
+            structureName: "Département Rhône",
+          },
+        },
+      );
+
+      expect(localAuthorities).toEqual([
+        { type: "epci", name: "Grenoble-Alpes-Métropole" },
         { type: "department", name: "Département Isère" },
         { type: "region", name: "Région Auvergne-Rhône-Alpes" },
       ]);

--- a/apps/web/src/features/create-project/views/stakeholders/developer/ProjectDeveloperForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/developer/ProjectDeveloperForm.tsx
@@ -33,7 +33,7 @@ export type FormValues =
       localAuthority: undefined;
     }
   | {
-      stakeholder: "user_company" | "site_tenant" | "site_owner" | "unknown";
+      stakeholder: "user_structure" | "site_tenant" | "site_owner" | "unknown";
       localAuthority: undefined;
       otherStructureName: undefined;
     };
@@ -77,7 +77,7 @@ function DeveloperForm({
         >
           {availableStakeholdersList.map(({ name, role }) => (
             <RadioButton
-              label={role === "user_company" ? `Ma structure, ${name}` : name}
+              label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
               {...register("stakeholder", { required: requiredMessage })}

--- a/apps/web/src/features/create-project/views/stakeholders/developer/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/developer/index.tsx
@@ -23,7 +23,7 @@ const convertFormValuesForStore = (
   switch (data.stakeholder) {
     case "site_tenant":
     case "site_owner":
-    case "user_company": {
+    case "user_structure": {
       const stakeholder = stakeholdersList.find(
         ({ role }) => role === data.stakeholder,
       ) as AvailableProjectStakeholder;

--- a/apps/web/src/features/create-project/views/stakeholders/future-site-owner/FutureSiteOwnerForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/future-site-owner/FutureSiteOwnerForm.tsx
@@ -33,7 +33,7 @@ export type FormValues =
     }
   | {
       stakeholder:
-        | "user_company"
+        | "user_structure"
         | "site_tenant"
         | "site_owner"
         | "project_developer"
@@ -69,7 +69,7 @@ function FutureSiteOwnerForm({
         >
           {availableStakeholdersList.map(({ name, role }) => (
             <RadioButton
-              label={role === "user_company" ? `Ma structure, ${name}` : name}
+              label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
               {...register("stakeholder", { required: requiredMessage })}

--- a/apps/web/src/features/create-project/views/stakeholders/future-site-owner/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/future-site-owner/index.tsx
@@ -26,7 +26,7 @@ const convertFormValuesForStore = (
     case "project_developer":
     case "future_site_operator":
     case "reinstatement_contract_owner":
-    case "user_company": {
+    case "user_structure": {
       const stakeholder = stakeholdersList.find(
         ({ role }) => role === data.stakeholder,
       ) as AvailableProjectStakeholder;

--- a/apps/web/src/features/create-project/views/stakeholders/operator/SiteOperatorForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/operator/SiteOperatorForm.tsx
@@ -32,7 +32,12 @@ export type FormValues =
       localAuthority: undefined;
     }
   | {
-      stakeholder: "user_company" | "site_tenant" | "site_owner" | "project_developer" | "unknown";
+      stakeholder:
+        | "user_structure"
+        | "site_tenant"
+        | "site_owner"
+        | "project_developer"
+        | "unknown";
       localAuthority: undefined;
       otherStructureName: undefined;
     };
@@ -62,7 +67,7 @@ function SiteOperatorForm({
         >
           {availableStakeholdersList.map(({ name, role }) => (
             <RadioButton
-              label={role === "user_company" ? `Ma structure, ${name}` : name}
+              label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
               {...register("stakeholder", { required: requiredMessage })}

--- a/apps/web/src/features/create-project/views/stakeholders/operator/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/operator/index.tsx
@@ -24,7 +24,7 @@ const convertFormValuesForStore = (
     case "site_tenant":
     case "site_owner":
     case "project_developer":
-    case "user_company": {
+    case "user_structure": {
       const stakeholder = stakeholdersList.find(
         ({ role }) => role === data.stakeholder,
       ) as AvailableProjectStakeholder;

--- a/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/SiteReinstatementContractOwnerForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/SiteReinstatementContractOwnerForm.tsx
@@ -34,7 +34,7 @@ export type FormValues =
     }
   | {
       stakeholder:
-        | "user_company"
+        | "user_structure"
         | "site_tenant"
         | "site_owner"
         | "project_developer"
@@ -79,7 +79,7 @@ function SiteReinstatementContractOwnerForm({
         >
           {availableStakeholdersList.map(({ name, role }) => (
             <RadioButton
-              label={role === "user_company" ? `Ma structure, ${name}` : name}
+              label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
               {...register("stakeholder", { required: requiredMessage })}

--- a/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/index.tsx
@@ -27,7 +27,7 @@ const convertFormValuesForStore = (
     case "site_owner":
     case "project_developer":
     case "future_site_operator":
-    case "user_company": {
+    case "user_structure": {
       const stakeholder = stakeholdersList.find(
         ({ role }) => role === data.stakeholder,
       ) as AvailableProjectStakeholder;

--- a/apps/web/src/features/create-site/views/site-management/owner/SiteOwnerForm.tsx
+++ b/apps/web/src/features/create-site/views/site-management/owner/SiteOwnerForm.tsx
@@ -2,28 +2,26 @@ import { useForm } from "react-hook-form";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/SelectNext";
 
-import { LoadingState } from "@/features/create-site/application/siteMunicipalityData.reducer";
+import { UserStructure } from "@/features/users/domain/user";
 import { LocalAutorityStructureType } from "@/shared/domain/stakeholder";
-import formatLocalAuthorityName from "@/shared/services/strings/formatLocalAuthorityName";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import Fieldset from "@/shared/views/components/form/Fieldset/Fieldset";
 import RadioButton from "@/shared/views/components/form/RadioButton/RadioButton";
 import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
-import LoadingSpinner from "@/shared/views/components/Spinner/LoadingSpinner";
+import TooltipInfoButton from "@/shared/views/components/TooltipInfoButton/TooltipInfoButton";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
   onSubmit: (data: FormValues) => void;
   onBack: () => void;
-  currentUserStructureName?: string;
+  currentUserStructure?: UserStructure;
   localAuthoritiesList: { type: "municipality" | "epci" | "region" | "department"; name: string }[];
-  localAuthoritiesLoadingState: LoadingState;
   isFriche: boolean;
 };
 
 export type FormValues =
   | {
-      ownerType: "user_company";
+      ownerType: "user_structure";
       localAuthority: undefined;
       ownerName: undefined;
     }
@@ -43,8 +41,7 @@ const requiredMessage = "Ce champ requis pour la suite du formulaire";
 function SiteOwnerForm({
   onSubmit,
   onBack,
-  currentUserStructureName,
-  localAuthoritiesLoadingState,
+  currentUserStructure,
   localAuthoritiesList,
   isFriche,
 }: Props) {
@@ -66,48 +63,55 @@ function SiteOwnerForm({
             formState.errors.ownerType ? formState.errors.ownerType.message : undefined
           }
         >
-          <RadioButton
-            label="Une collectivité"
-            value="local_or_regional_authority"
-            {...register("ownerType", { required: requiredMessage })}
-          />
-          {shouldAskForLocalAuthorityType && (
-            <>
-              {localAuthoritiesLoadingState === "loading" ? (
-                <LoadingSpinner />
-              ) : (
-                <Select
-                  options={
-                    localAuthoritiesLoadingState === "error"
-                      ? localAuthoritiesList.map(({ type, name }) => ({
-                          label: name,
-                          value: type,
-                        }))
-                      : localAuthoritiesList.map(({ type, name }) => ({
-                          label: formatLocalAuthorityName(type, name),
-                          value: type,
-                        }))
-                  }
-                  label={<RequiredLabel label="Type de collectivité" />}
-                  placeholder="Sélectionnez un type de collectivité"
-                  state={formState.errors.localAuthority ? "error" : "default"}
-                  stateRelatedMessage={formState.errors.localAuthority?.message}
-                  nativeSelectProps={register("localAuthority", {
-                    required: "Ce champ est requis",
-                  })}
-                />
-              )}
-            </>
-          )}
-          {currentUserStructureName && (
+          {currentUserStructure?.name && (
             <RadioButton
-              label={`Mon entreprise, ${currentUserStructureName}`}
-              value="user_company"
+              label={
+                currentUserStructure.type === "local_authority"
+                  ? `Ma collectivité, ${currentUserStructure.name}`
+                  : `Mon entreprise, ${currentUserStructure.name}`
+              }
+              value="user_structure"
               {...register("ownerType", { required: requiredMessage })}
             />
           )}
           <RadioButton
-            label={`Une entreprise`}
+            label={
+              currentUserStructure?.type === "local_authority"
+                ? "Une autre collectivité"
+                : "Une collectivité"
+            }
+            value="local_or_regional_authority"
+            {...register("ownerType", { required: requiredMessage })}
+          />
+
+          {shouldAskForLocalAuthorityType && (
+            <Select
+              options={localAuthoritiesList.map(({ type, name }) => ({
+                label: name,
+                value: type,
+              }))}
+              label={<RequiredLabel label="Type de collectivité" />}
+              placeholder="Sélectionnez un type de collectivité"
+              state={formState.errors.localAuthority ? "error" : "default"}
+              stateRelatedMessage={formState.errors.localAuthority?.message}
+              nativeSelectProps={register("localAuthority", {
+                required: "Ce champ est requis",
+              })}
+            />
+          )}
+
+          <RadioButton
+            label={
+              <span className="tw-flex tw-items-center">
+                {currentUserStructure?.type === "local_authority"
+                  ? `Une entreprise`
+                  : "Une autre entreprise"}
+                <TooltipInfoButton
+                  text="Entreprise publique ou privée, association, EPF..."
+                  id="company-info"
+                />
+              </span>
+            }
             value="other_company"
             {...register("ownerType", { required: requiredMessage })}
           />

--- a/apps/web/src/features/create-site/views/site-management/site-operator/index.tsx
+++ b/apps/web/src/features/create-site/views/site-management/site-operator/index.tsx
@@ -5,13 +5,16 @@ import { revertOperatorStep } from "@/features/create-site/application/createSit
 import { completeOperator } from "@/features/create-site/application/createSite.reducer";
 import { fetchSiteMunicipalityData } from "@/features/create-site/application/siteMunicipalityData.actions";
 import {
+  AvailableLocalAuthority,
   getAvailableLocalAuthorities,
-  LocalAuthority,
 } from "@/features/create-site/application/siteMunicipalityData.reducer";
 import { Tenant } from "@/features/create-site/domain/siteFoncier.types";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
 
-const getTenant = (data: FormValues, localAuthorities: LocalAuthority[]): Tenant | undefined => {
+const getTenant = (
+  data: FormValues,
+  localAuthorities: AvailableLocalAuthority[],
+): Tenant | undefined => {
   switch (data.operator) {
     case "company":
       return {
@@ -26,7 +29,7 @@ const getTenant = (data: FormValues, localAuthorities: LocalAuthority[]): Tenant
     case "local_or_regional_authority": {
       const localAuthority = localAuthorities.find(
         ({ type }) => type === data.localAuthority,
-      ) as LocalAuthority;
+      ) as AvailableLocalAuthority;
       return {
         name: localAuthority.name,
         structureType: data.localAuthority,

--- a/apps/web/src/features/create-site/views/site-management/tenant/index.tsx
+++ b/apps/web/src/features/create-site/views/site-management/tenant/index.tsx
@@ -5,20 +5,20 @@ import { revertTenantStep } from "@/features/create-site/application/createSite.
 import { completeTenant } from "@/features/create-site/application/createSite.reducer";
 import { fetchSiteMunicipalityData } from "@/features/create-site/application/siteMunicipalityData.actions";
 import {
+  AvailableLocalAuthority,
   getAvailableLocalAuthorities,
-  LocalAuthority,
 } from "@/features/create-site/application/siteMunicipalityData.reducer";
 import { Tenant } from "@/features/create-site/domain/siteFoncier.types";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
 
 const convertFormValuesForStore = (
   data: FormValues,
-  localAuthorities: LocalAuthority[],
+  localAuthorities: AvailableLocalAuthority[],
 ): Tenant | undefined => {
   if (data.tenantType === "local_or_regional_authority") {
     const localAuthority = localAuthorities.find(
       ({ type }) => type === data.localAuthority,
-    ) as LocalAuthority;
+    ) as AvailableLocalAuthority;
     return {
       name: localAuthority.name,
       structureType: data.localAuthority,

--- a/apps/web/src/features/users/domain/user.ts
+++ b/apps/web/src/features/users/domain/user.ts
@@ -4,10 +4,13 @@ const structureActivitySchema = z.enum([
   "urban_planner",
   "real_estate_developer",
   "local_authority_landlord",
-  "local_authority",
   "photovoltaic_plants_developer",
   "industrialist",
   "other",
+  "municipality",
+  "epci",
+  "department",
+  "region",
 ]);
 
 export type UserStructureActivity = z.infer<typeof structureActivitySchema>;

--- a/apps/web/src/features/users/views/CreateUserForm/CreateUserForm.tsx
+++ b/apps/web/src/features/users/views/CreateUserForm/CreateUserForm.tsx
@@ -5,8 +5,8 @@ import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
-import Select from "@codegouvfr/react-dsfr/SelectNext";
-import { UserStructureActivity } from "../../domain/user";
+import UserStructureForm, { StructureFormValues } from "./CreateUserStructureForm";
+import { AdministrativeDivisionService } from ".";
 
 import PolitiqueConfidentialiteContent from "@/shared/app-settings/views/PolitiqueConfidentialiteContent/PolitiqueConfidentialiteContent";
 import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
@@ -21,33 +21,22 @@ export type FormValues = {
   lastname: string;
   firstname: string;
   email: string;
-  structureActivity: UserStructureActivity;
-  structureName?: string;
   personnalDataUseConsentment: "agreed";
-};
+} & StructureFormValues;
 
 type Props = {
   createUserLoadingState: "idle" | "loading" | "success" | "error";
   onSubmit: (data: FormValues) => void;
+  administrativeDivisionService: AdministrativeDivisionService;
 };
 
-const structureActivityLabelMap = new Map<UserStructureActivity, string>([
-  ["urban_planner", "Aménageur urbain"],
-  ["real_estate_developer", "Promoteur"],
-  ["local_authority_landlord", "Bailleur social"],
-  ["local_authority", "Collectivité"],
-  ["photovoltaic_plants_developer", "Développeur de centrale photovoltaïque"],
-  ["industrialist", "Industriel"],
-  ["other", "Autre"],
-]);
-
-const structureActivityOptions = Array.from(structureActivityLabelMap).map(([value, label]) => ({
-  value,
-  label,
-}));
-
-function CreateUserForm({ onSubmit, createUserLoadingState }: Props) {
-  const { register, handleSubmit, formState } = useForm<FormValues>();
+function CreateUserForm({
+  onSubmit,
+  createUserLoadingState,
+  administrativeDivisionService,
+}: Props) {
+  const formContext = useForm<FormValues>();
+  const { register, handleSubmit, formState } = formContext;
 
   return (
     <section className={fr.cx("fr-container", "fr-py-4w")}>
@@ -73,39 +62,19 @@ function CreateUserForm({ onSubmit, createUserLoadingState }: Props) {
             }}
           />
           <Input
-            label="Nom"
-            nativeInputProps={{ ...register("lastname"), placeholder: "Chateau" }}
-          />
-          <Input
             label="Prénom"
             nativeInputProps={{ ...register("firstname"), placeholder: "Laurent" }}
           />
-          <h4>Votre structure</h4>
-          <Select
-            className={fr.cx("fr-col-6")}
-            label={<RequiredLabel label="Profil" />}
-            placeholder="Collectivité, aménageur urbain..."
-            state={formState.errors.structureActivity ? "error" : "default"}
-            stateRelatedMessage={
-              formState.errors.structureActivity
-                ? formState.errors.structureActivity.message
-                : undefined
-            }
-            nativeSelectProps={{
-              ...register("structureActivity", {
-                required: "Vous devez sélectionner un type de profil pour continuer",
-              }),
-            }}
-            options={structureActivityOptions}
-          />
           <Input
-            label="Nom de la structure"
-            nativeInputProps={{
-              placeholder: "La région Auvergne-Rhône-Alpes",
-              ...register("structureName"),
-            }}
+            label="Nom"
+            nativeInputProps={{ ...register("lastname"), placeholder: "Chateau" }}
+          />
+          <UserStructureForm
+            administrativeDivisionService={administrativeDivisionService}
+            formContext={formContext}
           />
           <Checkbox
+            className="tw-mt-5"
             state={formState.errors.personnalDataUseConsentment ? "error" : "default"}
             stateRelatedMessage={
               formState.errors.personnalDataUseConsentment

--- a/apps/web/src/features/users/views/CreateUserForm/CreateUserStructureForm.tsx
+++ b/apps/web/src/features/users/views/CreateUserForm/CreateUserStructureForm.tsx
@@ -1,0 +1,202 @@
+import { ChangeEvent, useEffect, useState } from "react";
+import { UseFormReturn } from "react-hook-form";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import Select from "@codegouvfr/react-dsfr/SelectNext";
+import { AutoComplete } from "antd";
+import { UserStructureActivity } from "../../domain/user";
+import { FormValues } from "./CreateUserForm";
+import { AdministrativeDivision, AdministrativeDivisionService } from ".";
+
+import { LocalAutorityStructureType } from "@/shared/domain/stakeholder";
+import formatLocalAuthorityName from "@/shared/services/strings/formatLocalAuthorityName";
+import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
+
+type StructureCategory =
+  | Exclude<UserStructureActivity, LocalAutorityStructureType>
+  | "local_authority";
+
+export type Municipality = {
+  label: AdministrativeDivision["name"];
+  value: AdministrativeDivision["code"];
+  localAuthorities: AdministrativeDivision["localAuthorities"];
+};
+
+export type StructureFormValues =
+  | {
+      structureCategory: Exclude<UserStructureActivity, LocalAutorityStructureType>;
+      structureName: string;
+      structureMunicipalityText: undefined;
+      selectedStructureMunicipality: undefined;
+      selectedStructureLocalAuthorityType: undefined;
+    }
+  | {
+      structureCategory: "local_authority";
+      structureMunicipalityText?: string;
+      selectedStructureMunicipality?: Municipality;
+      selectedStructureLocalAuthorityType: LocalAutorityStructureType;
+      structureName: string;
+    };
+
+type Props = {
+  formContext: UseFormReturn<FormValues>;
+  administrativeDivisionService: AdministrativeDivisionService;
+};
+
+const structureActivityLabelMap = new Map<StructureCategory, string>([
+  ["local_authority", "Collectivité"],
+  ["local_authority_landlord", "Bailleur social"],
+  ["real_estate_developer", "Promoteur"],
+  ["photovoltaic_plants_developer", "Développeur photovoltaïque"],
+  ["industrialist", "Industriel"],
+  ["other", "Autre"],
+]);
+
+const structureActivityOptions = Array.from(structureActivityLabelMap).map(([value, label]) => ({
+  value,
+  label,
+}));
+
+function UserStructureForm({ administrativeDivisionService, formContext }: Props) {
+  const { watch, register, unregister, setValue, formState } = formContext;
+  const structureCategory = watch("structureCategory");
+  const selectedStructureMunicipality = watch("selectedStructureMunicipality");
+  const structureMunicipalityText = watch("structureMunicipalityText");
+  const selectedStructureLocalAuthorityType = watch("selectedStructureLocalAuthorityType");
+
+  const [suggestions, setSuggestions] = useState<Municipality[]>([]);
+
+  const onSearch = async (text: string) => {
+    if (text.length <= 3) {
+      return;
+    }
+    const options = await administrativeDivisionService.searchMunicipality(text);
+    setSuggestions(
+      options.map((municipality) => ({
+        value: municipality.code,
+        label: municipality.name,
+        localAuthorities: municipality.localAuthorities,
+      })),
+    );
+  };
+
+  useEffect(() => {
+    if (structureCategory === "local_authority") {
+      register("selectedStructureMunicipality", {
+        required: "La communue est nécessaire pour déterminer le nom de votre collectivité",
+      });
+      return;
+    }
+
+    unregister([
+      "selectedStructureMunicipality",
+      "selectedStructureLocalAuthorityType",
+      "structureMunicipalityText",
+    ]);
+    setValue("structureName", "");
+  }, [register, setValue, structureCategory, unregister]);
+
+  useEffect(() => {
+    if (!selectedStructureMunicipality) {
+      return;
+    }
+
+    const selectedStructureLocalAuthority = selectedStructureMunicipality.localAuthorities.find(
+      ({ type }) => type === selectedStructureLocalAuthorityType,
+    );
+
+    if (!selectedStructureLocalAuthority) {
+      return;
+    }
+
+    setValue(
+      "structureName",
+      formatLocalAuthorityName(
+        selectedStructureLocalAuthority.type,
+        selectedStructureLocalAuthority.name,
+      ),
+    );
+  }, [selectedStructureLocalAuthorityType, selectedStructureMunicipality, setValue]);
+
+  return (
+    <>
+      <Select
+        label={<RequiredLabel label="Type de structure" />}
+        placeholder="Sélectionner une structure..."
+        state={formState.errors.structureCategory ? "error" : "default"}
+        stateRelatedMessage={
+          formState.errors.structureCategory
+            ? formState.errors.structureCategory.message
+            : undefined
+        }
+        nativeSelectProps={{
+          ...register("structureCategory", {
+            required: "Vous devez sélectionner un type de structure pour continuer",
+          }),
+        }}
+        options={structureActivityOptions}
+      />
+      {structureCategory === "local_authority" ? (
+        <>
+          <AutoComplete
+            className="fr-mb-8w tw-w-full"
+            value={selectedStructureMunicipality?.value}
+            options={suggestions}
+            onSearch={onSearch}
+            onSelect={(_: string, option: Municipality) => {
+              setValue("selectedStructureMunicipality", option, { shouldValidate: true });
+              setValue("structureMunicipalityText", option.label);
+            }}
+          >
+            <Input
+              label={<RequiredLabel label="Commune ou code postal" />}
+              state={formState.errors.selectedStructureMunicipality ? "error" : "default"}
+              stateRelatedMessage={
+                formState.errors.selectedStructureMunicipality
+                  ? formState.errors.selectedStructureMunicipality.message
+                  : undefined
+              }
+              nativeInputProps={{
+                placeholder: "38000, Angers...",
+                value: structureMunicipalityText ?? "",
+                onChange: (e: ChangeEvent<HTMLInputElement>) => {
+                  setValue("structureMunicipalityText", e.target.value);
+                  setValue("selectedStructureMunicipality", undefined);
+                },
+              }}
+            />
+          </AutoComplete>
+
+          {selectedStructureMunicipality && (
+            <Select
+              options={selectedStructureMunicipality.localAuthorities.map(({ type, name }) => ({
+                label: formatLocalAuthorityName(type, name),
+                value: type,
+              }))}
+              label={<RequiredLabel label="Nom de la collectivité" />}
+              placeholder="Sélectionnez la collectivité"
+              state={formState.errors.selectedStructureLocalAuthorityType ? "error" : "default"}
+              stateRelatedMessage={formState.errors.selectedStructureLocalAuthorityType?.message}
+              nativeSelectProps={register("selectedStructureLocalAuthorityType", {
+                required: "Ce champ est requis",
+              })}
+            />
+          )}
+        </>
+      ) : (
+        <Input
+          label={<RequiredLabel label="Nom de la structure" />}
+          state={formState.errors.structureName ? "error" : "default"}
+          stateRelatedMessage={formState.errors.structureName?.message}
+          nativeInputProps={{
+            placeholder: "3F, Générale du Solaire, GreenCity...",
+            ...register("structureName", {
+              required: "Le nom de votre structure est requis.",
+            }),
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+export default UserStructureForm;

--- a/apps/web/src/features/users/views/CreateUserForm/index.tsx
+++ b/apps/web/src/features/users/views/CreateUserForm/index.tsx
@@ -1,13 +1,34 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { createUser } from "../../application/createUser.action";
 import CreateUserForm, { FormValues } from "./CreateUserForm";
 
 import { routes } from "@/app/views/router";
+import { LocalAutorityStructureType } from "@/shared/domain/stakeholder";
+import { AdministrativeDivisionGeoApi } from "@/shared/infrastructure/administrative-division-service/administrativeDivisionGeoApi";
 import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
+
+export type AdministrativeDivision = {
+  code: string;
+  name: string;
+  localAuthorities: {
+    type: LocalAutorityStructureType;
+    name: string;
+    code: string;
+  }[];
+};
+
+export interface AdministrativeDivisionService {
+  searchMunicipality(searchText: string): Promise<AdministrativeDivision[]>;
+}
 
 function CreateUserFormContainer() {
   const dispatch = useAppDispatch();
   const createUserLoadingState = useAppSelector((state) => state.currentUser.createUserState);
+
+  const administrativeDivisionService: AdministrativeDivisionService = useMemo(
+    () => new AdministrativeDivisionGeoApi(),
+    [],
+  );
 
   const onSubmit = (data: FormValues) => {
     void dispatch(
@@ -15,8 +36,11 @@ function CreateUserFormContainer() {
         email: data.email,
         firstname: data.firstname,
         lastname: data.lastname,
-        structureType: data.structureActivity === "local_authority" ? "local_authority" : "company",
-        structureActivity: data.structureActivity,
+        structureType: data.structureCategory === "local_authority" ? "local_authority" : "company",
+        structureActivity:
+          data.structureCategory === "local_authority"
+            ? data.selectedStructureLocalAuthorityType
+            : data.structureCategory,
         structureName: data.structureName,
         personalDataStorageConsented: true,
         personalDataAnalyticsUseConsented: true,
@@ -31,7 +55,13 @@ function CreateUserFormContainer() {
     }
   }, [createUserLoadingState]);
 
-  return <CreateUserForm onSubmit={onSubmit} createUserLoadingState={createUserLoadingState} />;
+  return (
+    <CreateUserForm
+      onSubmit={onSubmit}
+      createUserLoadingState={createUserLoadingState}
+      administrativeDivisionService={administrativeDivisionService}
+    />
+  );
 }
 
 export default CreateUserFormContainer;


### PR DESCRIPTION
- [Ajout du choix de la collectivité en fonction de l’adresse dans le form identité](https://www.notion.so/accelerateur-transition-ecologique-ademe/Formulaire-Cr-ation-de-compte-changement-et-ajout-d-inputs-64fdbd07249b4479a66699f3963b4df2?pvs=4)
- [Adaptation des formulaires site et projet pour gérer le cas collectivité](https://www.notion.so/accelerateur-transition-ecologique-ademe/Qui-est-le-propri-taire-actuel-de-cette-friche-Nouvelles-r-gles-de-gestion-c846b51ed5874bf18bcb4e3def20c841?pvs=4)