### PR TITLE
feat(web): update next button behaviour for create site form

### DIFF
--- a/apps/web/src/features/create-site/views/create-mode-selection/CreateModeSelectionForm.tsx
+++ b/apps/web/src/features/create-site/views/create-mode-selection/CreateModeSelectionForm.tsx
@@ -78,7 +78,9 @@ function CreateModeSelectionForm({ onSubmit }: Props) {
           </div>
           {validationError && <p className={fr.cx("fr-error-text")}>{validationError.message}</p>}
         </div>
-        <Button nativeButtonProps={{ type: "submit" }}>Suivant</Button>
+        <Button nativeButtonProps={{ type: "submit", disabled: !formState.isValid }}>
+          Valider
+        </Button>
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/accidents/accidents-count/FricheAccidentsForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/accidents/accidents-count/FricheAccidentsForm.tsx
@@ -12,7 +12,7 @@ type Props = {
   onBack: () => void;
 };
 
-type HasRecentAccidentsStringOption = "yes" | "no";
+type HasRecentAccidentsStringOption = "yes" | "no" | null;
 
 export type FormValues = {
   hasRecentAccidents: HasRecentAccidentsStringOption;
@@ -27,6 +27,18 @@ function FricheAccidentsForm({ onSubmit, onBack }: Props) {
   });
 
   const { hasRecentAccidents: hasRecentAccidentsError } = formState.errors;
+
+  const {
+    hasRecentAccidents: hasRecentAccidentsValue,
+    accidentsMinorInjuries,
+    accidentsSevereInjuries,
+    accidentsDeaths,
+  } = watch();
+  const hasRecentAccidents = watch("hasRecentAccidents") === "yes";
+
+  const isValid = hasRecentAccidents
+    ? accidentsMinorInjuries || accidentsSevereInjuries || accidentsDeaths
+    : true;
 
   return (
     <WizardFormLayout
@@ -45,7 +57,7 @@ function FricheAccidentsForm({ onSubmit, onBack }: Props) {
           }
         >
           <RadioButton label="Oui" value="yes" {...register("hasRecentAccidents")} />
-          {watch("hasRecentAccidents") === "yes" && (
+          {hasRecentAccidents && (
             <>
               <NumericInput
                 name="accidentsMinorInjuries"
@@ -87,7 +99,11 @@ function FricheAccidentsForm({ onSubmit, onBack }: Props) {
           )}
           <RadioButton label="Non / Ne sait pas" value="no" {...register("hasRecentAccidents")} />
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          disabled={!isValid}
+          nextLabel={hasRecentAccidentsValue !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/address/AddressForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/address/AddressForm.tsx
@@ -29,6 +29,8 @@ function SiteAddressForm({ onSubmit, isFriche, onBack }: Props) {
     required: "L'adresse est nécessaire pour les étapes suivantes",
   });
 
+  const selectedAddress = watch("selectedAddress");
+
   return (
     <>
       <WizardFormLayout
@@ -77,7 +79,7 @@ function SiteAddressForm({ onSubmit, isFriche, onBack }: Props) {
                   field.onChange(searchText);
                   setValue("selectedAddress", undefined);
                 }}
-                selectedAddress={watch("selectedAddress")}
+                selectedAddress={selectedAddress}
                 onSelect={(v) => {
                   setValue("selectedAddress", v);
                   setValue("searchText", v.value);
@@ -90,7 +92,7 @@ function SiteAddressForm({ onSubmit, isFriche, onBack }: Props) {
               />
             )}
           />
-          <BackNextButtonsGroup onBack={onBack} />
+          <BackNextButtonsGroup onBack={onBack} disabled={!selectedAddress} nextLabel="Valider" />
         </form>
       </WizardFormLayout>
     </>

--- a/apps/web/src/features/create-site/views/custom/friche-activity/FricheActivityForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/friche-activity/FricheActivityForm.tsx
@@ -64,7 +64,7 @@ function FricheActivityForm({ onSubmit, onBack }: Props) {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<FormValues>();
 
   const error = errors.activity;
@@ -79,7 +79,7 @@ function FricheActivityForm({ onSubmit, onBack }: Props) {
           options={FRICHE_ACTIVITY_OPTIONS}
           error={error}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/naming/SiteNameAndDescription.tsx
+++ b/apps/web/src/features/create-site/views/custom/naming/SiteNameAndDescription.tsx
@@ -43,7 +43,7 @@ function SiteNameAndDescriptionForm({ onSubmit, onBack, defaultSiteName }: Props
           textArea
           nativeTextAreaProps={register("description")}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/full-time-jobs/SiteFullTimeJobsInvolvedForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/full-time-jobs/SiteFullTimeJobsInvolvedForm.tsx
@@ -15,7 +15,7 @@ export type FormValues = {
 };
 
 function SiteFullTimeJobsInvolvedForm({ onSubmit, onBack }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>();
+  const { control, handleSubmit, watch } = useForm<FormValues>();
 
   return (
     <WizardFormLayout
@@ -42,7 +42,10 @@ function SiteFullTimeJobsInvolvedForm({ onSubmit, onBack }: Props) {
           }}
           control={control}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={watch("fullTimeJobsInvolved") ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/is-friche-leased/IsFricheLeasedForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/is-friche-leased/IsFricheLeasedForm.tsx
@@ -10,19 +10,17 @@ type Props = {
 };
 
 export type FormValues = {
-  isFricheLeased: "yes" | "no";
+  isFricheLeased: "yes" | "no" | null;
 };
 
-const requiredMessage = "Ce champ est requis";
-
 function IsFricheLeasedForm({ onSubmit, onBack }: Props) {
-  const { register, handleSubmit, formState } = useForm<FormValues>();
+  const { register, handleSubmit, formState, watch } = useForm<FormValues>();
 
   return (
     <WizardFormLayout title="La friche est-elle encore louée ?">
       <form onSubmit={handleSubmit(onSubmit)}>
         <RadioButtons
-          {...register("isFricheLeased", { required: requiredMessage })}
+          {...register("isFricheLeased")}
           options={[
             {
               label: `Oui`,
@@ -35,7 +33,10 @@ function IsFricheLeasedForm({ onSubmit, onBack }: Props) {
           ]}
           error={formState.errors.isFricheLeased}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={watch("isFricheLeased") !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/is-site-operated/IsSiteOperatedForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/is-site-operated/IsSiteOperatedForm.tsx
@@ -10,19 +10,17 @@ type Props = {
 };
 
 export type FormValues = {
-  isSiteOperated: "yes" | "no";
+  isSiteOperated: "yes" | "no" | null;
 };
 
-const requiredMessage = "Ce champ est requis";
-
 function IsSiteOperatedForm({ onSubmit, onBack }: Props) {
-  const { register, handleSubmit, formState } = useForm<FormValues>();
+  const { register, handleSubmit, formState, watch } = useForm<FormValues>();
 
   return (
     <WizardFormLayout title="Le site est-il exploité ?">
       <form onSubmit={handleSubmit(onSubmit)}>
         <RadioButtons
-          {...register("isSiteOperated", { required: requiredMessage })}
+          {...register("isSiteOperated")}
           options={[
             {
               label: `Oui`,
@@ -35,7 +33,10 @@ function IsSiteOperatedForm({ onSubmit, onBack }: Props) {
           ]}
           error={formState.errors.isSiteOperated}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={watch("isSiteOperated") !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/owner/SiteOwnerForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/owner/SiteOwnerForm.tsx
@@ -143,7 +143,7 @@ function SiteOwnerForm({
             />
           )}
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/site-operator/SiteOperatorForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/site-operator/SiteOperatorForm.tsx
@@ -126,7 +126,7 @@ function SiteOperatorForm({
             />
           )}
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/tenant/SiteTenantForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/tenant/SiteTenantForm.tsx
@@ -108,7 +108,7 @@ function SiteTenantForm({ onSubmit, onBack, localAuthoritiesList }: Props) {
             />
           )}
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/yearly-expenses/SiteYearlyExpensesForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/yearly-expenses/SiteYearlyExpensesForm.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { typedObjectEntries } from "shared";
 import SiteYearlyExpensesFormInstructions from "./SiteYearlyExpensesFormInstructions";
 
 import { getLabelForExpensePurpose } from "@/features/create-site/domain/expenses.functions";
@@ -145,6 +146,12 @@ function SiteYearlyExpensesForm({
 
   const title = `💸 Dépenses annuelles ${isFriche ? "de la friche" : "du site"}`;
 
+  const formValues = watch();
+
+  const hasNoValuesFilled =
+    typedObjectEntries(formValues).filter(([, value]) => typeof value?.amount === "number")
+      .length === 0;
+
   return (
     <WizardFormLayout title={title} instructions={<SiteYearlyExpensesFormInstructions />}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -253,7 +260,10 @@ function SiteYearlyExpensesForm({
           </>
         )}
 
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={hasNoValuesFilled ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-management/yearly-income/SiteYearlyIncomeForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-management/yearly-income/SiteYearlyIncomeForm.tsx
@@ -1,4 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
+import { typedObjectEntries } from "shared";
 
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
@@ -15,7 +16,12 @@ export type FormValues = {
 };
 
 function SiteYearlyIncomeForm({ onSubmit, onBack }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>();
+  const { control, handleSubmit, watch } = useForm<FormValues>();
+
+  const formValues = watch();
+
+  const hasNoValuesFilled =
+    typedObjectEntries(formValues).filter(([, value]) => typeof value === "number").length === 0;
 
   return (
     <WizardFormLayout title="Recettes annuelles liées à l'exploitation du site">
@@ -60,7 +66,10 @@ function SiteYearlyIncomeForm({ onSubmit, onBack }: Props) {
             );
           }}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={hasNoValuesFilled ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/site-type/SiteTypeForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/site-type/SiteTypeForm.tsx
@@ -55,7 +55,7 @@ function SiteTypeForm({ onSubmit, onBack }: Props) {
             options={options}
             error={error}
           />
-          <BackNextButtonsGroup onBack={onBack} />
+          <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
         </form>
       </WizardFormLayout>
     </>

--- a/apps/web/src/features/create-site/views/custom/soil-contamination/SoilContaminationForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/soil-contamination/SoilContaminationForm.tsx
@@ -16,7 +16,7 @@ type Props = {
   siteSurfaceArea: number;
 };
 
-type HasContaminatedSoilsString = "yes" | "no";
+type HasContaminatedSoilsString = "yes" | "no" | null;
 
 export type FormValues = {
   hasContaminatedSoils: HasContaminatedSoilsString;
@@ -94,7 +94,11 @@ function SoilContaminationForm({ onSubmit, onBack, siteSurfaceArea }: Props) {
           <RadioButton {...register("hasContaminatedSoils")} label="Non" value="no" />
         </Fieldset>
 
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          disabled={!formState.isValid}
+          nextLabel={hasContaminatedSoilsValue !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/soils/soils-distribution/accuracy-selection/AccuracySelectionForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/soils-distribution/accuracy-selection/AccuracySelectionForm.tsx
@@ -47,7 +47,7 @@ function SiteSoilsDistributionAccuracySelectionForm({ onSubmit, onBack, isFriche
             },
           ]}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-percentage/ByPercentageForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-percentage/ByPercentageForm.tsx
@@ -10,6 +10,7 @@ import {
   getPictogramForSoilType,
 } from "@/shared/services/label-mapping/soilTypeLabelMapping";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
+import SurfaceAreaPieChart from "@/shared/views/components/Charts/SurfaceAreaPieChart";
 import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
 import SliderNumericInput from "@/shared/views/components/form/NumericInput/SliderNumericInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
@@ -44,7 +45,12 @@ function SiteSoilsDistributionByPercentageForm({ soils, onSubmit, onBack }: Prop
   const remainder = 100 - totalAllocated;
 
   return (
-    <WizardFormLayout title="Quelle est la répartition des différents sols ?">
+    <WizardFormLayout
+      title="Quelle est la répartition des différents sols ?"
+      instructions={
+        <SurfaceAreaPieChart soilsDistribution={soilsValues} remainderSurfaceArea={remainder} />
+      }
+    >
       <form onSubmit={_onSubmit}>
         {soils.map((soilType) => (
           <SliderNumericInput
@@ -86,7 +92,7 @@ function SiteSoilsDistributionByPercentageForm({ soils, onSubmit, onBack }: Prop
               : `${formatNumberFr(Math.abs(remainder))}% ${remainder > 0 ? "manquants" : "en trop"}`
           }
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={remainder !== 0} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
@@ -12,6 +12,7 @@ import {
   getPictogramForSoilType,
 } from "@/shared/services/label-mapping/soilTypeLabelMapping";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
+import SurfaceAreaPieChart from "@/shared/views/components/Charts/SurfaceAreaPieChart";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
 import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
@@ -40,6 +41,7 @@ function SiteSoilsDistributionBySquareMetersForm({
   const _onSubmit = handleSubmit(onSubmit);
 
   const soilsValues = watch();
+  console.log(soilsValues);
 
   const totalAllocatedSurface = useMemo(() => getTotalSurface(soilsValues), [soilsValues]);
 
@@ -47,7 +49,12 @@ function SiteSoilsDistributionBySquareMetersForm({
   const isValid = remainder === 0;
 
   return (
-    <WizardFormLayout title="Quelles sont les superficies des différents sols ?">
+    <WizardFormLayout
+      title="Quelles sont les superficies des différents sols ?"
+      instructions={
+        <SurfaceAreaPieChart soilsDistribution={soilsValues} remainderSurfaceArea={remainder} />
+      }
+    >
       <form onSubmit={_onSubmit}>
         {soils.map((soilType) => (
           <Controller
@@ -97,7 +104,7 @@ function SiteSoilsDistributionBySquareMetersForm({
               : `${formatSurfaceArea(Math.abs(remainder))} ${remainder > 0 ? "manquants" : "en trop"}`
           }
         />
-        <BackNextButtonsGroup onBack={onBack} disabled={!isValid} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/soils/soils-selection/SoilsForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/soils-selection/SoilsForm.tsx
@@ -168,8 +168,10 @@ function SiteSoilsForm({ onSubmit, onBack, isFriche }: Props) {
             </section>
           );
         })}
-        {validationError && <p className={fr.cx("fr-error-text")}>{validationError.message}</p>}
-        <BackNextButtonsGroup onBack={onBack} />
+        {validationError && (
+          <p className={fr.cx("fr-error-text", "fr-mb-1-5v")}>{validationError.message}</p>
+        )}
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/custom/soils/surface-area/SiteSurfaceAreaForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/surface-area/SiteSurfaceAreaForm.tsx
@@ -53,7 +53,7 @@ function SurfaceAreaForm({ onSubmit, onBack }: Props) {
           </p>
         )}
 
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!surface} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-site/views/express/address/AddressForm.tsx
+++ b/apps/web/src/features/create-site/views/express/address/AddressForm.tsx
@@ -29,6 +29,8 @@ function SiteAddressForm({ onSubmit, isFriche, onBack }: Props) {
       "La commune est utilisée par Bénéfriches pour calculer les impacts à partir de données locales.",
   });
 
+  const selectedAddress = watch("selectedAddress");
+
   return (
     <>
       <WizardFormLayout title={title}>
@@ -48,7 +50,7 @@ function SiteAddressForm({ onSubmit, isFriche, onBack }: Props) {
                   field.onChange(searchText);
                   setValue("selectedAddress", undefined);
                 }}
-                selectedAddress={watch("selectedAddress")}
+                selectedAddress={selectedAddress}
                 onSelect={(v) => {
                   setValue("selectedAddress", v as MunicipalityAddress);
                   setValue("searchText", v.value);
@@ -61,7 +63,7 @@ function SiteAddressForm({ onSubmit, isFriche, onBack }: Props) {
               />
             )}
           />
-          <BackNextButtonsGroup onBack={onBack} />
+          <BackNextButtonsGroup onBack={onBack} disabled={!selectedAddress} nextLabel="Valider" />
         </form>
       </WizardFormLayout>
     </>

--- a/apps/web/src/features/create-site/views/express/site-type/SiteTypeForm.tsx
+++ b/apps/web/src/features/create-site/views/express/site-type/SiteTypeForm.tsx
@@ -55,7 +55,7 @@ function SiteTypeForm({ onSubmit, onBack }: Props) {
             options={options}
             error={error}
           />
-          <BackNextButtonsGroup onBack={onBack} />
+          <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
         </form>
       </WizardFormLayout>
     </>

--- a/apps/web/src/features/create-site/views/express/surface-area/SiteSurfaceAreaForm.tsx
+++ b/apps/web/src/features/create-site/views/express/surface-area/SiteSurfaceAreaForm.tsx
@@ -53,7 +53,7 @@ function SurfaceAreaForm({ onSubmit, onBack }: Props) {
           </p>
         )}
 
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!surface} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/shared/views/components/BackNextButtons/BackNextButtons.tsx
+++ b/apps/web/src/shared/views/components/BackNextButtons/BackNextButtons.tsx
@@ -4,16 +4,22 @@ type Props = {
   onBack: () => void;
   onNext?: () => void;
   disabled?: boolean;
+  nextLabel?: string;
 };
 
-const BackNextButtonsGroup = ({ onBack, onNext, disabled = false }: Props) => {
+const BackNextButtonsGroup = ({
+  onBack,
+  onNext,
+  disabled = false,
+  nextLabel = "Suivant",
+}: Props) => {
   const backButtonProps = {
     children: "Précédent",
     priority: "secondary",
     nativeButtonProps: { type: "button", onClick: onBack },
   } as const;
   const nextButtonProps = {
-    children: "Suivant",
+    children: nextLabel,
     nativeButtonProps: { type: "submit", onClick: onNext, disabled },
   } as const;
   return (

--- a/apps/web/src/shared/views/components/Charts/SurfaceAreaPieChart.tsx
+++ b/apps/web/src/shared/views/components/Charts/SurfaceAreaPieChart.tsx
@@ -12,9 +12,10 @@ import { getLabelForSoilType } from "@/shared/services/label-mapping/soilTypeLab
 
 type Props = {
   soilsDistribution: SoilsDistribution;
+  remainderSurfaceArea?: number;
 };
 
-const SurfaceAreaPieChart = ({ soilsDistribution }: Props) => {
+const SurfaceAreaPieChart = ({ soilsDistribution, remainderSurfaceArea }: Props) => {
   const variablePieChartRef = useRef<HighchartsReact.RefObject>(null);
   const soilsEntries = typedObjectEntries(soilsDistribution).filter(
     ([, surfaceArea]) => (surfaceArea as number) > 0,
@@ -27,6 +28,14 @@ const SurfaceAreaPieChart = ({ soilsDistribution }: Props) => {
       color: getColorForSoilType(soilType),
     };
   });
+
+  if (remainderSurfaceArea) {
+    data.push({
+      name: "Non assigné",
+      y: remainderSurfaceArea,
+      color: fr.colors.decisions.border.disabled.grey.default,
+    });
+  }
 
   const variablePieChartOptions: Highcharts.Options = {
     title: { text: "" },
@@ -49,9 +58,7 @@ const SurfaceAreaPieChart = ({ soilsDistribution }: Props) => {
 
   return (
     <div className={classNames(fr.cx("fr-container", "fr-py-4w"))}>
-      <HighchartsCustomColorsWrapper
-        colors={soilsEntries.map(([soilType]) => getColorForSoilType(soilType))}
-      >
+      <HighchartsCustomColorsWrapper colors={data.map(({ color }) => color)}>
         <HighchartsReact
           highcharts={Highcharts}
           options={variablePieChartOptions}


### PR DESCRIPTION
- Modification des états du bouton next en fonction du type de question et de l’état du formulaire (pour le formulaire site uniquement sur cette PR) : https://www.notion.so/accelerateur-transition-ecologique-ademe/R-gle-de-gestion-des-boutons-1056523d57d7806ca245c2a4a8e93062
- Ajout d’un graph représentant l’avancement du remplissage des surfaces sur les écrans de surfaces

![image](https://github.com/user-attachments/assets/9bb53a70-1a73-4394-b30c-aab30d110969)
