### PR TITLE
fix: prevent impacts computing failure when soils carbon storage fails

### DIFF
--- a/apps/api/src/reconversion-projects/core/gateways/FakeGetSoilsCarbonStorageService.ts
+++ b/apps/api/src/reconversion-projects/core/gateways/FakeGetSoilsCarbonStorageService.ts
@@ -27,12 +27,20 @@ export const resultMock: SoilsCarbonStorageResult = {
 
 export class FakeGetSoilsCarbonStorageService implements GetSoilsCarbonStoragePerSoilsService {
   result: SoilsCarbonStorageResult | null = null;
+  _isShouldFailOnExecute = false;
 
   _setResult(result: SoilsCarbonStorageResult) {
     this.result = result;
   }
 
+  shouldFailOnExecute() {
+    this._isShouldFailOnExecute = true;
+  }
+
   execute(): Promise<SoilsCarbonStorageResult> {
+    if (this._isShouldFailOnExecute) {
+      throw new Error("FakeGetSoilsCarbonStorageService.execute failed");
+    }
     return Promise.resolve(this.result ?? resultMock);
   }
 }

--- a/apps/api/src/reconversion-projects/core/model/impacts/socio-economic/computeEnvironmentalMonetaryImpacts.ts
+++ b/apps/api/src/reconversion-projects/core/model/impacts/socio-economic/computeEnvironmentalMonetaryImpacts.ts
@@ -14,8 +14,8 @@ type EnvironmentalMonetaryImpactInput = {
   evaluationPeriodInYears: number;
   baseSoilsDistribution: SoilsDistribution;
   forecastSoilsDistribution: SoilsDistribution;
-  baseSoilsCarbonStorage: number;
-  forecastSoilsCarbonStorage: number;
+  baseSoilsCarbonStorage: number | null;
+  forecastSoilsCarbonStorage: number | null;
   operationsFirstYear: number;
   decontaminatedSurface?: number;
 };
@@ -217,13 +217,16 @@ export const computeEnvironmentalMonetaryImpacts = (
 
   const ecosystemServicesImpacts: EcosystemServicesImpact["details"] = [
     {
-      amount: Math.round(
-        computeSoilsCarbonStorage(
-          input.baseSoilsCarbonStorage,
-          input.forecastSoilsCarbonStorage,
-          input.operationsFirstYear,
-        ),
-      ),
+      amount:
+        input.baseSoilsCarbonStorage && input.forecastSoilsCarbonStorage
+          ? Math.round(
+              computeSoilsCarbonStorage(
+                input.baseSoilsCarbonStorage,
+                input.forecastSoilsCarbonStorage,
+                input.operationsFirstYear,
+              ),
+            )
+          : 0,
       impact: "carbon_storage",
     },
     {

--- a/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.spec.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.spec.ts
@@ -380,6 +380,7 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
             forecast: 112.29599999999999,
           },
           soilsCarbonStorage: {
+            isSuccess: true,
             current: {
               total: 20,
               soils: [
@@ -422,6 +423,32 @@ describe("ComputeReconversionProjectImpactsUseCase", () => {
             },
           },
         },
+      });
+    });
+
+    it("returns impacts when soils carbon storage cannbot be computed", async () => {
+      const evaluationPeriodInYears = 10;
+      const projectQuery = new InMemoryReconversionProjectImpactsQuery();
+      projectQuery._setData(reconversionProjectImpactDataView);
+      const siteQuery = new InMemorySiteImpactsQuery();
+      siteQuery._setData(site);
+      const soilsCarbonStorageService = new FakeGetSoilsCarbonStorageService();
+      soilsCarbonStorageService.shouldFailOnExecute();
+
+      const usecase = new ComputeReconversionProjectImpactsUseCase(
+        projectQuery,
+        siteQuery,
+        soilsCarbonStorageService,
+        dateProvider,
+        new GetCityRelatedDataService(new MockLocalDataInseeService(), new MockDV3FApiService()),
+      );
+      const result = await usecase.execute({
+        reconversionProjectId: reconversionProjectImpactDataView.id,
+        evaluationPeriodInYears,
+      });
+      expect(result.id).toEqual(reconversionProjectImpactDataView.id);
+      expect(result.impacts.soilsCarbonStorage).toEqual({
+        isSuccess: false,
       });
     });
   });

--- a/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.ts
+++ b/apps/api/src/reconversion-projects/core/usecases/computeReconversionProjectImpacts.usecase.ts
@@ -199,7 +199,7 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
     const operationsFirstYear =
       reconversionProject.operationsFirstYear ?? this.dateProvider.now().getFullYear();
 
-    const soilsCarbonStorage = await computeSoilsCarbonStorageImpact({
+    const soilsCarbonStorageImpactResult = await computeSoilsCarbonStorageImpact({
       currentSoilsDistribution: relatedSite.soilsDistribution,
       forecastSoilsDistribution: reconversionProject.soilsDistribution,
       siteCityCode: relatedSite.addressCityCode,
@@ -235,8 +235,12 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
         baseSoilsDistribution: relatedSite.soilsDistribution,
         forecastSoilsDistribution: reconversionProject.soilsDistribution,
         evaluationPeriodInYears,
-        baseSoilsCarbonStorage: soilsCarbonStorage.current.total,
-        forecastSoilsCarbonStorage: soilsCarbonStorage.forecast.total,
+        baseSoilsCarbonStorage: soilsCarbonStorageImpactResult.isSuccess
+          ? soilsCarbonStorageImpactResult.current.total
+          : null,
+        forecastSoilsCarbonStorage: soilsCarbonStorageImpactResult.isSuccess
+          ? soilsCarbonStorageImpactResult.forecast.total
+          : null,
         operationsFirstYear: operationsFirstYear,
         decontaminatedSurface: reconversionProject.decontaminatedSoilSurface,
       }),
@@ -327,7 +331,7 @@ export class ComputeReconversionProjectImpactsUseCase implements UseCase<Request
               deaths: relatedSite.accidentsDeaths,
             })
           : undefined,
-        soilsCarbonStorage,
+        soilsCarbonStorage: soilsCarbonStorageImpactResult,
         ...developmentPlanRelatedImpacts,
       },
     };

--- a/apps/web/src/features/projects/application/projectImpacts.mock.ts
+++ b/apps/web/src/features/projects/application/projectImpacts.mock.ts
@@ -173,6 +173,7 @@ const baseImpacts = {
     },
   },
   soilsCarbonStorage: {
+    isSuccess: true,
     current: {
       total: 20,
       soils: [

--- a/apps/web/src/features/projects/application/projectImpactsEnvironmental.selectors.ts
+++ b/apps/web/src/features/projects/application/projectImpactsEnvironmental.selectors.ts
@@ -82,6 +82,7 @@ export const getEnvironmentalProjectImpacts = createSelector(
   selectCurrentFilter,
   selectImpactsData,
   (currentFilter, impactsData): EnvironmentalImpact[] => {
+    if (!impactsData) return [];
     const {
       nonContaminatedSurfaceArea,
       avoidedCO2TonsWithEnergyProduction,
@@ -89,7 +90,7 @@ export const getEnvironmentalProjectImpacts = createSelector(
       permeableSurfaceArea,
       avoidedAirConditioningCo2EqEmissions,
       avoidedCarTrafficCo2EqEmissions,
-    } = impactsData || {};
+    } = impactsData;
 
     const impacts: EnvironmentalImpact[] = [];
     const displayAll = currentFilter === "all";
@@ -111,7 +112,7 @@ export const getEnvironmentalProjectImpacts = createSelector(
       });
     }
 
-    if (soilsCarbonStorage) {
+    if (soilsCarbonStorage.isSuccess) {
       const current = soilsCarbonStorage.current.soils;
       const forecast = soilsCarbonStorage.forecast.soils;
       const soilsTypes = Array.from(new Set([...current, ...forecast].map(({ type }) => type)));
@@ -144,12 +145,11 @@ export const getEnvironmentalProjectImpacts = createSelector(
     if (
       avoidedCarTrafficCo2EqEmissions ||
       avoidedAirConditioningCo2EqEmissions ||
-      avoidedCO2TonsWithEnergyProduction ||
-      soilsCarbonStorage
+      avoidedCO2TonsWithEnergyProduction
     ) {
       const details: ImpactDetails[] = [];
 
-      if (soilsCarbonStorage) {
+      if (soilsCarbonStorage.isSuccess) {
         const base = convertCarbonToCO2eq(soilsCarbonStorage.current.total);
         const forecast = convertCarbonToCO2eq(soilsCarbonStorage.forecast.total);
 
@@ -211,37 +211,35 @@ export const getEnvironmentalProjectImpacts = createSelector(
       }
     }
 
-    if (permeableSurfaceArea) {
-      const { base, forecast, mineralSoil, greenSoil } = permeableSurfaceArea;
+    const { base, forecast, mineralSoil, greenSoil } = permeableSurfaceArea;
 
-      impacts.push({
-        name: "permeable_surface_area",
-        type: "surfaceArea",
-        impact: {
-          base,
-          forecast,
-          difference: forecast - base,
-          details: [
-            {
-              name: "mineral_soil",
-              impact: {
-                base: mineralSoil.base,
-                forecast: mineralSoil.forecast,
-                difference: mineralSoil.forecast - mineralSoil.base,
-              },
+    impacts.push({
+      name: "permeable_surface_area",
+      type: "surfaceArea",
+      impact: {
+        base,
+        forecast,
+        difference: forecast - base,
+        details: [
+          {
+            name: "mineral_soil",
+            impact: {
+              base: mineralSoil.base,
+              forecast: mineralSoil.forecast,
+              difference: mineralSoil.forecast - mineralSoil.base,
             },
-            {
-              name: "green_soil",
-              impact: {
-                base: greenSoil.base,
-                forecast: greenSoil.forecast,
-                difference: greenSoil.forecast - greenSoil.base,
-              },
+          },
+          {
+            name: "green_soil",
+            impact: {
+              base: greenSoil.base,
+              forecast: greenSoil.forecast,
+              difference: greenSoil.forecast - greenSoil.base,
             },
-          ],
-        },
-      });
-    }
+          },
+        ],
+      },
+    });
 
     return impacts;
   },

--- a/apps/web/src/features/projects/application/projectKeyImpactIndicators.selectors.ts
+++ b/apps/web/src/features/projects/application/projectKeyImpactIndicators.selectors.ts
@@ -98,13 +98,17 @@ const getHouseholdsPoweredByRenewableEnergy = (state: RootState["projectImpacts"
 };
 
 const getAvoidedCo2eqEmissions = (state: RootState["projectImpacts"]) => {
+  if (!state.impactsData) {
+    return 0;
+  }
+
   const total = [
-    state.impactsData?.avoidedAirConditioningCo2EqEmissions ?? 0,
-    state.impactsData?.avoidedCarTrafficCo2EqEmissions ?? 0,
-    state.impactsData?.avoidedCO2TonsWithEnergyProduction?.forecast ?? 0,
+    state.impactsData.avoidedAirConditioningCo2EqEmissions ?? 0,
+    state.impactsData.avoidedCarTrafficCo2EqEmissions ?? 0,
+    state.impactsData.avoidedCO2TonsWithEnergyProduction?.forecast ?? 0,
   ].reduce((total, amount) => total + amount, 0);
 
-  if (state.impactsData?.soilsCarbonStorage) {
+  if (state.impactsData.soilsCarbonStorage.isSuccess) {
     const base = convertCarbonToCO2eq(state.impactsData.soilsCarbonStorage.current.total);
     const forecast = convertCarbonToCO2eq(state.impactsData.soilsCarbonStorage.forecast.total);
     return total + (forecast - base);

--- a/apps/web/src/features/projects/domain/impacts.types.ts
+++ b/apps/web/src/features/projects/domain/impacts.types.ts
@@ -142,6 +142,28 @@ export type EcosystemServicesImpact = BaseEconomicImpact & {
   }[];
 };
 
+export type SoilsCarbonStorageImpactIndicator =
+  | {
+      isSuccess: true;
+      current: {
+        total: number;
+        soils: {
+          type: SoilType;
+          surfaceArea: number;
+          carbonStorage: number;
+        }[];
+      };
+      forecast: {
+        total: number;
+        soils: {
+          type: SoilType;
+          surfaceArea: number;
+          carbonStorage: number;
+        }[];
+      };
+    }
+  | { isSuccess: false };
+
 export type ReconversionProjectImpacts = {
   permeableSurfaceArea: {
     base: number;
@@ -213,24 +235,7 @@ export type ReconversionProjectImpacts = {
     current: 0;
     forecast: number;
   };
-  soilsCarbonStorage: {
-    current: {
-      total: number;
-      soils: {
-        type: SoilType;
-        surfaceArea: number;
-        carbonStorage: number;
-      }[];
-    };
-    forecast: {
-      total: number;
-      soils: {
-        type: SoilType;
-        surfaceArea: number;
-        carbonStorage: number;
-      }[];
-    };
-  };
+  soilsCarbonStorage: SoilsCarbonStorageImpactIndicator;
   socioeconomic: {
     total: number;
     impacts: (


### PR DESCRIPTION
Lorsque le calcul du carbone dans les sols échouait, tout le usecase était en erreur.
J'ai rencontré le cas pour des friches situées à La Réunion par exemple, territoire pour lequel on a pas d'infos dans les data INSEE.

C'est marginal mais dans tous les cas, il ne faut pas que ce soit un bottleneck 😅 