### PR TITLE
chore: update react dsfr predev and prebuild scripts and css import in index.html

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,8 +9,8 @@
     <link rel="apple-touch-icon" href="/favicon/favicon-180.png" />
     <link rel="manifest" href="/favicon/manifest.webmanifest" crossorigin="use-credentials" />
 
-    <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css?hash=ef6306c7" />
-    <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
+    <link rel="stylesheet" href="./node_modules/@codegouvfr/react-dsfr/main.css" />
+    
     <script async src="https://tally.so/widgets/embed.js"></script>
     <script src="/js/env-vars.js"></script>
     <title>Bénéfriches, l'outil qui calcule la valeur réelle de votre projet d'aménagement</title>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,8 +23,8 @@
     "preinstall": "npx only-allow pnpm",
     "## needed by @codegouvfr/react-dsfr": "//",
     "postinstall": "copy-dsfr-to-public",
-    "predev": "only-include-used-icons",
-    "prebuild": "only-include-used-icons"
+    "predev": "react-dsfr update-icons",
+    "prebuild": "react-dsfr update-icons"
   },
   "dependencies": {
     "@codegouvfr/react-dsfr": "^1.10.11",


### PR DESCRIPTION
D’après certaines issues sur le repo [react-dsfr](https://github.com/codegouvfr/react-dsfr) il y a eu des changements sur les imports css pour les icônes (le script `only-include-used-icons`) avec notamment l’ajout d’un hash pour éviter que le cache du navigateur empêche de récupérer le nouveau fichier en cas de nouvelles icônes utilisées.
Le script `only-include-used-icons `qui génère ce hash, d’où le fait que ça change à chaque `pnpm dev`

D’après [la doc](https://react-dsfr.codegouv.studio/ ) avec `vite`, on peut directement importer le fichier css à partir des node_modules dans le `index.html`.

Au `build`, l’import est remplacé par les fichiers avec hash : 
```html
<!doctype html>
<html lang="fr">

<head>
  <meta charset="UTF-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
  <link rel="icon" href="/favicon/favicon-32.png" sizes="32x32" type="image/png" />
  <link rel="icon" href="/favicon/favicon-128.png" sizes="128x128" type="image/png" />
  <link rel="icon" href="/favicon/favicon-192.png" sizes="192x192" type="image/png" />
  <link rel="apple-touch-icon" href="/favicon/favicon-180.png" />
  <link rel="manifest" href="/favicon/manifest.webmanifest" crossorigin="use-credentials" />


  <script async src="https://tally.so/widgets/embed.js"></script>
  <script src="/js/env-vars.js"></script>
  <title>Bénéfriches, l'outil qui calcule la valeur réelle de votre projet d'aménagement</title>
  <script type="module" crossorigin src="/assets/index-B5YMlOz_.js"></script>
  <link rel="stylesheet" crossorigin href="/assets/index-Bw30ip1W.css">

<body>
  <div id="root"></div>
</body>

</html>
```

