### PR TITLE
feat(web): update next button behaviour for create project form

### DIFF
--- a/apps/web/src/features/create-project/application/createProject.reducer.ts
+++ b/apps/web/src/features/create-project/application/createProject.reducer.ts
@@ -139,7 +139,7 @@ export const projectCreationSlice = createSlice({
     },
     completeSoilsDecontaminationSelection: (
       state,
-      action: PayloadAction<"all" | "partial" | "none" | "unknown">,
+      action: PayloadAction<"all" | "partial" | "none" | "unknown" | null>,
     ) => {
       switch (action.payload) {
         case "all":
@@ -151,6 +151,7 @@ export const projectCreationSlice = createSlice({
           state.stepsHistory.push("SOILS_TRANSFORMATION_INTRODUCTION");
           break;
         case "unknown":
+        case null:
           state.projectData.decontaminatedSurfaceArea = undefined;
           state.stepsHistory.push("SOILS_TRANSFORMATION_INTRODUCTION");
           break;

--- a/apps/web/src/features/create-project/views/costs/photovoltaic-panels-installation-costs/PhotoVoltaicPanelsInstallationCostsForm.tsx
+++ b/apps/web/src/features/create-project/views/costs/photovoltaic-panels-installation-costs/PhotoVoltaicPanelsInstallationCostsForm.tsx
@@ -1,4 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
+import { typedObjectEntries } from "shared";
 
 import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
 import { sumObjectValues } from "@/shared/services/sum/sum";
@@ -34,6 +35,9 @@ const PhotovoltaicPanelsInstallationExpensesForm = ({ onSubmit, onBack, defaultV
   });
 
   const allExpenses = watch();
+
+  const hasNoValuesFilled =
+    typedObjectEntries(allExpenses).filter(([, value]) => typeof value === "number").length === 0;
 
   return (
     <WizardFormLayout
@@ -118,12 +122,18 @@ const PhotovoltaicPanelsInstallationExpensesForm = ({ onSubmit, onBack, defaultV
           }}
         />
 
-        <p>
-          <strong>
-            Total des dépenses d'installation : {formatNumberFr(sumObjectValues(allExpenses))} €
-          </strong>
-        </p>
-        <BackNextButtonsGroup onBack={onBack} />
+        {!hasNoValuesFilled && (
+          <p>
+            <strong>
+              Total des dépenses d'installation : {formatNumberFr(sumObjectValues(allExpenses))} €
+            </strong>
+          </p>
+        )}
+
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={hasNoValuesFilled ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/costs/reinstatement-costs/index.tsx
+++ b/apps/web/src/features/create-project/views/costs/reinstatement-costs/index.tsx
@@ -83,13 +83,15 @@ const mapProps = (
   } = computeProjectReinstatementCosts(
     siteSoilsDistribution,
     projectSoilsDistribution,
-    siteData?.contaminatedSoilSurface ?? 0,
+    projectData.decontaminatedSurfaceArea ?? 0,
   );
   return {
     hasBuildings: hasBuildings(siteSoilsDistribution),
     hasImpermeableSoils:
       hasImpermeableSoils(siteSoilsDistribution) || hasMineralSoils(siteSoilsDistribution),
-    hasContaminatedSoils: siteData?.hasContaminatedSoils ?? false,
+    hasProjectedDecontamination: !!(
+      projectData.decontaminatedSurfaceArea && projectData.decontaminatedSurfaceArea > 0
+    ),
     defaultValues: {
       deimpermeabilizationAmount: deimpermeabilization && Math.round(deimpermeabilization),
       sustainableSoilsReinstatementAmount:

--- a/apps/web/src/features/create-project/views/costs/site-purchase-amounts/SitePurchaseAmountsForm.tsx
+++ b/apps/web/src/features/create-project/views/costs/site-purchase-amounts/SitePurchaseAmountsForm.tsx
@@ -107,7 +107,7 @@ const SitePurchaseAmountsForm = ({ onSubmit, onBack }: Props) => {
             );
           }}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel={!sellingPrice ? "Passer" : "Valider"} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/costs/yearly-projected-costs/YearlyProjectedCostsForm.tsx
+++ b/apps/web/src/features/create-project/views/costs/yearly-projected-costs/YearlyProjectedCostsForm.tsx
@@ -1,4 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
+import { typedObjectEntries } from "shared";
 
 import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
 import { sumObjectValues } from "@/shared/services/sum/sum";
@@ -35,6 +36,9 @@ const YearlyProjectedExpensesForm = ({ onSubmit, onBack, defaultValues }: Props)
   });
 
   const allExpenses = watch();
+
+  const hasNoValuesFilled =
+    typedObjectEntries(allExpenses).filter(([, value]) => typeof value === "number").length === 0;
 
   return (
     <WizardFormLayout
@@ -139,12 +143,18 @@ const YearlyProjectedExpensesForm = ({ onSubmit, onBack, defaultValues }: Props)
           }}
         />
 
-        <p>
-          <strong>
-            Total des dépenses annuelles : {formatNumberFr(sumObjectValues(allExpenses))} €
-          </strong>
-        </p>
-        <BackNextButtonsGroup onBack={onBack} />
+        {!hasNoValuesFilled && (
+          <p>
+            <strong>
+              Total des dépenses annuelles : {formatNumberFr(sumObjectValues(allExpenses))} €
+            </strong>
+          </p>
+        )}
+
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={hasNoValuesFilled ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/jobs/conversion-full-time-jobs-involved/ConversionFullTimeJobsInvolvedForm.tsx
+++ b/apps/web/src/features/create-project/views/jobs/conversion-full-time-jobs-involved/ConversionFullTimeJobsInvolvedForm.tsx
@@ -26,13 +26,15 @@ function ConversionFullTimeJobsInvolvedForm({
   onSubmit,
   onBack,
 }: Props) {
-  const { handleSubmit, control } = useForm<FormValues>({
+  const { handleSubmit, control, watch } = useForm<FormValues>({
     shouldUnregister: true,
     defaultValues: {
       fullTimeJobs: defaultValues.fullTimeJobs,
       reinstatementFullTimeJobs: defaultValues.reinstatementFullTimeJobs,
     },
   });
+
+  const { fullTimeJobs, reinstatementFullTimeJobs } = watch();
 
   return (
     <WizardFormLayout
@@ -93,7 +95,10 @@ function ConversionFullTimeJobsInvolvedForm({
             );
           }}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={!fullTimeJobs && !reinstatementFullTimeJobs ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/jobs/operations-full-time-jobs-involved/OperationsFullTimeJobsInvolvedForm.tsx
+++ b/apps/web/src/features/create-project/views/jobs/operations-full-time-jobs-involved/OperationsFullTimeJobsInvolvedForm.tsx
@@ -16,7 +16,7 @@ export type FormValues = {
 };
 
 function OperationsFullTimeJobsInvolvedForm({ defaultValue, onSubmit, onBack }: Props) {
-  const { handleSubmit, control } = useForm<FormValues>({
+  const { handleSubmit, control, watch } = useForm<FormValues>({
     defaultValues: {
       fullTimeJobs: defaultValue,
     },
@@ -56,7 +56,10 @@ function OperationsFullTimeJobsInvolvedForm({ defaultValue, onSubmit, onBack }: 
             );
           }}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={!watch("fullTimeJobs") ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/mixed-use-neighbourhood/create-mode-selection/CreateModeSelectionForm.tsx
+++ b/apps/web/src/features/create-project/views/mixed-use-neighbourhood/create-mode-selection/CreateModeSelectionForm.tsx
@@ -83,7 +83,7 @@ function CreateModeSelectionForm({ onSubmit, onBack }: Props) {
           </div>
           {validationError && <p className={fr.cx("fr-error-text")}>{validationError.message}</p>}
         </div>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/name-and-description/ProjectNameAndDescriptionForm.tsx
+++ b/apps/web/src/features/create-project/views/name-and-description/ProjectNameAndDescriptionForm.tsx
@@ -43,7 +43,7 @@ function ProjectNameAndDescriptionForm({ onSubmit, onBack, defaultProjectName }:
           textArea
           nativeTextAreaProps={register("description")}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/photovoltaic/contract-duration/ContractDurationForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/contract-duration/ContractDurationForm.tsx
@@ -16,7 +16,7 @@ type FormValues = {
 };
 
 function PhotovoltaicAnnualProductionForm({ onSubmit, onBack }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>({
+  const { control, handleSubmit, formState } = useForm<FormValues>({
     defaultValues: {
       photovoltaicContractDuration: AVERAGE_PHOTOVOLTAIC_CONTRACT_DURATION_IN_YEARS,
     },
@@ -43,7 +43,7 @@ function PhotovoltaicAnnualProductionForm({ onSubmit, onBack }: Props) {
           }}
           control={control}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/expected-annual-production/ExpectedAnnualProductionForm.tsx
@@ -22,7 +22,7 @@ function PhotovoltaicAnnualProductionForm({
   onBack,
   expectedPerformanceMwhPerYear,
 }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>({
+  const { control, handleSubmit, formState } = useForm<FormValues>({
     defaultValues: {
       photovoltaicExpectedAnnualProduction: expectedPerformanceMwhPerYear,
     },
@@ -51,7 +51,7 @@ function PhotovoltaicAnnualProductionForm({
           control={control}
           allowDecimals={false}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/photovoltaic/key-parameter/KeyParameterForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/key-parameter/KeyParameterForm.tsx
@@ -63,7 +63,7 @@ function KeyParameterForm({ onSubmit, onBack }: Props) {
           options={options}
           error={error}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/photovoltaic/power/PowerForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/power/PowerForm.tsx
@@ -25,7 +25,7 @@ function PhotovoltaicPowerForm({
   siteSurfaceArea,
   recommendedElectricalPowerKWc,
 }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>();
+  const { control, handleSubmit, formState } = useForm<FormValues>();
 
   const hintText = `Maximum conseillé : ${formatNumberFr(recommendedElectricalPowerKWc)} kWc`;
 
@@ -53,7 +53,7 @@ function PhotovoltaicPowerForm({
           control={control}
           name="photovoltaicInstallationElectricalPowerKWc"
           rules={{
-            min: 0,
+            min: 1,
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
           }}
           render={(controller) => {
@@ -69,7 +69,7 @@ function PhotovoltaicPowerForm({
           }}
         />
 
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/photovoltaic/power/PowerFromSurfaceForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/power/PowerFromSurfaceForm.tsx
@@ -24,7 +24,7 @@ function PhotovoltaicPowerFromSurfaceForm({
   photovoltaicSurfaceArea,
   recommendedElectricalPowerKWc,
 }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>({
+  const { control, handleSubmit, formState } = useForm<FormValues>({
     defaultValues: {
       photovoltaicInstallationElectricalPowerKWc: recommendedElectricalPowerKWc,
     },
@@ -57,7 +57,7 @@ function PhotovoltaicPowerFromSurfaceForm({
           control={control}
           name="photovoltaicInstallationElectricalPowerKWc"
           rules={{
-            min: 0,
+            min: 1,
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
           }}
           render={(controller) => {
@@ -72,7 +72,7 @@ function PhotovoltaicPowerFromSurfaceForm({
             );
           }}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceForm.tsx
@@ -20,7 +20,7 @@ type FormValues = {
 };
 
 function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
-  const { control, handleSubmit, watch } = useForm<FormValues>();
+  const { control, handleSubmit, watch, formState } = useForm<FormValues>();
 
   const hintText = `Maximum : ${formatSurfaceArea(siteSurfaceArea)}`;
 
@@ -64,7 +64,7 @@ function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
           control={control}
           name="photovoltaicInstallationSurfaceSquareMeters"
           rules={{
-            min: 0,
+            min: 1,
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
             max: {
               value: siteSurfaceArea,
@@ -88,7 +88,7 @@ function PhotovoltaicSurfaceForm({ onSubmit, siteSurfaceArea, onBack }: Props) {
             💡 Soit <strong>{formatNumberFr(convertSquareMetersToHectares(surface))}</strong> ha.
           </p>
         )}
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceFromPowerForm.tsx
+++ b/apps/web/src/features/create-project/views/photovoltaic/surface/SurfaceFromPowerForm.tsx
@@ -29,7 +29,7 @@ function PhotovoltaicSurfaceFromPowerForm({
   recommendedSurface,
   siteSurfaceArea,
 }: Props) {
-  const { control, handleSubmit, watch } = useForm<FormValues>({
+  const { control, handleSubmit, watch, formState } = useForm<FormValues>({
     defaultValues: {
       photovoltaicInstallationSurfaceSquareMeters: recommendedSurface,
     },
@@ -90,7 +90,7 @@ function PhotovoltaicSurfaceFromPowerForm({
           control={control}
           name="photovoltaicInstallationSurfaceSquareMeters"
           rules={{
-            min: 0,
+            min: 1,
             required: "Ce champ est nécessaire pour déterminer les questions suivantes",
             max: {
               value: siteSurfaceArea,
@@ -114,7 +114,7 @@ function PhotovoltaicSurfaceFromPowerForm({
             💡 Soit <strong>{formatNumberFr(convertSquareMetersToHectares(surface))}</strong> ha.
           </p>
         )}
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/project-phase/ProjectPhaseForm.tsx
+++ b/apps/web/src/features/create-project/views/project-phase/ProjectPhaseForm.tsx
@@ -15,10 +15,8 @@ type Props = {
 };
 
 export type FormValues = {
-  phase: ProjectPhase;
+  phase?: ProjectPhase;
 };
-
-const requiredMessage = "Veuillez sélectionner l'avancement du projet.";
 
 const options = (["setup", "design", "construction", "completed", "unknown"] as const).map(
   (phase) => ({
@@ -33,21 +31,15 @@ const options = (["setup", "design", "construction", "completed", "unknown"] as 
 }[];
 
 function ProjectPhaseForm({ onSubmit, onBack }: Props) {
-  const { register, handleSubmit, formState } = useForm<FormValues>({
+  const { register, handleSubmit, formState, watch } = useForm<FormValues>({
     shouldUnregister: true,
   });
 
   return (
     <WizardFormLayout title="A quelle phase de votre projet êtes-vous ?">
       <form onSubmit={handleSubmit(onSubmit)}>
-        <RadioButtons
-          {...register("phase", {
-            required: requiredMessage,
-          })}
-          options={options}
-          error={formState.errors.phase}
-        />
-        <BackNextButtonsGroup onBack={onBack} />
+        <RadioButtons {...register("phase")} options={options} error={formState.errors.phase} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel={watch("phase") ? "Valider" : "Passer"} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/project-phase/index.tsx
+++ b/apps/web/src/features/create-project/views/project-phase/index.tsx
@@ -12,7 +12,7 @@ function ProjectPhaseFormContainer() {
   return (
     <ProjectPhaseForm
       onSubmit={(formData: FormValues) => {
-        dispatch(completeProjectPhaseStep(formData));
+        dispatch(completeProjectPhaseStep({ phase: formData.phase ?? "unknown" }));
       }}
       onBack={() => {
         dispatch(revertProjectPhaseStep());

--- a/apps/web/src/features/create-project/views/project-types/ProjectTypesForm.tsx
+++ b/apps/web/src/features/create-project/views/project-types/ProjectTypesForm.tsx
@@ -61,8 +61,11 @@ function ProjectTypesForm({ onSubmit, allowedDevelopmentPlanCategories }: Props)
             </div>
             {validationError && <p className={fr.cx("fr-error-text")}>{validationError.message}</p>}
           </div>
-          <Button className="tw-float-right" nativeButtonProps={{ type: "submit" }}>
-            Suivant
+          <Button
+            className="tw-float-right"
+            nativeButtonProps={{ type: "submit", disabled: !formState.isValid }}
+          >
+            Valider
           </Button>
         </form>
       </WizardFormLayout>

--- a/apps/web/src/features/create-project/views/renewable-energy-types/RenewableEnergyTypeForm.tsx
+++ b/apps/web/src/features/create-project/views/renewable-energy-types/RenewableEnergyTypeForm.tsx
@@ -61,7 +61,7 @@ function RenewableEnergyTypesForm({ onSubmit, onBack }: Props) {
           </div>
           {validationError && <p className={fr.cx("fr-error-text")}>{validationError.message}</p>}
         </div>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/revenue/financial-assistance/ProjectFinancialAssistanceRevenueForm.tsx
+++ b/apps/web/src/features/create-project/views/revenue/financial-assistance/ProjectFinancialAssistanceRevenueForm.tsx
@@ -1,4 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
+import { typedObjectEntries } from "shared";
 
 import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
 import { sumObjectValues } from "@/shared/services/sum/sum";
@@ -22,6 +23,9 @@ const ProjectFinancialAssistanceRevenueForm = ({ onSubmit, onBack }: Props) => {
   const { handleSubmit, control, watch } = useForm<FormValues>();
 
   const allRevenues = watch();
+
+  const hasNoValuesFilled =
+    typedObjectEntries(allRevenues).filter(([, value]) => typeof value === "number").length === 0;
 
   return (
     <WizardFormLayout
@@ -102,12 +106,18 @@ const ProjectFinancialAssistanceRevenueForm = ({ onSubmit, onBack }: Props) => {
           }}
         />
 
-        <p>
-          <strong>
-            Total des aides aux travaux : {formatNumberFr(sumObjectValues(allRevenues))} €
-          </strong>
-        </p>
-        <BackNextButtonsGroup onBack={onBack} />
+        {!hasNoValuesFilled && (
+          <p>
+            <strong>
+              Total des aides aux travaux : {formatNumberFr(sumObjectValues(allRevenues))} €
+            </strong>
+          </p>
+        )}
+
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={hasNoValuesFilled ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/revenue/yearly-projected-revenue/ProjectYearlyProjectedRevenueForm.tsx
+++ b/apps/web/src/features/create-project/views/revenue/yearly-projected-revenue/ProjectYearlyProjectedRevenueForm.tsx
@@ -1,4 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
+import { typedObjectEntries } from "shared";
 
 import { formatNumberFr } from "@/shared/services/format-number/formatNumber";
 import { sumObjectValues } from "@/shared/services/sum/sum";
@@ -25,6 +26,9 @@ const ProjectYearlyProjectedRevenueForm = ({ onSubmit, onBack, defaultValues }: 
   const { handleSubmit, control, watch } = useForm<FormValues>({ defaultValues });
 
   const allRevenues = watch();
+
+  const hasNoValuesFilled =
+    typedObjectEntries(allRevenues).filter(([, value]) => typeof value === "number").length === 0;
 
   return (
     <WizardFormLayout
@@ -89,12 +93,18 @@ const ProjectYearlyProjectedRevenueForm = ({ onSubmit, onBack, defaultValues }: 
           }}
         />
 
-        <p>
-          <strong>
-            Total des recettes annuelles : {formatNumberFr(sumObjectValues(allRevenues))} €
-          </strong>
-        </p>
-        <BackNextButtonsGroup onBack={onBack} />
+        {!hasNoValuesFilled && (
+          <p>
+            <strong>
+              Total des recettes annuelles : {formatNumberFr(sumObjectValues(allRevenues))} €
+            </strong>
+          </p>
+        )}
+
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={hasNoValuesFilled ? "Passer" : "Valider"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/schedule/projection/ScheduleProjectionForm.tsx
+++ b/apps/web/src/features/create-project/views/schedule/projection/ScheduleProjectionForm.tsx
@@ -176,7 +176,7 @@ function ScheduleProjectionForm({
             },
           }}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/soils-decontamination/selection/SoilsDecontaminationSelection.tsx
+++ b/apps/web/src/features/create-project/views/soils-decontamination/selection/SoilsDecontaminationSelection.tsx
@@ -10,21 +10,17 @@ type Props = {
 };
 
 export type FormValues = {
-  decontaminationSelection: "all" | "partial" | "none" | "unknown";
+  decontaminationSelection: "all" | "partial" | "none" | "unknown" | null;
 };
 
-const requiredMessage = "Ce champ est requis";
-
 function SoilsDecontaminationSelection({ onSubmit, onBack }: Props) {
-  const { register, handleSubmit, formState } = useForm<FormValues>();
+  const { register, handleSubmit, formState, watch } = useForm<FormValues>();
 
   return (
     <WizardFormLayout title="Les sols pollués seront-ils dépollués ?">
       <form onSubmit={handleSubmit(onSubmit)}>
         <RadioButtons
-          {...register("decontaminationSelection", {
-            required: requiredMessage,
-          })}
+          {...register("decontaminationSelection")}
           options={[
             {
               label: "Oui, totalement dépollués",
@@ -45,7 +41,10 @@ function SoilsDecontaminationSelection({ onSubmit, onBack }: Props) {
           ]}
           error={formState.errors.decontaminationSelection}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={watch("decontaminationSelection") !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/soils-decontamination/surface-area/SoilsDecontaminationSurfaceArea.tsx
+++ b/apps/web/src/features/create-project/views/soils-decontamination/surface-area/SoilsDecontaminationSurfaceArea.tsx
@@ -1,7 +1,9 @@
 import { useForm } from "react-hook-form";
 
+import { formatSurfaceArea } from "@/shared/services/format-number/formatNumber";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import NumericInput from "@/shared/views/components/form/NumericInput/NumericInput";
+import RequiredLabel from "@/shared/views/components/form/RequiredLabel/RequiredLabel";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
@@ -15,14 +17,15 @@ export type FormValues = {
 };
 
 function SoilsDecontaminationSurfaceArea({ onSubmit, onBack, contaminatedSoilSurface }: Props) {
-  const { handleSubmit, control } = useForm<FormValues>();
+  const { handleSubmit, control, formState } = useForm<FormValues>();
 
   return (
     <WizardFormLayout title="Quelle part des sols pollués sera dépolluée ?">
       <form onSubmit={handleSubmit(onSubmit)}>
         <NumericInput
           control={control}
-          label="Superficie à dépolluer"
+          hintText={`Surface contaminée : ${formatSurfaceArea(contaminatedSoilSurface)}`}
+          label={<RequiredLabel label="Superficie à dépolluer" />}
           name="surfaceArea"
           rules={{
             required: "Ce champ est requis",
@@ -37,7 +40,7 @@ function SoilsDecontaminationSurfaceArea({ onSubmit, onBack, contaminatedSoilSur
             },
           }}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} disabled={!formState.isValid} nextLabel="Valider" />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/soils/soils-transformation/future-soils-selection/FutureSoilsSelectionForm.tsx
+++ b/apps/web/src/features/create-project/views/soils/soils-transformation/future-soils-selection/FutureSoilsSelectionForm.tsx
@@ -83,7 +83,7 @@ function FutureSoilsSelectionForm({
   onSubmit,
   onBack,
 }: Props) {
-  const { control, handleSubmit } = useForm<FormValues>({
+  const { control, handleSubmit, formState } = useForm<FormValues>({
     defaultValues: {
       soils: REQUIRED_SOILS,
     },
@@ -166,7 +166,7 @@ function FutureSoilsSelectionForm({
             </section>
           );
         })}
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/soils/soils-transformation/future-soils-surface-area/FutureSoilsSurfaceAreaForm.tsx
+++ b/apps/web/src/features/create-project/views/soils/soils-transformation/future-soils-surface-area/FutureSoilsSurfaceAreaForm.tsx
@@ -34,7 +34,7 @@ function FutureSoilsSurfaceAreaForm({
   onSubmit,
   onBack,
 }: Props) {
-  const { control, handleSubmit, watch } = useForm<FormValues>();
+  const { control, handleSubmit, watch, formState } = useForm<FormValues>();
 
   const allocatedSoilsDistribution = watch();
 
@@ -42,18 +42,12 @@ function FutureSoilsSurfaceAreaForm({
   const allocatedSuitableSurfaceAreaForPhotovoltaicPanels =
     getSuitableSurfaceAreaForPhotovoltaicPanels(allocatedSoilsDistribution);
 
-  const _onSubmit = (data: FormValues) => {
-    const allocatedSurfaceArea = getTotalSurfaceArea(data);
-    if (allocatedSurfaceArea !== siteSurfaceArea) return;
-    onSubmit(data);
-  };
-
   return (
     <WizardFormLayout
       title="Quelles seront les superficies des sols ?"
       instructions={<FutureSoilsSurfaceAreaInstructions />}
     >
-      <form onSubmit={handleSubmit(_onSubmit)}>
+      <form onSubmit={handleSubmit(onSubmit)}>
         {selectedSoils.map((soilType) => {
           const existingSoilSurfaceArea = currentSoilsDistribution[soilType];
           const soilTypeDescription = getDescriptionForSoilType(soilType);
@@ -106,7 +100,11 @@ function FutureSoilsSurfaceAreaForm({
             availableSurfaceArea={siteSurfaceArea}
           />
         </div>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel="Valider"
+          disabled={!formState.isValid || totalAllocatedSurface !== siteSurfaceArea}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/soils/soils-transformation/non-suitable-soils-selection/NonSuitableSoilsSelection.tsx
+++ b/apps/web/src/features/create-project/views/soils/soils-transformation/non-suitable-soils-selection/NonSuitableSoilsSelection.tsx
@@ -126,7 +126,7 @@ function NonSuitableSoilsSelection({
           })}
         </div>
         {validationError && <p className={fr.cx("fr-error-text")}>{validationError.message}</p>}
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/soils/soils-transformation/non-suitable-soils-surface-to-transform/NonSuitableSoilsSurfaceToTransformForm.tsx
+++ b/apps/web/src/features/create-project/views/soils/soils-transformation/non-suitable-soils-surface-to-transform/NonSuitableSoilsSurfaceToTransformForm.tsx
@@ -36,7 +36,7 @@ function NonSuitableSoilsSurfaceToTransformForm({
   onSubmit,
   onBack,
 }: Props) {
-  const { control, handleSubmit, watch } = useForm<FormValues>({
+  const { control, handleSubmit, watch, formState } = useForm<FormValues>({
     defaultValues: {
       soilsTransformation: getSoilsTransformationDefaultValue(soilsToTransform),
     },
@@ -100,7 +100,7 @@ function NonSuitableSoilsSurfaceToTransformForm({
           state={missesSuitableSurfaceArea ? "error" : "default"}
           stateRelatedMessage={`Vous devez aplanir ou remblayer au moins ${formatSurfaceArea(missingSuitableSurfaceArea)}`}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/soils/soils-transformation/transformation-project-selection/SoilsTransformationProjectForm.tsx
+++ b/apps/web/src/features/create-project/views/soils/soils-transformation/transformation-project-selection/SoilsTransformationProjectForm.tsx
@@ -131,7 +131,7 @@ function SoilsTransformationProjectForm({ onSubmit, onBack }: Props) {
             );
           })}
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/stakeholders/developer/ProjectDeveloperForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/developer/ProjectDeveloperForm.tsx
@@ -36,9 +36,12 @@ export type FormValues =
       stakeholder: "user_structure" | "site_tenant" | "site_owner" | "unknown";
       localAuthority: undefined;
       otherStructureName: undefined;
+    }
+  | {
+      stakeholder: null;
+      localAuthority: undefined;
+      otherStructureName: undefined;
     };
-
-const requiredMessage = "Ce champ est requis";
 
 function DeveloperForm({
   onSubmit,
@@ -80,14 +83,14 @@ function DeveloperForm({
               label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           ))}
           {availableLocalAuthoritiesStakeholders.length > 0 && (
             <RadioButton
               label="Une collectivité"
               value="local_or_regional_authority"
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           )}
 
@@ -110,11 +113,11 @@ function DeveloperForm({
           <RadioButton
             label="Une autre structure"
             value="other_structure"
-            {...register("stakeholder", { required: requiredMessage })}
+            {...register("stakeholder")}
           />
           {selectedStakeholder === "other_structure" && (
             <Input
-              label="Nom de la structure"
+              label={<RequiredLabel label="Nom de la structure" />}
               state={formState.errors.otherStructureName ? "error" : "default"}
               stateRelatedMessage={formState.errors.otherStructureName?.message}
               nativeInputProps={register("otherStructureName", {
@@ -122,13 +125,13 @@ function DeveloperForm({
               })}
             />
           )}
-          <RadioButton
-            label="Ne sait pas"
-            value="unknown"
-            {...register("stakeholder", { required: requiredMessage })}
-          />
+          <RadioButton label="Ne sait pas" value="unknown" {...register("stakeholder")} />
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          disabled={!formState.isValid}
+          nextLabel={selectedStakeholder !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/stakeholders/developer/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/developer/index.tsx
@@ -49,8 +49,9 @@ const convertFormValuesForStore = (
         structureType: "other",
       };
     case "unknown":
+    case null:
       return {
-        name: "Inconnu",
+        name: "Aménageur",
         structureType: "unknown",
       };
   }

--- a/apps/web/src/features/create-project/views/stakeholders/future-site-owner/FutureSiteOwnerForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/future-site-owner/FutureSiteOwnerForm.tsx
@@ -42,9 +42,12 @@ export type FormValues =
         | "unknown";
       localAuthority: undefined;
       otherStructureName: undefined;
+    }
+  | {
+      stakeholder: null;
+      localAuthority: undefined;
+      otherStructureName: undefined;
     };
-
-const requiredMessage = "Ce champ est requis";
 
 function FutureSiteOwnerForm({
   onSubmit,
@@ -72,7 +75,7 @@ function FutureSiteOwnerForm({
               label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           ))}
 
@@ -80,7 +83,7 @@ function FutureSiteOwnerForm({
             <RadioButton
               label="Une collectivité"
               value="local_or_regional_authority"
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           )}
 
@@ -103,11 +106,11 @@ function FutureSiteOwnerForm({
           <RadioButton
             label="Une autre structure"
             value="other_structure"
-            {...register("stakeholder", { required: requiredMessage })}
+            {...register("stakeholder")}
           />
           {selectedStakeholder === "other_structure" && (
             <Input
-              label="Nom de la structure"
+              label={<RequiredLabel label="Nom de la structure" />}
               state={formState.errors.otherStructureName ? "error" : "default"}
               stateRelatedMessage={formState.errors.otherStructureName?.message}
               nativeInputProps={register("otherStructureName", {
@@ -115,13 +118,13 @@ function FutureSiteOwnerForm({
               })}
             />
           )}
-          <RadioButton
-            label="Ne sait pas"
-            value="unknown"
-            {...register("stakeholder", { required: requiredMessage })}
-          />
+          <RadioButton label="Ne sait pas" value="unknown" {...register("stakeholder")} />
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          disabled={!formState.isValid}
+          nextLabel={selectedStakeholder !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/stakeholders/future-site-owner/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/future-site-owner/index.tsx
@@ -52,8 +52,9 @@ const convertFormValuesForStore = (
         structureType: "other",
       };
     case "unknown":
+    case null:
       return {
-        name: "Inconnu",
+        name: "Futur propriétaire",
         structureType: "unknown",
       };
   }

--- a/apps/web/src/features/create-project/views/stakeholders/operator/SiteOperatorForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/operator/SiteOperatorForm.tsx
@@ -40,9 +40,12 @@ export type FormValues =
         | "unknown";
       localAuthority: undefined;
       otherStructureName: undefined;
+    }
+  | {
+      stakeholder: null;
+      localAuthority: undefined;
+      otherStructureName: undefined;
     };
-
-const requiredMessage = "Ce champ est requis";
 
 function SiteOperatorForm({
   onSubmit,
@@ -70,14 +73,14 @@ function SiteOperatorForm({
               label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           ))}
           {availableLocalAuthoritiesStakeholders.length > 0 && (
             <RadioButton
               label="Une collectivité"
               value="local_or_regional_authority"
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           )}
 
@@ -100,11 +103,11 @@ function SiteOperatorForm({
           <RadioButton
             label="Une autre structure"
             value="other_structure"
-            {...register("stakeholder", { required: requiredMessage })}
+            {...register("stakeholder")}
           />
           {selectedStakeholder === "other_structure" && (
             <Input
-              label="Nom de la structure"
+              label={<RequiredLabel label="Nom de la structure" />}
               state={formState.errors.otherStructureName ? "error" : "default"}
               stateRelatedMessage={formState.errors.otherStructureName?.message}
               nativeInputProps={register("otherStructureName", {
@@ -112,13 +115,13 @@ function SiteOperatorForm({
               })}
             />
           )}
-          <RadioButton
-            label="Ne sait pas"
-            value="unknown"
-            {...register("stakeholder", { required: requiredMessage })}
-          />
+          <RadioButton label="Ne sait pas" value="unknown" {...register("stakeholder")} />
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          disabled={!formState.isValid}
+          nextLabel={selectedStakeholder !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/stakeholders/operator/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/operator/index.tsx
@@ -50,8 +50,9 @@ const convertFormValuesForStore = (
         structureType: "other",
       };
     case "unknown":
+    case null:
       return {
-        name: "Inconnu",
+        name: "Futur exploitant",
         structureType: "unknown",
       };
   }

--- a/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/SiteReinstatementContractOwnerForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/SiteReinstatementContractOwnerForm.tsx
@@ -42,9 +42,12 @@ export type FormValues =
         | "unknown";
       localAuthority: undefined;
       otherStructureName: undefined;
+    }
+  | {
+      stakeholder: null;
+      localAuthority: undefined;
+      otherStructureName: undefined;
     };
-
-const requiredMessage = "Ce champ est requis";
 
 function SiteReinstatementContractOwnerForm({
   onSubmit,
@@ -82,7 +85,7 @@ function SiteReinstatementContractOwnerForm({
               label={role === "user_structure" ? `Ma structure, ${name}` : name}
               value={role}
               key={role}
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           ))}
 
@@ -90,7 +93,7 @@ function SiteReinstatementContractOwnerForm({
             <RadioButton
               label="Une collectivité"
               value="local_or_regional_authority"
-              {...register("stakeholder", { required: requiredMessage })}
+              {...register("stakeholder")}
             />
           )}
 
@@ -113,11 +116,11 @@ function SiteReinstatementContractOwnerForm({
           <RadioButton
             label="Une autre structure"
             value="other_structure"
-            {...register("stakeholder", { required: requiredMessage })}
+            {...register("stakeholder")}
           />
           {selectedStakeholder === "other_structure" && (
             <Input
-              label="Nom de la structure"
+              label={<RequiredLabel label="Nom de la structure" />}
               state={formState.errors.otherStructureName ? "error" : "default"}
               stateRelatedMessage={formState.errors.otherStructureName?.message}
               nativeInputProps={register("otherStructureName", {
@@ -125,13 +128,13 @@ function SiteReinstatementContractOwnerForm({
               })}
             />
           )}
-          <RadioButton
-            label="Ne sait pas"
-            value="unknown"
-            {...register("stakeholder", { required: requiredMessage })}
-          />
+          <RadioButton label="Ne sait pas" value="unknown" {...register("stakeholder")} />
         </Fieldset>
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          disabled={!formState.isValid}
+          nextLabel={selectedStakeholder !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/index.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/reinstatement-contract-owner/index.tsx
@@ -53,8 +53,9 @@ const convertFormValuesForStore = (
         structureType: "other",
       };
     case "unknown":
+    case null:
       return {
-        name: "Inconnu",
+        name: "Maître d’ouvrage des travaux de remise en état",
         structureType: "unknown",
       };
   }

--- a/apps/web/src/features/create-project/views/stakeholders/site-purchased/SitePurchasedForm.tsx
+++ b/apps/web/src/features/create-project/views/stakeholders/site-purchased/SitePurchasedForm.tsx
@@ -11,13 +11,11 @@ type Props = {
 };
 
 export type FormValues = {
-  willSiteBePurchased: "yes" | "no";
+  willSiteBePurchased: "yes" | "no" | null;
 };
 
 function SitePurchasedForm({ onSubmit, onBack, currentOwnerName }: Props) {
-  const { register, handleSubmit, formState } = useForm<FormValues>({
-    defaultValues: { willSiteBePurchased: "no" },
-  });
+  const { register, handleSubmit, formState, watch } = useForm<FormValues>();
 
   return (
     <WizardFormLayout
@@ -32,13 +30,16 @@ function SitePurchasedForm({ onSubmit, onBack, currentOwnerName }: Props) {
               value: "yes",
             },
             {
-              label: "Non",
+              label: "Non / Ne sait pas",
               value: "no",
             },
           ]}
           error={formState.errors.willSiteBePurchased}
         />
-        <BackNextButtonsGroup onBack={onBack} />
+        <BackNextButtonsGroup
+          onBack={onBack}
+          nextLabel={watch("willSiteBePurchased") !== null ? "Valider" : "Passer"}
+        />
       </form>
     </WizardFormLayout>
   );

--- a/apps/web/src/features/create-project/views/summary/ProjectCreationDataSummary.tsx
+++ b/apps/web/src/features/create-project/views/summary/ProjectCreationDataSummary.tsx
@@ -368,7 +368,7 @@ function ProjectCreationDataSummary({ projectData, siteData, onNext, onBack }: P
           />
         </Accordion>
         <div className="fr-mt-4w">
-          <BackNextButtonsGroup onBack={onBack} onNext={onNext} />
+          <BackNextButtonsGroup onBack={onBack} onNext={onNext} nextLabel="Valider" />
         </div>
       </WizardFormLayout>
     </>

--- a/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
@@ -41,7 +41,6 @@ function SiteSoilsDistributionBySquareMetersForm({
   const _onSubmit = handleSubmit(onSubmit);
 
   const soilsValues = watch();
-  console.log(soilsValues);
 
   const totalAllocatedSurface = useMemo(() => getTotalSurface(soilsValues), [soilsValues]);
 


### PR DESCRIPTION
- Modification des états du bouton next en fonction du type de question et de l’état du formulaire pour le formulaire projet : https://www.notion.so/accelerateur-transition-ecologique-ademe/R-gle-de-gestion-des-boutons-1056523d57d7806ca245c2a4a8e93062
- Quelques petits correctifs au passage (des frais de décontamination qui étaient pré-calculés même si l’utilisateur indique ne pas décontaminer.)