### PR TITLE
fix(api): do not compute avoided friche costs impacts if site is not friche

### DIFF
--- a/apps/api/src/reconversion-projects/core/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.spec.ts
+++ b/apps/api/src/reconversion-projects/core/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.spec.ts
@@ -11,6 +11,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
@@ -21,6 +22,7 @@ describe("Socio-economic impacts", () => {
         futureSiteOwner: "Mairie de Paris",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [{ amount: 30000, purpose: "rent" }],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -38,6 +40,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 20000, purpose: "rent" }],
         yearlyProjectedCosts: [],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -54,6 +57,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 5000, purpose: "rent" }],
         yearlyProjectedCosts: [{ amount: 10000, purpose: "rent" }],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -72,6 +76,7 @@ describe("Socio-economic impacts", () => {
         futureSiteOwner: "New owner",
         yearlyCurrentCosts: [{ amount: 5000, purpose: "rent" }],
         yearlyProjectedCosts: [{ amount: 10000, purpose: "rent" }],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -97,6 +102,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
@@ -133,6 +139,7 @@ describe("Socio-economic impacts", () => {
           },
         ],
         yearlyProjectedCosts: [],
+        isFriche: true,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -171,6 +178,7 @@ describe("Socio-economic impacts", () => {
           },
         ],
         yearlyProjectedCosts: [],
+        isFriche: true,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -185,6 +193,23 @@ describe("Socio-economic impacts", () => {
         },
       ]);
     });
+
+    it("returns no avoided friche costs if site is not friche", () => {
+      const result = computeDirectAndIndirectEconomicImpacts({
+        evaluationPeriodInYears: 10,
+        currentOwner: "Current owner",
+        currentTenant: undefined,
+        yearlyCurrentCosts: [
+          {
+            amount: 14000,
+            purpose: "maintenance",
+          },
+        ],
+        yearlyProjectedCosts: [],
+        isFriche: false,
+      });
+      expect(result).toEqual<SocioEconomicImpactsResult>([]);
+    });
   });
 
   describe("Taxes income", () => {
@@ -194,6 +219,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
@@ -204,6 +230,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 12000, purpose: "taxes" }],
         yearlyProjectedCosts: [{ amount: 20000, purpose: "taxes" }],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -221,6 +248,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [{ amount: 12000, purpose: "taxes" }],
         yearlyProjectedCosts: [],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -238,6 +266,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [{ amount: 1234, purpose: "taxes" }],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {
@@ -257,6 +286,7 @@ describe("Socio-economic impacts", () => {
         currentOwner: "Current owner",
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([]);
     });
@@ -269,6 +299,7 @@ describe("Socio-economic impacts", () => {
         yearlyCurrentCosts: [],
         yearlyProjectedCosts: [],
         propertyTransferDutiesAmount: 5000,
+        isFriche: false,
       });
       expect(result).toEqual<SocioEconomicImpactsResult>([
         {

--- a/apps/api/src/reconversion-projects/core/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.ts
+++ b/apps/api/src/reconversion-projects/core/model/impacts/socio-economic/computeDirectAndIndirectEconomicImpacts.ts
@@ -21,6 +21,7 @@ type DirectAndIndirectEconomicImpactsInput = {
   yearlyCurrentCosts: { purpose: string; amount: number }[];
   yearlyProjectedCosts: ReconversionProject["yearlyProjectedCosts"];
   propertyTransferDutiesAmount?: number;
+  isFriche: boolean;
 };
 
 type BaseEconomicImpact = { actor: string; amount: number };
@@ -102,7 +103,7 @@ export const computeDirectAndIndirectEconomicImpacts = (
     FRICHE_COST_PURPOSES.includes(purpose as FricheCostPurpose),
   ) as { purpose: FricheCostPurpose; amount: number }[];
 
-  if (currentFricheCosts.length) {
+  if (currentFricheCosts.length && input.isFriche) {
     const fricheCostImpactAmount = sumListWithKey(currentFricheCosts, "amount");
     impacts.push({
       amount: fricheCostImpactAmount * input.evaluationPeriodInYears,

--- a/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.ts
@@ -221,6 +221,7 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
         yearlyCurrentCosts: relatedSite.yearlyCosts,
         yearlyProjectedCosts: reconversionProject.yearlyProjectedCosts,
         propertyTransferDutiesAmount: reconversionProject.sitePurchasePropertyTransferDutiesAmount,
+        isFriche: relatedSite.isFriche,
       }),
       ...computeEnvironmentalMonetaryImpacts({
         baseSoilsDistribution: relatedSite.soilsDistribution,


### PR DESCRIPTION
l’impact « Dépenses de sécurisation de la friche évités » s’affichait pour les sites non friche car le coût « maintenance » est compté dans les dépenses évités pour la friche, et c’est un coût que l’on peut remplir pour un site non friche (et pré-rempli pour un site express).