### PR TITLE
feat: allow users to look up their projects features on a dedicated page

### DIFF
--- a/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.ts
+++ b/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.controller.ts
@@ -11,6 +11,7 @@ import {
   CreateReconversionProjectUseCase,
   reconversionProjectPropsSchema,
 } from "src/reconversion-projects/core/usecases/createReconversionProject.usecase";
+import { GetReconversionProjectFeaturesUseCase } from "src/reconversion-projects/core/usecases/getReconversionProjectFeatures.usecase";
 import { GetUserReconversionProjectsBySiteUseCase } from "src/reconversion-projects/core/usecases/getUserReconversionProjectsBySite.usecase";
 
 const jsonScheduleSchema = z.object({
@@ -58,6 +59,7 @@ export class ReconversionProjectController {
     private readonly getReconversionProjectsBySite: GetUserReconversionProjectsBySiteUseCase,
     private readonly getReconversionProjectImpactsUseCase: ComputeReconversionProjectImpactsUseCase,
     private readonly createExpressReconversionProjectUseCase: CreateExpressReconversionProjectUseCase,
+    private readonly getReconversionProjectFeaturesUseCase: GetReconversionProjectFeaturesUseCase,
   ) {}
 
   @Post()
@@ -90,6 +92,17 @@ export class ReconversionProjectController {
     const result = await this.getReconversionProjectImpactsUseCase.execute({
       reconversionProjectId,
       evaluationPeriodInYears,
+    });
+
+    return result;
+  }
+
+  @Get(":reconversionProjectId/features")
+  async getReconversionProjectFeatures(
+    @Param("reconversionProjectId") reconversionProjectId: string,
+  ) {
+    const result = await this.getReconversionProjectFeaturesUseCase.execute({
+      reconversionProjectId,
     });
 
     return result;

--- a/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.module.ts
+++ b/apps/api/src/reconversion-projects/adapters/primary/reconversionProjects.module.ts
@@ -14,6 +14,7 @@ import {
   ReconversionProjectRepository,
   SiteRepository,
 } from "src/reconversion-projects/core/usecases/createReconversionProject.usecase";
+import { GetReconversionProjectFeaturesUseCase } from "src/reconversion-projects/core/usecases/getReconversionProjectFeatures.usecase";
 import {
   GetUserReconversionProjectsBySiteUseCase,
   ReconversionProjectsListRepository,
@@ -23,6 +24,7 @@ import { IDateProvider } from "src/shared-kernel/adapters/date/IDateProvider";
 import { SqlSitesReadRepository } from "src/sites/adapters/secondary/site-repository/read/SqlSiteReadRepository";
 import { SqlSiteWriteRepository } from "src/sites/adapters/secondary/site-repository/write/SqlSiteWriteRepository";
 import { SitesReadRepository } from "src/sites/core/gateways/SitesReadRepository";
+import { SqlReconversionProjectQuery } from "../secondary/queries/SqlReconversionProjectQuery";
 import { SqlReconversionProjectImpactsRepository } from "../secondary/reconversion-project-impacts-repository/SqlReconversionProjectImpactsRepository";
 import { SqlReconversionProjectRepository } from "../secondary/reconversion-project-repository/SqlReconversionProjectRepository";
 import { SqlReconversionProjectsListRepository } from "../secondary/reconversion-projects-list-repository/SqlReconversionProjectsListRepository";
@@ -98,7 +100,15 @@ import { ReconversionProjectController } from "./reconversionProjects.controller
         GetCityPopulationAndSurfaceAreaUseCase,
       ],
     },
+    {
+      provide: GetReconversionProjectFeaturesUseCase,
+      useFactory(reconversionProjectQuery: SqlReconversionProjectQuery) {
+        return new GetReconversionProjectFeaturesUseCase(reconversionProjectQuery);
+      },
+      inject: [SqlReconversionProjectQuery],
+    },
     SqlReconversionProjectRepository,
+    SqlReconversionProjectQuery,
     SqlReconversionProjectsListRepository,
     SqlSiteWriteRepository,
     SqlSitesReadRepository,

--- a/apps/api/src/reconversion-projects/adapters/secondary/queries/SqlReconversionProjectQuery.ts
+++ b/apps/api/src/reconversion-projects/adapters/secondary/queries/SqlReconversionProjectQuery.ts
@@ -1,0 +1,217 @@
+import { Inject } from "@nestjs/common";
+import { Knex } from "knex";
+import { MixedUseNeighbourhoodFeatures } from "src/reconversion-projects/core/model/mixedUseNeighbourhood";
+import {
+  DevelopmentPlan,
+  PhotovoltaicPowerStationFeatures,
+  Schedule,
+} from "src/reconversion-projects/core/model/reconversionProject";
+import { SqlConnection } from "src/shared-kernel/adapters/sql-knex/sqlConnection.module";
+import {
+  ReconversionProjectFeaturesView,
+  ReconversionProjectQueryGateway,
+} from "../../../core/usecases/getReconversionProjectFeatures.usecase";
+
+const mapSqlSchedule = (startDate: string | null, endDate: string | null): Schedule | undefined => {
+  return startDate && endDate
+    ? {
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
+      }
+    : undefined;
+};
+
+const sumIfNotNull = (a: number | null, b: number | null): number | undefined => {
+  return a && b ? a + b : undefined;
+};
+
+export class SqlReconversionProjectQuery implements ReconversionProjectQueryGateway {
+  constructor(@Inject(SqlConnection) private readonly sqlConnection: Knex) {}
+
+  async getFeaturesById(
+    reconversionProjectId: string,
+  ): Promise<ReconversionProjectFeaturesView | undefined> {
+    const sqlResult = (await this.sqlConnection("reconversion_projects")
+      .select(
+        "reconversion_projects.id",
+        "reconversion_projects.name",
+        "reconversion_projects.description",
+        "reconversion_projects.operations_first_year",
+        "reconversion_projects.future_site_owner_name",
+        "reconversion_projects.future_operator_name",
+        "reconversion_projects.conversion_full_time_jobs_involved",
+        "reconversion_projects.reinstatement_full_time_jobs_involved",
+        "reconversion_projects.future_operations_full_time_jobs",
+        "site_purchase_selling_price",
+        "site_purchase_property_transfer_duties",
+        "site_resale_expected_selling_price",
+        "site_resale_expected_property_transfer_duties",
+        this.sqlConnection
+          .select(this.sqlConnection.raw("json_agg(row_to_json(soils_distribution_rows))"))
+          .from({ soils_distribution_rows: "reconversion_project_soils_distributions" })
+          .where("reconversion_project_id", reconversionProjectId)
+          .as("soils_distribution"),
+        this.sqlConnection
+          .select(this.sqlConnection.raw("json_agg(row_to_json(financial_assistance_rows))"))
+          .from({ financial_assistance_rows: "reconversion_project_financial_assistance_revenues" })
+          .where("reconversion_project_id", reconversionProjectId)
+          .as("financial_assistance_revenues"),
+        this.sqlConnection
+          .select(this.sqlConnection.raw("json_agg(row_to_json(reinstatement_costs_rows))"))
+          .from(
+            this.sqlConnection("reconversion_project_reinstatement_costs")
+              .select("amount", "purpose")
+              .where("reconversion_project_id", reconversionProjectId)
+              .as("reinstatement_costs_rows"),
+          )
+          .as("reinstatement_costs"),
+        this.sqlConnection
+          .select(this.sqlConnection.raw("json_agg(row_to_json(expenses_rows))"))
+          .from(
+            this.sqlConnection("reconversion_project_yearly_expenses")
+              .select("amount", "purpose")
+              .where("reconversion_project_id", reconversionProjectId)
+              .as("expenses_rows"),
+          )
+          .as("expenses"),
+        this.sqlConnection
+          .select(this.sqlConnection.raw("json_agg(row_to_json(revenues_rows))"))
+          .from(
+            this.sqlConnection("reconversion_project_yearly_revenues")
+              .select("amount", "source")
+              .where("reconversion_project_id", reconversionProjectId)
+              .as("revenues_rows"),
+          )
+          .as("revenues"),
+        this.sqlConnection.raw(
+          `(
+              SELECT row_to_json(development_plan_row)
+              FROM (
+                SELECT
+                  dp.developer_name, dp.schedule_start_date, dp.schedule_end_date, dp.type, dp.features,
+                  (
+                    SELECT json_agg(row_to_json(development_plan_costs_rows))
+                    FROM (
+                      SELECT amount, purpose
+                      FROM reconversion_project_development_plan_costs
+                      WHERE development_plan_id = dp.id
+                    ) development_plan_costs_rows
+                  ) as costs
+                FROM reconversion_project_development_plans dp
+                WHERE dp.reconversion_project_id = ?
+                LIMIT 1
+              ) development_plan_row
+            ) as development_plan`,
+          [reconversionProjectId],
+        ),
+      )
+      .where("reconversion_projects.id", reconversionProjectId)
+      .first()) as
+      | {
+          id: string;
+          name: string;
+          description: string | null;
+          operations_first_year: number | null;
+          future_site_owner_name: string | null;
+          future_operator_name: string | null;
+          future_operations_full_time_jobs: number | null;
+          conversion_full_time_jobs_involved: number | null;
+          reinstatement_full_time_jobs_involved: number | null;
+          reinstatement_contract_owner_name: string | null;
+          reinstatement_schedule_start_date: string | null;
+          reinstatement_schedule_end_date: string | null;
+          soils_distribution: { soil_type: string; surface_area: number }[];
+          expenses: { amount: number; purpose: string }[] | null;
+          revenues: { amount: number; source: string }[] | null;
+          financial_assistance_revenues: { amount: number; source: string }[] | null;
+          reinstatement_costs: { amount: number; purpose: string }[] | null;
+          site_purchase_selling_price: number | null;
+          site_purchase_property_transfer_duties: number | null;
+          site_resale_expected_selling_price: number | null;
+          site_resale_expected_property_transfer_duties: number | null;
+          development_plan: {
+            type: string;
+            costs: { amount: number; purpose: string }[];
+            developer_name: string;
+            schedule_start_date: string | null;
+            schedule_end_date: string | null;
+            features: DevelopmentPlan["features"];
+          };
+        }
+      | undefined;
+
+    if (!sqlResult) {
+      return undefined;
+    }
+
+    const getDevelopmentPlan = (): ReconversionProjectFeaturesView["developmentPlan"] => {
+      if (sqlResult.development_plan.type === "PHOTOVOLTAIC_POWER_PLANT") {
+        const { contractDuration, electricalPowerKWc, surfaceArea, expectedAnnualProduction } =
+          sqlResult.development_plan.features as PhotovoltaicPowerStationFeatures;
+        return {
+          installationCosts: sqlResult.development_plan.costs,
+          developerName: sqlResult.development_plan.developer_name,
+          installationSchedule: mapSqlSchedule(
+            sqlResult.development_plan.schedule_start_date,
+            sqlResult.development_plan.schedule_end_date,
+          ),
+          type: "PHOTOVOLTAIC_POWER_PLANT",
+          contractDuration,
+          electricalPowerKWc,
+          surfaceArea,
+          expectedAnnualProduction,
+        };
+      }
+      if (sqlResult.development_plan.type === "MIXED_USE_NEIGHBOURHOOD") {
+        return {
+          installationCosts: sqlResult.development_plan.costs,
+          developerName: sqlResult.development_plan.developer_name,
+          installationSchedule: mapSqlSchedule(
+            sqlResult.development_plan.schedule_start_date,
+            sqlResult.development_plan.schedule_end_date,
+          ),
+          type: "MIXED_USE_NEIGHBOURHOOD",
+          spaces: (sqlResult.development_plan.features as MixedUseNeighbourhoodFeatures)
+            .spacesDistribution,
+        };
+      }
+      throw new Error("Unknown development plan type");
+    };
+
+    return {
+      id: sqlResult.id,
+      name: sqlResult.name,
+      description: sqlResult.description ?? undefined,
+      firstYearOfOperation: sqlResult.operations_first_year ?? undefined,
+      futureOwner: sqlResult.future_site_owner_name ?? undefined,
+      futureOperator: sqlResult.future_operator_name ?? undefined,
+      developmentPlan: getDevelopmentPlan(),
+      soilsDistribution: sqlResult.soils_distribution.reduce((acc, { soil_type, surface_area }) => {
+        return {
+          ...acc,
+          [soil_type]: surface_area,
+        };
+      }, {}),
+      yearlyProjectedExpenses: sqlResult.expenses ?? [],
+      yearlyProjectedRevenues: sqlResult.revenues ?? [],
+      reinstatementContractOwner: sqlResult.reinstatement_contract_owner_name ?? undefined,
+      conversionFullTimeJobs: sqlResult.conversion_full_time_jobs_involved ?? undefined,
+      operationsFullTimeJobs: sqlResult.future_operations_full_time_jobs ?? undefined,
+      reinstatementSchedule: mapSqlSchedule(
+        sqlResult.reinstatement_schedule_start_date,
+        sqlResult.reinstatement_schedule_end_date,
+      ),
+      reinstatementFullTimeJobs: sqlResult.reinstatement_full_time_jobs_involved ?? undefined,
+      financialAssistanceRevenues: sqlResult.financial_assistance_revenues ?? undefined,
+      reinstatementCosts: sqlResult.reinstatement_costs ?? undefined,
+      sitePurchaseTotalAmount: sumIfNotNull(
+        sqlResult.site_purchase_selling_price,
+        sqlResult.site_purchase_property_transfer_duties,
+      ),
+      siteResaleTotalAmount: sumIfNotNull(
+        sqlResult.site_resale_expected_selling_price,
+        sqlResult.site_resale_expected_property_transfer_duties,
+      ),
+    };
+  }
+}

--- a/apps/api/src/reconversion-projects/core/usecases/getReconversionProjectFeatures.usecase.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/getReconversionProjectFeatures.usecase.ts
@@ -1,0 +1,77 @@
+import { UseCase } from "src/shared-kernel/usecase";
+import { SoilsDistribution } from "src/soils/domain/soils";
+import { SpacesDistribution } from "../model/mixedUseNeighbourhood";
+import { Schedule } from "../model/reconversionProject";
+
+export type ReconversionProjectFeaturesView = {
+  id: string;
+  name: string;
+  description?: string;
+  developmentPlan:
+    | {
+        type: "PHOTOVOLTAIC_POWER_PLANT";
+        electricalPowerKWc: number;
+        surfaceArea: number;
+        expectedAnnualProduction: number;
+        contractDuration: number;
+        installationCosts: { amount: number; purpose: string }[];
+        installationSchedule?: Schedule;
+        developerName?: string;
+      }
+    | {
+        type: "MIXED_USE_NEIGHBOURHOOD";
+        developerName?: string;
+        spaces: SpacesDistribution;
+        installationCosts: { amount: number; purpose: string }[];
+        installationSchedule?: Schedule;
+      };
+  soilsDistribution: SoilsDistribution;
+  futureOwner?: string;
+  futureOperator?: string;
+  reinstatementContractOwner?: string;
+  reinstatementFullTimeJobs?: number;
+  conversionFullTimeJobs?: number;
+  operationsFullTimeJobs?: number;
+  financialAssistanceRevenues?: { amount: number; source: string }[];
+  reinstatementCosts?: { amount: number; purpose: string }[];
+  yearlyProjectedExpenses: { amount: number; purpose: string }[];
+  yearlyProjectedRevenues: { amount: number; source: string }[];
+  reinstatementSchedule?: Schedule;
+  firstYearOfOperation?: number;
+  sitePurchaseTotalAmount?: number;
+  siteResaleTotalAmount?: number;
+};
+
+export interface ReconversionProjectQueryGateway {
+  getFeaturesById(
+    reconversionProjectId: string,
+  ): Promise<ReconversionProjectFeaturesView | undefined>;
+}
+
+class ReconversionProjectIdRequiredError extends Error {
+  constructor() {
+    super(`GetReconversionProjectFeaturesUseCase: reconversionProjectId is required`);
+    this.name = "ReconversionProjectIdRequiredError";
+  }
+}
+
+type Request = {
+  reconversionProjectId: string;
+};
+
+export class GetReconversionProjectFeaturesUseCase
+  implements UseCase<Request, ReconversionProjectFeaturesView>
+{
+  constructor(private readonly reconversionProjectQuery: ReconversionProjectQueryGateway) {}
+
+  async execute({ reconversionProjectId }: Request): Promise<ReconversionProjectFeaturesView> {
+    if (!reconversionProjectId) {
+      throw new ReconversionProjectIdRequiredError();
+    }
+
+    const result = await this.reconversionProjectQuery.getFeaturesById(reconversionProjectId);
+
+    if (!result) throw new Error(`Reconversion project with id ${reconversionProjectId} not found`);
+    return result;
+  }
+}

--- a/apps/web/src/app/application/appDependencies.ts
+++ b/apps/web/src/app/application/appDependencies.ts
@@ -6,6 +6,7 @@ import { HttpSaveReconversionProjectService } from "@/features/create-project/in
 import { HttpSitesService } from "@/features/create-project/infrastructure/sites-service/HttpSiteService";
 import { HttpCreateSiteApi } from "@/features/create-site/infrastructure/create-site-service/HttpCreateSiteApi";
 import { LocalStorageProjectDetailsApi } from "@/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi";
+import { HttpProjectFeaturesService } from "@/features/projects/infrastructure/project-features-service/HttpProjectFeaturesService";
 import { HttpReconversionProjectsListApi } from "@/features/projects/infrastructure/projects-list-service/HttpProjectsListApi";
 import { HttpReconversionProjectImpactsApi } from "@/features/projects/infrastructure/reconversion-project-impacts-service/HttpReconversionProjectImpactsService";
 import { HttpSiteFeaturesService } from "@/features/site-features/infra/site-features-service/HttpSiteFeaturesService";
@@ -28,4 +29,5 @@ export const appDependencies: AppDependencies = {
   currentUserService: new LocalStorageUserService(),
   createUserService: new HttpCreateUserService(),
   siteFeaturesService: new HttpSiteFeaturesService(),
+  projectFeaturesService: new HttpProjectFeaturesService(),
 };

--- a/apps/web/src/app/application/store.ts
+++ b/apps/web/src/app/application/store.ts
@@ -18,6 +18,8 @@ import { SiteMunicipalityDataGateway as CreateSiteMunicipalityDataGateway } from
 import siteMunicipalityData from "@/features/create-site/application/siteMunicipalityData.reducer";
 import siteCarbonStorage from "@/features/create-site/application/siteSoilsCarbonStorage.reducer";
 import { ReconversionProjectImpactsGateway } from "@/features/projects/application/fetchReconversionProjectImpacts.action";
+import { ProjectFeaturesGateway } from "@/features/projects/application/project-features/projectFeatures.actions";
+import { projectFeaturesReducer } from "@/features/projects/application/project-features/projectFeatures.reducer";
 import projectImpacts from "@/features/projects/application/projectImpacts.reducer";
 import { ProjectsDetailsGateway } from "@/features/projects/application/projectImpactsComparison.actions";
 import projectImpactsComparison from "@/features/projects/application/projectImpactsComparison.reducer";
@@ -42,6 +44,7 @@ export type AppDependencies = {
   currentUserService: CurrentUserGateway;
   createUserService: CreateUserGateway;
   siteFeaturesService: SiteFeaturesGateway;
+  projectFeaturesService: ProjectFeaturesGateway;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -58,6 +61,7 @@ const rootReducer = combineReducers({
   reconversionProjectsList,
   currentUser,
   projectImpacts,
+  projectFeatures: projectFeaturesReducer,
   projectImpactsComparison,
   projectSoilsCarbonStorage,
   siteMunicipalityData,

--- a/apps/web/src/features/projects/application/project-features/projectFeatures.actions.ts
+++ b/apps/web/src/features/projects/application/project-features/projectFeatures.actions.ts
@@ -1,0 +1,15 @@
+import { ProjectFeatures } from "../../domain/projects.types";
+
+import { createAppAsyncThunk } from "@/app/application/appAsyncThunk";
+
+export interface ProjectFeaturesGateway {
+  getById(projectId: string): Promise<ProjectFeatures>;
+}
+
+export const fetchProjectFeatures = createAppAsyncThunk<ProjectFeatures, { projectId: string }>(
+  "projectFeatures/fetchProjectFeatures",
+  async ({ projectId }, { extra }) => {
+    const projectFeatures = await extra.projectFeaturesService.getById(projectId);
+    return projectFeatures;
+  },
+);

--- a/apps/web/src/features/projects/application/project-features/projectFeatures.reducer.ts
+++ b/apps/web/src/features/projects/application/project-features/projectFeatures.reducer.ts
@@ -1,0 +1,41 @@
+import { createReducer, createSelector } from "@reduxjs/toolkit";
+import { ProjectFeatures } from "../../domain/projects.types";
+import { fetchProjectFeatures } from "./projectFeatures.actions";
+
+import { RootState } from "@/app/application/store";
+
+type LoadingState = "idle" | "loading" | "success" | "error";
+
+export type ProjectFeaturesState = {
+  dataLoadingState: LoadingState;
+  data?: ProjectFeatures;
+};
+
+export const getInitialState = (): ProjectFeaturesState => {
+  return {
+    data: undefined,
+    dataLoadingState: "idle",
+  };
+};
+
+export const projectFeaturesReducer = createReducer(getInitialState(), (builder) => {
+  builder.addCase(fetchProjectFeatures.pending, (state) => {
+    state.dataLoadingState = "loading";
+  });
+  builder.addCase(fetchProjectFeatures.fulfilled, (state, action) => {
+    state.dataLoadingState = "success";
+    state.data = action.payload;
+  });
+  builder.addCase(fetchProjectFeatures.rejected, (state) => {
+    state.dataLoadingState = "error";
+  });
+});
+
+const selectSelf = (state: RootState) => state.projectFeatures;
+
+export const selectProjectFeatures = createSelector(
+  selectSelf,
+  (state): ProjectFeatures | undefined => {
+    return state.data;
+  },
+);

--- a/apps/web/src/features/projects/application/projectImpactsComparison.actions.ts
+++ b/apps/web/src/features/projects/application/projectImpactsComparison.actions.ts
@@ -1,6 +1,6 @@
 import { SoilType } from "shared";
 import { validate as uuidValidate } from "uuid";
-import { Project, ProjectSite } from "../domain/projects.types";
+import { ProjectForComparison, ProjectSite } from "../domain/projects.types";
 
 import { createAppAsyncThunk } from "@/app/application/appAsyncThunk";
 
@@ -79,7 +79,7 @@ export const fetchCurrentAndProjectedSoilsCarbonStorage =
   );
 
 export type ProjectDetailsResult = {
-  projectData?: Project;
+  projectData?: ProjectForComparison;
   siteData?: ProjectSite;
 };
 
@@ -87,13 +87,13 @@ type FetchDataResult = {
   baseScenario: {
     type: "STATU_QUO" | "PROJECT";
     id: string;
-    projectData?: Project;
+    projectData?: ProjectForComparison;
     siteData: ProjectSite;
   };
   withScenario: {
     type: "PROJECT";
     id: string;
-    projectData: Project;
+    projectData: ProjectForComparison;
     siteData: ProjectSite;
   };
 };

--- a/apps/web/src/features/projects/application/projectImpactsComparison.reducer.ts
+++ b/apps/web/src/features/projects/application/projectImpactsComparison.reducer.ts
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { SoilType } from "shared";
-import { Project, ProjectSite } from "../domain/projects.types";
+import { ProjectForComparison, ProjectSite } from "../domain/projects.types";
 import {
   fetchBaseProjectAndWithProjectData,
   fetchCurrentAndProjectedSoilsCarbonStorage,
@@ -22,14 +22,14 @@ export type ProjectImpactsComparisonState = {
   baseScenario: {
     type?: "STATU_QUO" | "PROJECT";
     id?: string;
-    projectData?: Project;
+    projectData?: ProjectForComparison;
     siteData?: ProjectSite;
     soilsCarbonStorage?: SoilsCarbonStorage;
   };
   withScenario: {
     type?: "PROJECT";
     id?: string;
-    projectData?: Project;
+    projectData?: ProjectForComparison;
     siteData?: ProjectSite;
     soilsCarbonStorage?: SoilsCarbonStorage;
   };

--- a/apps/web/src/features/projects/domain/projects.types.ts
+++ b/apps/web/src/features/projects/domain/projects.types.ts
@@ -1,6 +1,18 @@
 import { FricheActivity, SoilsDistribution } from "shared";
 
 import {
+  MixedUseNeighbourhoodDevelopmentExpense,
+  MixedUseNeighbourhoodSpace,
+} from "@/shared/domain/mixedUseNeighbourhood";
+import {
+  FinancialAssistanceRevenue,
+  PhotovoltaicInstallationCost,
+  RecurringCost,
+  RecurringRevenue,
+  ReinstatementCost,
+  WorksSchedule,
+} from "@/shared/domain/reconversionProject";
+import {
   LocalAutorityStructureType,
   OwnerStructureType,
   TenantStructureType,
@@ -71,14 +83,6 @@ export type ProjectSite = {
   owner: Owner;
 };
 
-type Expense = {
-  amount: number;
-};
-
-type Revenue = {
-  amount: number;
-};
-
 type ProjectStakeholderStructure =
   | OwnerStructureType
   | TenantStructureType
@@ -89,7 +93,48 @@ type ProjectStakeholderStructure =
 
 export type ProjectStakeholder = { name: string; structureType: ProjectStakeholderStructure };
 
-export type Project = {
+export type ProjectFeatures = {
+  id: string;
+  name: string;
+  description?: string;
+  developmentPlan:
+    | {
+        type: "PHOTOVOLTAIC_POWER_PLANT";
+        developerName?: string;
+        installationCosts: PhotovoltaicInstallationCost[];
+        installationSchedule?: WorksSchedule;
+        electricalPowerKWc: number;
+        surfaceArea: number;
+        expectedAnnualProduction: number;
+        contractDuration: number;
+      }
+    | {
+        type: "MIXED_USE_NEIGHBOURHOOD";
+        developerName?: string;
+        installationCosts: MixedUseNeighbourhoodDevelopmentExpense[];
+        installationSchedule?: WorksSchedule;
+        spaces: Record<MixedUseNeighbourhoodSpace, number>;
+      };
+  soilsDistribution: SoilsDistribution;
+  futureOwner?: string;
+  futureOperator?: string;
+  reinstatementContractOwner?: string;
+  reinstatementFullTimeJobs?: number;
+  conversionFullTimeJobs?: number;
+  operationsFullTimeJobs?: number;
+  financialAssistanceRevenues?: FinancialAssistanceRevenue[];
+  reinstatementCosts?: ReinstatementCost[];
+  yearlyProjectedExpenses: RecurringCost[];
+  yearlyProjectedRevenues: RecurringRevenue[];
+  reinstatementSchedule?: WorksSchedule;
+  firstYearOfOperation?: number;
+  sitePurchaseTotalAmount?: number;
+  siteResaleTotalAmount?: number;
+};
+
+export type ProjectDevelopmentPlanType = "PHOTOVOLTAIC_POWER_PLANT" | "MIXED_USE_NEIGHBOURHOOD";
+
+export type ProjectForComparison = {
   id: string;
   name: string;
   relatedSiteId: string;
@@ -99,8 +144,6 @@ export type Project = {
   reinstatementCost?: number;
   photovoltaicPanelsInstallationCost: number;
   financialAssistanceRevenues: number;
-  yearlyProjectedCosts: Expense[];
-  yearlyProjectedRevenues: Revenue[];
+  yearlyProjectedCosts: RecurringCost[];
+  yearlyProjectedRevenues: RecurringRevenue[];
 };
-
-export type ProjectDevelopmentPlanType = "PHOTOVOLTAIC_POWER_PLANT" | "MIXED_USE_NEIGHBOURHOOD";

--- a/apps/web/src/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi.ts
+++ b/apps/web/src/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi.ts
@@ -3,7 +3,7 @@ import {
   ProjectDetailsResult as ProjectImpactsComparisonResult,
   ProjectsDetailsGateway as ProjectImpactsComparisonGateway,
 } from "../../application/projectImpactsComparison.actions";
-import { ProjectSite } from "../../domain/projects.types";
+import { ProjectForComparison, ProjectSite } from "../../domain/projects.types";
 
 import { SITES_LIST_STORAGE_KEY } from "@/features/create-site/infrastructure/create-site-service/localStorageCreateSiteApi";
 import { LocalAutorityStructureType } from "@/shared/domain/stakeholder";
@@ -57,6 +57,6 @@ export class LocalStorageProjectDetailsApi implements ProjectImpactsComparisonGa
     const relatedSite = sitesList.find((site) => site.id === project.relatedSiteId);
     if (!relatedSite) throw new Error(`Could not find Site with id ${project.relatedSiteId}`);
 
-    return { siteData: relatedSite, projectData: project };
+    return { siteData: relatedSite, projectData: project as ProjectForComparison };
   }
 }

--- a/apps/web/src/features/projects/infrastructure/project-features-service/HttpProjectFeaturesService.ts
+++ b/apps/web/src/features/projects/infrastructure/project-features-service/HttpProjectFeaturesService.ts
@@ -1,0 +1,14 @@
+import { ProjectFeaturesGateway } from "../../application/project-features/projectFeatures.actions";
+import { ProjectFeatures } from "../../domain/projects.types";
+
+export class HttpProjectFeaturesService implements ProjectFeaturesGateway {
+  async getById(projectId: string): Promise<ProjectFeatures> {
+    const response = await fetch(`/api/reconversion-projects/${projectId}/features`);
+
+    if (!response.ok)
+      throw new Error(`Error while fetching reconversion project features with id ${projectId}`);
+
+    const jsonResponse = (await response.json()) as ProjectFeatures;
+    return jsonResponse;
+  }
+}

--- a/apps/web/src/features/projects/infrastructure/project-features-service/MockProjectFeaturesService.ts
+++ b/apps/web/src/features/projects/infrastructure/project-features-service/MockProjectFeaturesService.ts
@@ -1,0 +1,65 @@
+import { ProjectFeaturesGateway } from "../../application/project-features/projectFeatures.actions";
+import { ProjectFeatures } from "../../domain/projects.types";
+
+export class MockProjectFeaturesService implements ProjectFeaturesGateway {
+  projectFeatures: ProjectFeatures = {
+    id: "189038dd-3a6a-43af-bc8d-c4999d8d82ca",
+    name: "Mocked project name",
+    description: "Mocked project description",
+    developmentPlan: {
+      type: "PHOTOVOLTAIC_POWER_PLANT",
+      developerName: "ADEME",
+      installationCosts: [{ amount: 12000, purpose: "installation_works" }],
+      installationSchedule: {
+        startDate: "2029-01-01",
+        endDate: "2029-12-31",
+      },
+      electricalPowerKWc: 12309,
+      surfaceArea: 120000,
+      expectedAnnualProduction: 4399,
+      contractDuration: 20,
+    },
+    soilsDistribution: {
+      ARTIFICIAL_GRASS_OR_BUSHES_FILLED: 115000,
+      MINERAL_SOIL: 3500,
+      IMPERMEABLE_SOILS: 1500,
+    },
+    futureOwner: "ADEME",
+    futureOperator: "ADEME",
+    reinstatementContractOwner: "ADEME",
+    reinstatementFullTimeJobs: 1.5,
+    conversionFullTimeJobs: 3,
+    operationsFullTimeJobs: 0.4,
+    financialAssistanceRevenues: [{ amount: 9999, source: "public_subsidies" }],
+    reinstatementCosts: [
+      {
+        amount: 9999,
+        purpose: "deimpermeabilization",
+      },
+    ],
+    yearlyProjectedExpenses: [
+      { amount: 9999, purpose: "maintenance" },
+      { amount: 4009, purpose: "taxes" },
+    ],
+    yearlyProjectedRevenues: [
+      {
+        amount: 34000,
+        source: "operations",
+      },
+    ],
+    reinstatementSchedule: {
+      startDate: "2029-01-01",
+      endDate: "2029-12-31",
+    },
+    firstYearOfOperation: 2030,
+    sitePurchaseTotalAmount: 540000,
+  };
+
+  _setProjectFeatures(projectFeatures: ProjectFeatures): void {
+    this.projectFeatures = projectFeatures;
+  }
+
+  getById(): Promise<ProjectFeatures> {
+    return Promise.resolve(this.projectFeatures);
+  }
+}

--- a/apps/web/src/features/projects/views/project-page/ProjectImpactsPage.tsx
+++ b/apps/web/src/features/projects/views/project-page/ProjectImpactsPage.tsx
@@ -6,8 +6,8 @@ import {
   ViewMode,
 } from "../../application/projectImpacts.reducer";
 import { ProjectDevelopmentPlanType } from "../../domain/projects.types";
-import ProjectFeaturesView from "./features/ProjectFeaturesView";
 import ProjectImpactsPage from "./impacts/ProjectImpactsView";
+import ProjectFeaturesView from "./features";
 import ProjectImpactsActionBar from "./ProjectImpactsActionBar";
 import ProjectsImpactsPageHeader from "./ProjectPageHeader";
 
@@ -15,6 +15,7 @@ import classNames from "@/shared/views/clsx";
 import LoadingSpinner from "@/shared/views/components/Spinner/LoadingSpinner";
 
 type Props = {
+  projectId: string;
   dataLoadingState: ProjectImpactsState["dataLoadingState"];
   projectContext: {
     name: string;
@@ -42,6 +43,7 @@ const getProjectTypeClassName = (type?: ProjectDevelopmentPlanType) => {
 };
 
 function ProjectPage({
+  projectId,
   projectContext,
   dataLoadingState,
   onEvaluationPeriodChange,
@@ -95,7 +97,6 @@ function ProjectPage({
                 role="tab"
                 aria-selected="false"
                 aria-controls="tabpanel-caracteristiques-panel"
-                disabled
               >
                 Caractéristiques
               </button>
@@ -145,7 +146,7 @@ function ProjectPage({
           aria-labelledby="tabpanel-caracteristiques"
           tabIndex={1}
         >
-          <ProjectFeaturesView />
+          <ProjectFeaturesView projectId={projectId} />
         </div>
       </div>
     </div>

--- a/apps/web/src/features/projects/views/project-page/features/DataLine.tsx
+++ b/apps/web/src/features/projects/views/project-page/features/DataLine.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from "react";
+
+import classNames from "@/shared/views/clsx";
+
+type DataLineProps = {
+  label: ReactNode;
+  value: ReactNode;
+  className?: string;
+};
+export default function DataLine({ label, value, className = "" }: DataLineProps) {
+  const classes = classNames(
+    "tw-flex",
+    "tw-justify-between",
+    "tw-py-2",
+    "tw-px-0",
+    "tw-border-0",
+    "tw-border-b",
+    "tw-border-solid",
+    "tw-border-borderGrey",
+    className,
+  );
+  return (
+    <dl className={classes}>
+      <dd className="fr-p-0">{label}</dd>
+      <dt className="tw-text-right">{value}</dt>
+    </dl>
+  );
+}

--- a/apps/web/src/features/projects/views/project-page/features/DevelopmentPlanFeatures.tsx
+++ b/apps/web/src/features/projects/views/project-page/features/DevelopmentPlanFeatures.tsx
@@ -1,0 +1,57 @@
+import { typedObjectEntries } from "shared";
+import DataLine from "./DataLine";
+import SectionTitle from "./SectionTitle";
+
+import { ProjectFeatures } from "@/features/projects/domain/projects.types";
+import { getLabelForMixedUseNeighbourhoodSpace } from "@/shared/domain/mixedUseNeighbourhood";
+import { formatNumberFr, formatSurfaceArea } from "@/shared/services/format-number/formatNumber";
+import { sumList } from "@/shared/services/sum/sum";
+
+type Props = ProjectFeatures["developmentPlan"];
+
+export default function DevelopmentPlanFeatures(props: Props) {
+  switch (props.type) {
+    case "PHOTOVOLTAIC_POWER_PLANT":
+      return (
+        <section className="tw-mb-10">
+          <SectionTitle>⚙️ Paramètres du projet</SectionTitle>
+          <DataLine
+            label={<strong>Puissance d'installation</strong>}
+            value={`${formatNumberFr(props.electricalPowerKWc)} kWc`}
+          />
+          <DataLine
+            label={<strong>Superficie occupée par les panneaux</strong>}
+            value={formatSurfaceArea(props.surfaceArea)}
+          />
+          <DataLine
+            label={<strong>Production annuelle attendue</strong>}
+            value={`${formatNumberFr(props.expectedAnnualProduction)} MWh / an`}
+          />
+          <DataLine
+            label={<strong>Durée du contrat de revente d'énergie</strong>}
+            value={`${formatNumberFr(props.contractDuration)} ans`}
+          />
+        </section>
+      );
+    case "MIXED_USE_NEIGHBOURHOOD":
+      return (
+        <section className="tw-mb-10">
+          <SectionTitle>🏘 Espaces du quartier</SectionTitle>
+          <DataLine
+            label={<strong>Superficie totale</strong>}
+            value={formatSurfaceArea(sumList(Object.values(props.spaces)))}
+          />
+          {typedObjectEntries(props.spaces).map(([space, surfaceArea]) => {
+            return (
+              <DataLine
+                label={getLabelForMixedUseNeighbourhoodSpace(space)}
+                value={formatSurfaceArea(surfaceArea)}
+                key={space}
+                className="fr-pl-2w"
+              />
+            );
+          })}
+        </section>
+      );
+  }
+}

--- a/apps/web/src/features/projects/views/project-page/features/DevelopmentPlanInstallationExpenses.tsx
+++ b/apps/web/src/features/projects/views/project-page/features/DevelopmentPlanInstallationExpenses.tsx
@@ -1,0 +1,75 @@
+import DataLine from "./DataLine";
+
+import {
+  ProjectDevelopmentPlanType,
+  ProjectFeatures,
+} from "@/features/projects/domain/projects.types";
+import {
+  getLabelForMixedUseNeighbourhoodDevelopmentExpense,
+  MixedUseNeighbourhoodDevelopmentExpense,
+} from "@/shared/domain/mixedUseNeighbourhood";
+import {
+  getLabelForPhotovoltaicInstallationCostPurpose,
+  PhotovoltaicInstallationCost,
+} from "@/shared/domain/reconversionProject";
+import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
+import { sumList } from "@/shared/services/sum/sum";
+
+type Props = {
+  developmentPlanType: ProjectDevelopmentPlanType;
+  installationCosts: ProjectFeatures["developmentPlan"]["installationCosts"];
+};
+
+export default function DevelopmentPlanInstallationExpenses({
+  developmentPlanType,
+  installationCosts,
+}: Props) {
+  switch (developmentPlanType) {
+    case "PHOTOVOLTAIC_POWER_PLANT":
+      return (
+        <>
+          <DataLine
+            label={<strong>Dépenses d'installation de la centrale photovoltaïque</strong>}
+            value={
+              <strong>{formatNumberFr(sumList(installationCosts.map((r) => r.amount)))} €</strong>
+            }
+          />
+          {installationCosts.map(({ amount, purpose }) => {
+            return (
+              <DataLine
+                label={getLabelForPhotovoltaicInstallationCostPurpose(
+                  purpose as PhotovoltaicInstallationCost["purpose"],
+                )}
+                value={`${formatNumberFr(amount)} €`}
+                className="fr-pl-2w"
+                key={purpose}
+              />
+            );
+          })}
+        </>
+      );
+    case "MIXED_USE_NEIGHBOURHOOD":
+      return (
+        <>
+          <DataLine
+            label={<strong>Dépenses d'aménagement du quartier</strong>}
+            value={
+              <strong>{formatNumberFr(sumList(installationCosts.map((r) => r.amount)))} €</strong>
+            }
+          />
+          {installationCosts.map(({ amount, purpose }) => {
+            return (
+              <DataLine
+                label={getLabelForMixedUseNeighbourhoodDevelopmentExpense(
+                  purpose as MixedUseNeighbourhoodDevelopmentExpense["purpose"],
+                )}
+                value={`${formatNumberFr(amount)} €`}
+                className="fr-pl-2w"
+                key={purpose}
+              />
+            );
+          })}
+        </>
+      );
+  }
+}

--- a/apps/web/src/features/projects/views/project-page/features/ProjectFeaturesView.tsx
+++ b/apps/web/src/features/projects/views/project-page/features/ProjectFeaturesView.tsx
@@ -1,7 +1,292 @@
-export default function ProjectFeaturesView() {
+import { ReactNode } from "react";
+import { getTotalSurfaceArea, SoilType } from "shared";
+import DataLine from "./DataLine";
+import DevelopmentPlanFeatures from "./DevelopmentPlanFeatures";
+import DevelopmentPlanInstallationExpenses from "./DevelopmentPlanInstallationExpenses";
+import SectionTitle from "./SectionTitle";
+
+import {
+  getLabelForDevelopmentPlanCategory,
+  getLabelForRenewableEnergyProductionType,
+} from "@/features/create-project/views/projectTypeLabelMapping";
+import { ProjectFeatures } from "@/features/projects/domain/projects.types";
+import {
+  getLabelForFinancialAssistanceRevenueSource,
+  getLabelForRecurringCostPurpose,
+  getLabelForRecurringRevenueSource,
+  getLabelForReinstatementCostPurpose,
+} from "@/shared/domain/reconversionProject";
+import { formatNumberFr, formatSurfaceArea } from "@/shared/services/format-number/formatNumber";
+import { getLabelForSoilType } from "@/shared/services/label-mapping/soilTypeLabelMapping";
+import { sumList } from "@/shared/services/sum/sum";
+
+type Props = {
+  projectData: ProjectFeatures;
+};
+
+type ScheduleDatesProps = {
+  startDateString: string;
+  endDateString: string;
+};
+
+function ScheduleDates({ startDateString, endDateString }: ScheduleDatesProps) {
+  const startDate = new Date(startDateString);
+  const endDate = new Date(endDateString);
   return (
-    <section className="fr-container">
+    <span>
+      {startDate.toLocaleDateString()} ➡️ {endDate.toLocaleDateString()}
+    </span>
+  );
+}
+
+function Section({ children }: { children: ReactNode }) {
+  return <section className="tw-mb-10">{children}</section>;
+}
+
+export default function ProjectFeaturesView({ projectData }: Props) {
+  return (
+    <section className="fr-container tw-max-w-4xl">
       <h2>Caractéristiques du projet</h2>
+      <Section>
+        <SectionTitle>🏗 Type de projet</SectionTitle>
+        <DataLine
+          label={<strong>Type d'aménagement</strong>}
+          value={
+            projectData.developmentPlan.type === "PHOTOVOLTAIC_POWER_PLANT"
+              ? getLabelForDevelopmentPlanCategory("RENEWABLE_ENERGY")
+              : getLabelForDevelopmentPlanCategory(projectData.developmentPlan.type)
+          }
+        />
+        {projectData.developmentPlan.type === "PHOTOVOLTAIC_POWER_PLANT" && (
+          <DataLine
+            label={<strong>Type d'énergies renouvelables</strong>}
+            value={getLabelForRenewableEnergyProductionType("PHOTOVOLTAIC_POWER_PLANT")}
+          />
+        )}
+      </Section>
+      <DevelopmentPlanFeatures {...projectData.developmentPlan} />
+      <Section>
+        <SectionTitle>🌾 Transformation des sols</SectionTitle>
+        <DataLine
+          label={<strong>Superficie totale</strong>}
+          value={
+            <strong>{formatSurfaceArea(getTotalSurfaceArea(projectData.soilsDistribution))}</strong>
+          }
+        />
+        {Object.entries(projectData.soilsDistribution)
+          .filter(([, surfaceArea]) => surfaceArea > 0)
+          .map(([soilType, surfaceArea]) => {
+            return (
+              <DataLine
+                label={getLabelForSoilType(soilType as SoilType)}
+                value={formatSurfaceArea(surfaceArea)}
+                key={soilType}
+                className="fr-pl-2w"
+              />
+            );
+          })}
+      </Section>
+      <Section>
+        <SectionTitle>👱 Acteurs</SectionTitle>
+        <DataLine
+          label={<strong>Aménageur du site</strong>}
+          value={projectData.developmentPlan.developerName ?? "Non renseigné"}
+        />
+        <DataLine
+          label={<strong>Futur propriétaire du site</strong>}
+          value={projectData.futureOwner ?? "Pas de changement de propriétaire"}
+        />
+        {projectData.futureOperator && (
+          <DataLine label={<strong>Futur exploitant</strong>} value={projectData.futureOperator} />
+        )}
+        {projectData.reinstatementContractOwner && (
+          <DataLine
+            label={<strong>Maître d'ouvrage des travaux de remise en état de la friche</strong>}
+            value={projectData.reinstatementContractOwner}
+          />
+        )}
+        <div className="tw-py-2">
+          <strong> Emplois équivalent temps plein mobilisés</strong>
+        </div>
+        {projectData.reinstatementFullTimeJobs && (
+          <DataLine
+            label="Remise en état de la friche"
+            value={formatNumberFr(projectData.reinstatementFullTimeJobs)}
+            className="fr-pl-2w"
+          />
+        )}
+        {projectData.conversionFullTimeJobs && (
+          <DataLine
+            label="Installation des panneaux photovoltaïques"
+            value={
+              projectData.conversionFullTimeJobs
+                ? formatNumberFr(projectData.conversionFullTimeJobs)
+                : "Non renseigné"
+            }
+            className="fr-pl-2w"
+          />
+        )}
+        <DataLine
+          label="Exploitation du site reconverti"
+          value={
+            projectData.operationsFullTimeJobs
+              ? formatNumberFr(projectData.operationsFullTimeJobs)
+              : "Non renseigné"
+          }
+          className="fr-pl-2w"
+        />
+      </Section>
+      <Section>
+        <SectionTitle>💰 Dépenses et recettes du projet</SectionTitle>
+        {projectData.sitePurchaseTotalAmount ? (
+          <DataLine
+            label={<strong>Prix d'achat du site et droits de mutation</strong>}
+            value={<strong>{formatNumberFr(projectData.sitePurchaseTotalAmount)} €</strong>}
+          />
+        ) : undefined}
+        {!!projectData.reinstatementCosts && (
+          <>
+            <DataLine
+              label={<strong>Dépenses de remise en état de la friche</strong>}
+              value={
+                <strong>
+                  {formatNumberFr(sumList(projectData.reinstatementCosts.map((r) => r.amount)))} €
+                </strong>
+              }
+            />
+            {projectData.reinstatementCosts.map(({ amount, purpose }) => {
+              return (
+                <DataLine
+                  label={getLabelForReinstatementCostPurpose(purpose)}
+                  value={`${formatNumberFr(amount)} €`}
+                  className="fr-pl-2w"
+                  key={purpose}
+                />
+              );
+            })}
+          </>
+        )}
+        {projectData.developmentPlan.installationCosts.length > 0 && (
+          <DevelopmentPlanInstallationExpenses
+            developmentPlanType={projectData.developmentPlan.type}
+            installationCosts={projectData.developmentPlan.installationCosts}
+          />
+        )}
+        <DataLine
+          label={<strong>Dépenses annuelles</strong>}
+          value={
+            <div>
+              <strong>
+                {formatNumberFr(sumList(projectData.yearlyProjectedExpenses.map((e) => e.amount)))}{" "}
+                €
+              </strong>
+            </div>
+          }
+        />
+        {projectData.yearlyProjectedExpenses.map(({ amount, purpose }) => {
+          return (
+            <DataLine
+              label={getLabelForRecurringCostPurpose(purpose)}
+              value={`${formatNumberFr(amount)} €`}
+              className="fr-pl-2w"
+              key={purpose}
+            />
+          );
+        })}
+        {projectData.siteResaleTotalAmount ? (
+          <DataLine
+            label={<strong>Prix de revente du site et droits de mutation</strong>}
+            value={<strong>{formatNumberFr(projectData.siteResaleTotalAmount)} €</strong>}
+          />
+        ) : undefined}
+        {!!projectData.financialAssistanceRevenues && (
+          <>
+            <DataLine
+              label={<strong>Aides financières aux travaux</strong>}
+              value={
+                <strong>
+                  {formatNumberFr(
+                    sumList(projectData.financialAssistanceRevenues.map((r) => r.amount)),
+                  )}{" "}
+                  €
+                </strong>
+              }
+            />
+            {projectData.financialAssistanceRevenues.map(({ amount, source }) => {
+              return (
+                <DataLine
+                  label={getLabelForFinancialAssistanceRevenueSource(source)}
+                  value={`${formatNumberFr(amount)} €`}
+                  className="fr-pl-2w"
+                  key={source}
+                />
+              );
+            })}
+          </>
+        )}
+        <DataLine
+          label={
+            <div>
+              <strong>Recettes annuelles</strong>
+            </div>
+          }
+          value={
+            <div>
+              <strong>
+                {formatNumberFr(sumList(projectData.yearlyProjectedRevenues.map((e) => e.amount)))}{" "}
+                €
+              </strong>
+            </div>
+          }
+        />
+        {projectData.yearlyProjectedRevenues.map(({ amount, source }) => {
+          return (
+            <DataLine
+              label={getLabelForRecurringRevenueSource(source)}
+              value={`${formatNumberFr(amount)} €`}
+              className="fr-pl-2w"
+              key={source}
+            />
+          );
+        })}
+      </Section>
+      <Section>
+        <SectionTitle>📆 Calendrier</SectionTitle>
+        {projectData.reinstatementSchedule && (
+          <DataLine
+            label={<strong>Travaux de remise en état de la friche</strong>}
+            value={
+              <ScheduleDates
+                startDateString={projectData.reinstatementSchedule.startDate}
+                endDateString={projectData.reinstatementSchedule.endDate}
+              />
+            }
+          />
+        )}
+        {projectData.developmentPlan.installationSchedule && (
+          <DataLine
+            label={<strong>Travaux d'aménagement</strong>}
+            value={
+              <ScheduleDates
+                startDateString={projectData.developmentPlan.installationSchedule.startDate}
+                endDateString={projectData.developmentPlan.installationSchedule.endDate}
+              />
+            }
+          />
+        )}
+        <DataLine
+          label={<strong>Mise en service du site</strong>}
+          value={projectData.firstYearOfOperation ?? "Non renseigné"}
+        />
+      </Section>
+      <Section>
+        <SectionTitle>✍️ Dénomination</SectionTitle>
+        <DataLine label={<strong>Nom du projet</strong>} value={projectData.name} />
+        <DataLine
+          label={<strong>Description</strong>}
+          value={projectData.description || "Pas de description"}
+        />
+      </Section>
     </section>
   );
 }

--- a/apps/web/src/features/projects/views/project-page/features/ProjectFeaturesView.tsx
+++ b/apps/web/src/features/projects/views/project-page/features/ProjectFeaturesView.tsx
@@ -108,14 +108,14 @@ export default function ProjectFeaturesView({ projectData }: Props) {
         <div className="tw-py-2">
           <strong> Emplois équivalent temps plein mobilisés</strong>
         </div>
-        {projectData.reinstatementFullTimeJobs && (
+        {projectData.reinstatementFullTimeJobs ? (
           <DataLine
             label="Remise en état de la friche"
             value={formatNumberFr(projectData.reinstatementFullTimeJobs)}
             className="fr-pl-2w"
           />
-        )}
-        {projectData.conversionFullTimeJobs && (
+        ) : null}
+        {projectData.conversionFullTimeJobs ? (
           <DataLine
             label="Installation des panneaux photovoltaïques"
             value={
@@ -125,7 +125,7 @@ export default function ProjectFeaturesView({ projectData }: Props) {
             }
             className="fr-pl-2w"
           />
-        )}
+        ) : null}
         <DataLine
           label="Exploitation du site reconverti"
           value={

--- a/apps/web/src/features/projects/views/project-page/features/SectionTitle.tsx
+++ b/apps/web/src/features/projects/views/project-page/features/SectionTitle.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export default function SectionTitle({ children }: { children: ReactNode }) {
+  return <h3 className="tw-text-lg tw-mb-2">{children}</h3>;
+}

--- a/apps/web/src/features/projects/views/project-page/features/index.tsx
+++ b/apps/web/src/features/projects/views/project-page/features/index.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import ProjectFeaturesView from "./ProjectFeaturesView";
+
+import { fetchProjectFeatures } from "@/features/projects/application/project-features/projectFeatures.actions";
+import { selectProjectFeatures } from "@/features/projects/application/project-features/projectFeatures.reducer";
+import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
+
+type Props = {
+  projectId: string;
+};
+
+export default function ProjectFeaturesViewContainer({ projectId }: Props) {
+  const dispatch = useAppDispatch();
+  const projectFeatures = useAppSelector(selectProjectFeatures);
+
+  useEffect(() => {
+    void dispatch(fetchProjectFeatures({ projectId }));
+  }, [projectId, dispatch]);
+
+  if (!projectFeatures) return null;
+
+  return <ProjectFeaturesView projectData={projectFeatures} />;
+}

--- a/apps/web/src/features/projects/views/project-page/index.tsx
+++ b/apps/web/src/features/projects/views/project-page/index.tsx
@@ -30,6 +30,7 @@ function ProjectPageContainer({ projectId }: Props) {
 
   return (
     <ProjectPage
+      projectId={projectId}
       projectContext={projectContext}
       dataLoadingState={dataLoadingState}
       evaluationPeriod={evaluationPeriod}

--- a/apps/web/src/features/projects/views/projects-impacts-comparison/ImpactsComparisonHeader/index.tsx
+++ b/apps/web/src/features/projects/views/projects-impacts-comparison/ImpactsComparisonHeader/index.tsx
@@ -1,6 +1,6 @@
 import ImpactsComparisonPageHeader from "./ImpactsComparisonHeader";
 
-import { Project, ProjectSite } from "@/features/projects/domain/projects.types";
+import { ProjectForComparison, ProjectSite } from "@/features/projects/domain/projects.types";
 
 type Props = {
   baseScenario:
@@ -12,13 +12,13 @@ type Props = {
     | {
         type: "PROJECT";
         id: string;
-        projectData: Project;
+        projectData: ProjectForComparison;
         siteData: ProjectSite;
       };
   withScenario: {
     type: "PROJECT";
     id: string;
-    projectData: Project;
+    projectData: ProjectForComparison;
     siteData: ProjectSite;
   };
 };

--- a/apps/web/src/features/projects/views/projects-impacts-comparison/ProjectsImpactsComparisonPage.tsx
+++ b/apps/web/src/features/projects/views/projects-impacts-comparison/ProjectsImpactsComparisonPage.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useState } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import { ImpactCategoryFilter } from "../../application/projectImpacts.reducer";
-import { Project, ProjectSite } from "../../domain/projects.types";
+import { ProjectForComparison, ProjectSite } from "../../domain/projects.types";
 import ProjectsComparisonActionBar from "../shared/actions/ActionBar";
 import CarbonEmissionComparisonChart from "./charts/carbon-emission/CarbonEmissionComparisonChart";
 import CarbonStorageComparisonChart from "./charts/carbon-storage";
@@ -40,13 +40,13 @@ type SuccessDataProps = {
     | {
         type: "PROJECT";
         id: string;
-        projectData: Project;
+        projectData: ProjectForComparison;
         siteData: ProjectSite;
       };
   withScenario: {
     type: "PROJECT";
     id: string;
-    projectData: Project;
+    projectData: ProjectForComparison;
     siteData: ProjectSite;
   };
 };

--- a/apps/web/src/shared/domain/mixedUseNeighbourhood.ts
+++ b/apps/web/src/shared/domain/mixedUseNeighbourhood.ts
@@ -1,0 +1,55 @@
+export type MixedUseNeighbourhoodSpace =
+  // private spaces
+  | "BUILDINGS_FOOTPRINT" // emprise au sol bâti = surface occupée au sol par les bâtiments
+  | "PRIVATE_PAVED_ALLEY_OR_PARKING_LOT"
+  | "PRIVATE_GRAVEL_ALLEY_OR_PARKING_LOT"
+  | "PRIVATE_GARDEN_AND_GRASS_ALLEYS"
+  // public spaces
+  | "PUBLIC_GREEN_SPACES"
+  | "PUBLIC_PAVED_ROAD_OR_SQUARES_OR_SIDEWALKS"
+  | "PUBLIC_GRAVEL_ROAD_OR_SQUARES_OR_SIDEWALKS"
+  | "PUBLIC_GRASS_ROAD_OR_SQUARES_OR_SIDEWALKS"
+  | "PUBLIC_PARKING_LOT";
+
+export const getLabelForMixedUseNeighbourhoodSpace = (
+  space: MixedUseNeighbourhoodSpace,
+): string => {
+  switch (space) {
+    case "BUILDINGS_FOOTPRINT":
+      return "Emprise au sol bâti";
+    case "PRIVATE_PAVED_ALLEY_OR_PARKING_LOT":
+      return "Allée ou parking privé bitumé";
+    case "PRIVATE_GRAVEL_ALLEY_OR_PARKING_LOT":
+      return "Allée ou parking privé en gravier";
+    case "PRIVATE_GARDEN_AND_GRASS_ALLEYS":
+      return "Jardin et allées enherbées privées";
+    case "PUBLIC_GREEN_SPACES":
+      return "Espaces verts publics";
+    case "PUBLIC_PAVED_ROAD_OR_SQUARES_OR_SIDEWALKS":
+      return "Voies, places, trottoirs bitumés";
+    case "PUBLIC_GRAVEL_ROAD_OR_SQUARES_OR_SIDEWALKS":
+      return "Voies, places, trottoirs en gravier";
+    case "PUBLIC_GRASS_ROAD_OR_SQUARES_OR_SIDEWALKS":
+      return "Voies, places, trottoirs enherbés";
+    case "PUBLIC_PARKING_LOT":
+      return "Parking public";
+  }
+};
+
+export type MixedUseNeighbourhoodDevelopmentExpense = {
+  amount: number;
+  purpose: "technical_studies" | "development_works" | "other";
+};
+
+export const getLabelForMixedUseNeighbourhoodDevelopmentExpense = (
+  expensePurpose: MixedUseNeighbourhoodDevelopmentExpense["purpose"],
+): string => {
+  switch (expensePurpose) {
+    case "technical_studies":
+      return "📋 Études et honoraires techniques";
+    case "development_works":
+      return "🛠 Travaux d'aménagement";
+    case "other":
+      return "🚧 Autres dépenses d'aménagement";
+  }
+};

--- a/apps/web/src/test/testAppDependencies.ts
+++ b/apps/web/src/test/testAppDependencies.ts
@@ -8,6 +8,7 @@ import { InMemorySaveReconversionProjectService } from "@/features/create-projec
 import { SitesServiceMock } from "@/features/create-project/infrastructure/sites-service/SitesServiceMock";
 import { InMemoryCreateSiteService } from "@/features/create-site/infrastructure/create-site-service/inMemoryCreateSiteApi";
 import { LocalStorageProjectDetailsApi } from "@/features/projects/infrastructure/project-details-service/localStorageProjectDetailsApi";
+import { MockProjectFeaturesService } from "@/features/projects/infrastructure/project-features-service/MockProjectFeaturesService";
 import { InMemoryReconversionProjectsListService } from "@/features/projects/infrastructure/projects-list-service/InMemoryProjectsListService";
 import { MockReconversionProjectImpactsApi } from "@/features/projects/infrastructure/reconversion-project-impacts-service/MockReconversionProjectImpactsService";
 import { MockSiteFeaturesService } from "@/features/site-features/infra/site-features-service/MockSiteFeaturesService";
@@ -56,6 +57,7 @@ export const getTestAppDependencies = (
     createUserService: new InMemoryCreateUserService(),
     siteFeaturesService: new MockSiteFeaturesService(),
     saveExpressReconversionProjectService: new InMemorySaveExpressReconversionProjectService(),
+    projectFeaturesService: new MockProjectFeaturesService(),
     ...depsOverride,
   };
 };


### PR DESCRIPTION
J'ai gardé la UI avec les onglets pour l'instant mais mis le fetching dans un reducer à part.

Aussi les tabs du dsfr ne font pas de lazy rendering donc les caractéristiques sont chargées lorsque tu arrives sur la page impacts, même si tu la consulteras pas. Le coût de la requête est marginal mais ça va de toute façon changer avec la refonte de cette page.

A noter que j'ai utilisé des subqueries SQL, je trouve ça plus lisible et maintenable et il n'y a pas d'overhead sur la perf.
Tu en penses quoi ?