### PR TITLE
feat(web): create urban living and activity spaces forms

### DIFF
--- a/apps/web/src/features/create-project/application/urban-project/urbanProject.actions.ts
+++ b/apps/web/src/features/create-project/application/urban-project/urbanProject.actions.ts
@@ -1,5 +1,5 @@
 import { createAction as _createAction } from "@reduxjs/toolkit";
-import { UrbanGreenSpace, UrbanSpaceCategory } from "shared";
+import { UrbanGreenSpace, UrbanLivingAndActivitySpace, UrbanSpaceCategory } from "shared";
 import { z } from "zod";
 
 import { createAppAsyncThunk } from "@/app/application/appAsyncThunk";
@@ -68,3 +68,23 @@ export const greenSpacesDistributionCompleted = createAction<{
   surfaceAreaDistribution: Partial<Record<UrbanGreenSpace, number>>;
 }>("greenSpacesDistributionCompleted");
 export const greenSpacesDistributionReverted = createAction("greenSpacesDistributionReverted");
+
+// living and activity spaces
+export const livingAndActivitySpacesIntroductionCompleted = createAction(
+  "livingAndActivitySpacesIntroductionCompleted",
+);
+export const livingAndActivitySpacesIntroductionReverted = createAction(
+  "livingAndActivitySpacesIntroductionReverted",
+);
+export const livingAndActivitySpacesSelectionCompleted = createAction<
+  UrbanLivingAndActivitySpace[]
+>("livingAndActivitySpacesSelectionCompleted");
+export const livingAndActivitySpacesSelectionReverted = createAction(
+  "livingAndActivitySpacesSelectionReverted",
+);
+export const livingAndActivitySpacesDistributionCompleted = createAction<
+  Partial<Record<UrbanLivingAndActivitySpace, number>>
+>("livingAndActivitySpacesDistributionCompleted");
+export const livingAndActivitySpacesDistributionReverted = createAction(
+  "livingAndActivitySpacesDistributionReverted",
+);

--- a/apps/web/src/features/create-project/application/urban-project/urbanProject.selectors.ts
+++ b/apps/web/src/features/create-project/application/urban-project/urbanProject.selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from "@reduxjs/toolkit";
-import { UrbanGreenSpace, UrbanSpaceCategory } from "shared";
+import { UrbanGreenSpace, UrbanLivingAndActivitySpace, UrbanSpaceCategory } from "shared";
 
 import { RootState } from "@/app/application/store";
 
@@ -30,3 +30,10 @@ export const selectSpaceCategorySurfaceArea = createSelector(
 export const selectGreenSpaces = createSelector([selectSelf], (state): UrbanGreenSpace[] => {
   return state.creationData.greenSpaces ?? [];
 });
+
+export const selectLivingAndActivitySpaces = createSelector(
+  [selectSelf],
+  (state): UrbanLivingAndActivitySpace[] => {
+    return state.creationData.livingAndActivitySpaces ?? [];
+  },
+);

--- a/apps/web/src/features/create-project/application/urban-project/urbanProject.spec.ts
+++ b/apps/web/src/features/create-project/application/urban-project/urbanProject.spec.ts
@@ -12,6 +12,12 @@ import {
   greenSpacesIntroductionReverted,
   greenSpacesSelectionCompleted,
   greenSpacesSelectionReverted,
+  livingAndActivitySpacesDistributionCompleted,
+  livingAndActivitySpacesDistributionReverted,
+  livingAndActivitySpacesIntroductionCompleted,
+  livingAndActivitySpacesIntroductionReverted,
+  livingAndActivitySpacesSelectionCompleted,
+  livingAndActivitySpacesSelectionReverted,
   spacesDevelopmentPlanIntroductionCompleted,
   spacesDevelopmentPlanIntroductionReverted,
   spacesIntroductionCompleted,
@@ -417,6 +423,197 @@ describe("Urban project creation", () => {
         const newState = store.getState();
         expectRevertedState(initialRootState, newState, {
           creationDataDiff: { greenSpacesDistribution: undefined },
+        });
+      });
+    });
+    describe("LIVING_AND_ACTIVITY_SPACES_INTRODUCTION step", () => {
+      it("goes to LIVING_AND_ACTIVITY_SPACES_SELECTION when step is completed", () => {
+        const store = buildInitialState({
+          stepsHistory: ["LIVING_AND_ACTIVITY_SPACES_INTRODUCTION"],
+          creationData: {
+            spacesCategories: ["LIVING_AND_ACTIVITY_SPACES", "GREEN_SPACES"],
+            spacesCategoriesDistribution: { GREEN_SPACES: 2000, LIVING_AND_ACTIVITY_SPACES: 8000 },
+          },
+        });
+        const initialRootState = store.getState();
+
+        store.dispatch(livingAndActivitySpacesIntroductionCompleted());
+
+        const newState = store.getState();
+        expectUpdatedState(initialRootState, newState, {
+          currentStep: "LIVING_AND_ACTIVITY_SPACES_SELECTION",
+        });
+      });
+      it("goes to previous step and add LIVING_AND_ACTIVITY_SPACES to space categories to complete when step is reverted", () => {
+        const store = buildInitialState({
+          spacesCategoriesToComplete: ["GREEN_SPACES"],
+          stepsHistory: ["SPACES_CATEGORIES_SELECTION", "LIVING_AND_ACTIVITY_SPACES_INTRODUCTION"],
+          creationData: {
+            greenSpaces: ["LAWNS_AND_BUSHES", "TREE_FILLED_SPACE"],
+          },
+        });
+        const initialRootState = store.getState();
+
+        store.dispatch(livingAndActivitySpacesIntroductionReverted());
+
+        const newState = store.getState();
+        expectRevertedState(initialRootState, newState, {
+          spacesCategoriesToComplete: ["LIVING_AND_ACTIVITY_SPACES", "GREEN_SPACES"],
+        });
+      });
+    });
+    describe("LIVING_AND_ACTIVITY_SPACES_SELECTION step", () => {
+      it("goes to LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION and sets living/activity spaces when step is completed", () => {
+        const store = buildInitialState({
+          stepsHistory: ["LIVING_AND_ACTIVITY_SPACES_SELECTION"],
+          creationData: {
+            spacesCategories: ["LIVING_AND_ACTIVITY_SPACES", "GREEN_SPACES"],
+            spacesCategoriesDistribution: { GREEN_SPACES: 2000, LIVING_AND_ACTIVITY_SPACES: 8000 },
+          },
+        });
+        const initialRootState = store.getState();
+
+        store.dispatch(
+          livingAndActivitySpacesSelectionCompleted([
+            "BUILDINGS",
+            "PAVED_ALLEY_OR_PARKING_LOT",
+            "GARDEN_AND_GRASS_ALLEYS",
+          ]),
+        );
+
+        const newState = store.getState();
+        expectUpdatedState(initialRootState, newState, {
+          currentStep: "LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION",
+          creationDataDiff: {
+            livingAndActivitySpaces: [
+              "BUILDINGS",
+              "PAVED_ALLEY_OR_PARKING_LOT",
+              "GARDEN_AND_GRASS_ALLEYS",
+            ],
+          },
+        });
+      });
+      it("goes to previous step and unset living/activity spaces when step is reverted", () => {
+        const store = buildInitialState({
+          spacesCategoriesToComplete: ["GREEN_SPACES"],
+          stepsHistory: ["SPACES_CATEGORIES_SELECTION", "LIVING_AND_ACTIVITY_SPACES_INTRODUCTION"],
+          creationData: {
+            livingAndActivitySpaces: [
+              "BUILDINGS",
+              "PAVED_ALLEY_OR_PARKING_LOT",
+              "GARDEN_AND_GRASS_ALLEYS",
+            ],
+          },
+        });
+        const initialRootState = store.getState();
+
+        store.dispatch(livingAndActivitySpacesSelectionReverted());
+
+        const newState = store.getState();
+        expectRevertedState(initialRootState, newState, {
+          creationDataDiff: { livingAndActivitySpaces: undefined },
+        });
+      });
+    });
+    describe("LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION step", () => {
+      it("sets living/activity spaces surface areas and goes to next spaces category introduction step when step is completed", () => {
+        const store = buildInitialState({
+          stepsHistory: [
+            "LIVING_AND_ACTIVITY_SPACES_SELECTION",
+            "LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION",
+          ],
+          spacesCategoriesToComplete: ["PUBLIC_SPACES", "GREEN_SPACES"],
+          creationData: {
+            spacesCategories: ["LIVING_AND_ACTIVITY_SPACES", "PUBLIC_SPACES", "GREEN_SPACES"],
+            spacesCategoriesDistribution: {
+              GREEN_SPACES: 1000,
+              PUBLIC_SPACES: 1000,
+              LIVING_AND_ACTIVITY_SPACES: 8000,
+            },
+          },
+        });
+        const initialRootState = store.getState();
+
+        store.dispatch(
+          livingAndActivitySpacesDistributionCompleted({
+            BUILDINGS: 5000,
+            GRAVEL_ALLEY_OR_PARKING_LOT: 3000,
+          }),
+        );
+
+        const newState = store.getState();
+        expectUpdatedState(initialRootState, newState, {
+          currentStep: "PUBLIC_SPACES_INTRODUCTION",
+          spacesCategoriesToComplete: ["GREEN_SPACES"],
+          creationDataDiff: {
+            livingAndActivitySpacesDistribution: {
+              BUILDINGS: 5000,
+              GRAVEL_ALLEY_OR_PARKING_LOT: 3000,
+            },
+          },
+        });
+      });
+      it("sets living/activity spaces surface areas and goes to spaces summary step when step is completed and no more space category to complete", () => {
+        const store = buildInitialState({
+          stepsHistory: [
+            "LIVING_AND_ACTIVITY_SPACES_SELECTION",
+            "LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION",
+          ],
+          spacesCategoriesToComplete: [],
+          creationData: {
+            spacesCategories: ["LIVING_AND_ACTIVITY_SPACES"],
+            spacesCategoriesDistribution: { LIVING_AND_ACTIVITY_SPACES: 8000 },
+          },
+        });
+        const initialRootState = store.getState();
+
+        store.dispatch(
+          livingAndActivitySpacesDistributionCompleted({
+            BUILDINGS: 5000,
+            GRAVEL_ALLEY_OR_PARKING_LOT: 3000,
+          }),
+        );
+
+        const newState = store.getState();
+        expectUpdatedState(initialRootState, newState, {
+          currentStep: "SPACES_DEVELOPMENT_PLAN_SUMMARY",
+          creationDataDiff: {
+            livingAndActivitySpacesDistribution: {
+              BUILDINGS: 5000,
+              GRAVEL_ALLEY_OR_PARKING_LOT: 3000,
+            },
+          },
+        });
+      });
+      it("goes to previous step and unset green spaces step is reverted", () => {
+        const store = buildInitialState({
+          stepsHistory: [
+            "LIVING_AND_ACTIVITY_SPACES_INTRODUCTION",
+            "LIVING_AND_ACTIVITY_SPACES_SELECTION",
+            "LIVING_AND_ACTIVITY_SPACES_INTRODUCTION",
+          ],
+          creationData: {
+            spacesCategories: ["LIVING_AND_ACTIVITY_SPACES", "GREEN_SPACES"],
+            spacesCategoriesDistribution: { GREEN_SPACES: 2000, LIVING_AND_ACTIVITY_SPACES: 8000 },
+            livingAndActivitySpaces: [
+              "BUILDINGS",
+              "PAVED_ALLEY_OR_PARKING_LOT",
+              "GARDEN_AND_GRASS_ALLEYS",
+            ],
+            livingAndActivitySpacesDistribution: {
+              BUILDINGS: 2000,
+              PAVED_ALLEY_OR_PARKING_LOT: 3000,
+              GARDEN_AND_GRASS_ALLEYS: 3000,
+            },
+          },
+        });
+        const initialRootState = store.getState();
+
+        store.dispatch(livingAndActivitySpacesDistributionReverted());
+
+        const newState = store.getState();
+        expectRevertedState(initialRootState, newState, {
+          creationDataDiff: { livingAndActivitySpacesDistribution: undefined },
         });
       });
     });

--- a/apps/web/src/features/create-project/domain/urbanProject.ts
+++ b/apps/web/src/features/create-project/domain/urbanProject.ts
@@ -1,4 +1,4 @@
-import { UrbanGreenSpace, UrbanSpaceCategory } from "shared";
+import { UrbanGreenSpace, UrbanLivingAndActivitySpace, UrbanSpaceCategory } from "shared";
 
 export const getLabelForSpaceCategory = (spaceCategory: UrbanSpaceCategory): string => {
   switch (spaceCategory) {
@@ -64,5 +64,22 @@ export const getLabelForUrbanGreenSpace = (greenSpace: UrbanGreenSpace): string 
       return "Zone arborée";
     case "URBAN_POND_OR_LAKE":
       return "Plan d'eau";
+  }
+};
+
+export const getLabelForLivingAndActivitySpace = (
+  livingAndActivitySpace: UrbanLivingAndActivitySpace,
+): string => {
+  switch (livingAndActivitySpace) {
+    case "BUILDINGS":
+      return "Bâtiments";
+    case "PAVED_ALLEY_OR_PARKING_LOT":
+      return "Allée ou parking bitumé";
+    case "GRAVEL_ALLEY_OR_PARKING_LOT":
+      return "Allée ou parking en gravier";
+    case "GARDEN_AND_GRASS_ALLEYS":
+      return "Jardin ou allée enherbée";
+    case "TREE_FILLED_GARDEN_OR_ALLEY":
+      return "Jardin ou allée arborée";
   }
 };

--- a/apps/web/src/features/create-project/views/urban-project/UrbanProjectCreationWizard.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/UrbanProjectCreationWizard.tsx
@@ -29,6 +29,9 @@ const PROJECT_CREATION_STEP_QUERY_STRING_MAP = {
   GREEN_SPACES_SELECTION: "espaces-verts-selection",
   GREEN_SPACES_SURFACE_AREA_DISTRIBUTION: "espaces-verts-surfaces",
   LIVING_AND_ACTIVITY_SPACES_INTRODUCTION: "espaces-de-vie-et-activites-introduction",
+  LIVING_AND_ACTIVITY_SPACES_SELECTION: "espaces-de-vie-et-activites-selection",
+  LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION: "espaces-de-vie-et-activites-surfaces",
+  PUBLIC_SPACES_INTRODUCTION: "espaces-publics-introduction",
   SPACES_DEVELOPMENT_PLAN_SUMMARY: "recapitulatif-amenagement-des-espaces",
   CREATION_RESULT: "fin",
 } as const satisfies Record<UrbanProjectCreationStep, string>;

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/UrbanProjectCustomSteps.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/UrbanProjectCustomSteps.tsx
@@ -28,6 +28,9 @@ const getCategoryForStep = (step: UrbanProjectCustomCreationStep): StepCategory 
     case "GREEN_SPACES_SELECTION":
     case "GREEN_SPACES_SURFACE_AREA_DISTRIBUTION":
     case "LIVING_AND_ACTIVITY_SPACES_INTRODUCTION":
+    case "LIVING_AND_ACTIVITY_SPACES_SELECTION":
+    case "LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION":
+    case "PUBLIC_SPACES_INTRODUCTION":
     case "SPACES_DEVELOPMENT_PLAN_SUMMARY":
       return "Aménagement des espaces";
   }

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/index.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/index.tsx
@@ -9,6 +9,9 @@ import GreenSpacesIntroduction from "./spaces/green-spaces/introduction";
 import UrbanGreenSpacesSelection from "./spaces/green-spaces/selection";
 import UrbanGreenSpacesDistribution from "./spaces/green-spaces/surface-area-distribution";
 import UrbanProjectSpacesIntroduction from "./spaces/introduction";
+import LivingAndActivitySpacesIntroduction from "./spaces/living-and-activity-spaces/introduction";
+import LivingAndActivitySpacesSelection from "./spaces/living-and-activity-spaces/selection";
+import LivingAndActivitySpacesDistribution from "./spaces/living-and-activity-spaces/surface-area-distribution";
 import SpacesCategoriesSelection from "./spaces/selection";
 import UrbanProjectSpaceCategoriesSurfaceAreaDistribution from "./spaces/surface-area";
 
@@ -35,7 +38,13 @@ const getCurrentStepView = (
     case "GREEN_SPACES_SURFACE_AREA_DISTRIBUTION":
       return <UrbanGreenSpacesDistribution />;
     case "LIVING_AND_ACTIVITY_SPACES_INTRODUCTION":
-      return <div>LIVING_AND_ACTIVITY_SPACES_INTRODUCTION</div>;
+      return <LivingAndActivitySpacesIntroduction />;
+    case "LIVING_AND_ACTIVITY_SPACES_SELECTION":
+      return <LivingAndActivitySpacesSelection />;
+    case "LIVING_AND_ACTIVITY_SPACES_DISTRIBUTION":
+      return <LivingAndActivitySpacesDistribution />;
+    case "PUBLIC_SPACES_INTRODUCTION":
+      return <div>PUBLIC_SPACES_INTRODUCTION</div>;
     case "SPACES_DEVELOPMENT_PLAN_SUMMARY":
       return <div>SPACES_DEVELOPMENT_PLAN_SUMMARY</div>;
   }

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/green-spaces/surface-area-distribution/UrbanGreenSpacesDistribution.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/green-spaces/surface-area-distribution/UrbanGreenSpacesDistribution.tsx
@@ -3,13 +3,10 @@ import { Controller, useForm } from "react-hook-form";
 import { UrbanGreenSpace } from "shared";
 
 import { getLabelForUrbanGreenSpace } from "@/features/create-project/domain/urbanProject";
-import {
-  formatSurfaceArea,
-  SQUARE_METERS_HTML_SYMBOL,
-} from "@/shared/services/format-number/formatNumber";
+import { sumObjectValues } from "@/shared/services/sum/sum";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
-import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
+import SurfaceAreaControlInput from "@/shared/views/components/form/SurfaceAreaControlInput/SurfaceAreaControlInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
@@ -21,18 +18,13 @@ type Props = {
 
 export type FormValues = Record<UrbanGreenSpace, number>;
 
-const getTotalSurface = (surfaceAreaDistribution: FormValues) =>
-  Object.values(surfaceAreaDistribution)
-    .filter(Number)
-    .reduce((total, surface) => total + surface, 0);
-
 function UrbanGreenSpacesDistribution({ greenSpaces, totalSurfaceArea, onSubmit, onBack }: Props) {
   const { control, handleSubmit, watch } = useForm<FormValues>();
   const _onSubmit = handleSubmit(onSubmit);
 
   const surfaceAreas = watch();
 
-  const totalAllocatedSurface = useMemo(() => getTotalSurface(surfaceAreas), [surfaceAreas]);
+  const totalAllocatedSurface = useMemo(() => sumObjectValues(surfaceAreas), [surfaceAreas]);
 
   const remainder = totalSurfaceArea - totalAllocatedSurface;
   const isValid = remainder === 0;
@@ -69,23 +61,10 @@ function UrbanGreenSpacesDistribution({ greenSpaces, totalSurfaceArea, onSubmit,
           />
         ))}
 
-        <RowNumericInput
-          className="tw-pb-5"
-          label="Total de toutes les surfaces"
-          hintText={`en ${SQUARE_METERS_HTML_SYMBOL}`}
-          nativeInputProps={{
-            value: totalAllocatedSurface,
-            min: 0,
-            max: totalSurfaceArea,
-            type: "number",
-          }}
-          disabled
-          state={isValid ? "success" : "error"}
-          stateRelatedMessage={
-            isValid
-              ? "Le compte est bon !"
-              : `${formatSurfaceArea(Math.abs(remainder))} ${remainder > 0 ? "manquants" : "en trop"}`
-          }
+        <SurfaceAreaControlInput
+          label="Total de tous les espaces verts"
+          currentSurfaceArea={totalAllocatedSurface}
+          targetSurfaceArea={totalSurfaceArea}
         />
         <BackNextButtonsGroup onBack={onBack} disabled={!isValid} nextLabel="Valider" />
       </form>

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/introduction/LivingAndActivitySpacesIntroduction.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/introduction/LivingAndActivitySpacesIntroduction.tsx
@@ -1,0 +1,38 @@
+import { formatSurfaceArea } from "@/shared/services/format-number/formatNumber";
+import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
+import {
+  EditorialPageIcon,
+  EditorialPageLayout,
+  EditorialPageText,
+  EditorialPageTitle,
+} from "@/shared/views/layout/EditorialPageLayout";
+
+type Props = {
+  livingAndActivitySpacesSurfaceArea: number;
+  onNext: () => void;
+  onBack: () => void;
+};
+
+const LivingAndActivitySpacesIntroduction = ({
+  livingAndActivitySpacesSurfaceArea,
+  onNext,
+  onBack,
+}: Props) => {
+  return (
+    <EditorialPageLayout>
+      <EditorialPageIcon>🏢</EditorialPageIcon>
+      <EditorialPageTitle>Parlons des lieux de vie et d'activité.</EditorialPageTitle>
+      <EditorialPageText>
+        Votre projet d'aménagement comporte{" "}
+        <strong>{formatSurfaceArea(livingAndActivitySpacesSurfaceArea)}</strong> de surface au sol
+        de lieux de vie et d'activité.
+        <br />
+        Ces lieux peuvent contenir des bâtiments, mais aussi des des allées privées, des parkings
+        privés ou encore des jardins privatifs ou partagés.
+      </EditorialPageText>
+      <BackNextButtonsGroup onBack={onBack} onNext={onNext} />
+    </EditorialPageLayout>
+  );
+};
+
+export default LivingAndActivitySpacesIntroduction;

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/introduction/index.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/introduction/index.tsx
@@ -1,0 +1,27 @@
+import {
+  livingAndActivitySpacesIntroductionCompleted,
+  livingAndActivitySpacesIntroductionReverted,
+} from "@/features/create-project/application/urban-project/urbanProject.actions";
+import { selectSpaceCategorySurfaceArea } from "@/features/create-project/application/urban-project/urbanProject.selectors";
+import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
+
+import LivingAndActivitySpacesIntroduction from "./LivingAndActivitySpacesIntroduction";
+
+export default function LivingAndActivitySpacesIntroductionContainer() {
+  const dispatch = useAppDispatch();
+  const livingAndActivitySpacesSurfaceArea = useAppSelector((state) =>
+    selectSpaceCategorySurfaceArea(state, "LIVING_AND_ACTIVITY_SPACES"),
+  );
+
+  return (
+    <LivingAndActivitySpacesIntroduction
+      livingAndActivitySpacesSurfaceArea={livingAndActivitySpacesSurfaceArea}
+      onBack={() => {
+        dispatch(livingAndActivitySpacesIntroductionReverted());
+      }}
+      onNext={() => {
+        dispatch(livingAndActivitySpacesIntroductionCompleted());
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/selection/LivingAndActivitySpacesSelection.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/selection/LivingAndActivitySpacesSelection.tsx
@@ -1,0 +1,80 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { Controller, useForm } from "react-hook-form";
+import { UrbanLivingAndActivitySpace, livingAndActivitySpace } from "shared";
+
+import { getLabelForLivingAndActivitySpace } from "@/features/create-project/domain/urbanProject";
+import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
+import CheckableTile from "@/shared/views/components/CheckableTile/CheckableTile";
+import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
+
+export type FormValues = {
+  livingAndActivitySpaces: UrbanLivingAndActivitySpace[];
+};
+
+type Props = {
+  onSubmit: (data: FormValues) => void;
+  onBack: () => void;
+};
+
+type LivingAndActivitySpaceTileProps = {
+  livingAndActivitySpace: UrbanLivingAndActivitySpace;
+  isSelected: boolean;
+  onSelect: () => void;
+};
+
+const LivingAndActivitySpaceTile = ({
+  livingAndActivitySpace,
+  isSelected,
+  onSelect,
+}: LivingAndActivitySpaceTileProps) => {
+  const title = getLabelForLivingAndActivitySpace(livingAndActivitySpace);
+  const imgSrc = "";
+
+  return (
+    <CheckableTile title={title} imgSrc={imgSrc} isSelected={isSelected} onSelect={onSelect} />
+  );
+};
+
+function LivingAndActivitySpacesSelection({ onSubmit, onBack }: Props) {
+  const { control, handleSubmit, formState } = useForm<FormValues>({
+    defaultValues: { livingAndActivitySpaces: [] },
+  });
+
+  return (
+    <WizardFormLayout title="Quels types d'espaces y aura-t-il dans les lieux de vie et d'activité ?">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-mb-5w")}>
+          {livingAndActivitySpace.options.map((value) => {
+            return (
+              <div className={fr.cx("fr-col-12", "fr-col-sm-6")} key={value}>
+                <Controller
+                  control={control}
+                  name="livingAndActivitySpaces"
+                  render={({ field }) => {
+                    const isSelected = field.value.includes(value);
+                    return (
+                      <LivingAndActivitySpaceTile
+                        livingAndActivitySpace={value}
+                        isSelected={isSelected}
+                        onSelect={() => {
+                          field.onChange(
+                            isSelected
+                              ? field.value.filter((v) => v !== value)
+                              : [...field.value, value],
+                          );
+                        }}
+                      />
+                    );
+                  }}
+                />
+              </div>
+            );
+          })}
+        </div>
+        <BackNextButtonsGroup onBack={onBack} nextLabel="Valider" disabled={!formState.isValid} />
+      </form>
+    </WizardFormLayout>
+  );
+}
+
+export default LivingAndActivitySpacesSelection;

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/selection/index.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/selection/index.tsx
@@ -1,0 +1,22 @@
+import {
+  livingAndActivitySpacesSelectionCompleted,
+  livingAndActivitySpacesSelectionReverted,
+} from "@/features/create-project/application/urban-project/urbanProject.actions";
+import { useAppDispatch } from "@/shared/views/hooks/store.hooks";
+
+import LivingAndActivitySpacesSelection, { FormValues } from "./LivingAndActivitySpacesSelection";
+
+export default function LivingAndActivitySpacesSelectionContainer() {
+  const dispatch = useAppDispatch();
+
+  return (
+    <LivingAndActivitySpacesSelection
+      onBack={() => {
+        dispatch(livingAndActivitySpacesSelectionReverted());
+      }}
+      onSubmit={(formData: FormValues) => {
+        dispatch(livingAndActivitySpacesSelectionCompleted(formData.livingAndActivitySpaces));
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/surface-area-distribution/LivingAndActivitySpacesDistribution.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/surface-area-distribution/LivingAndActivitySpacesDistribution.tsx
@@ -3,13 +3,10 @@ import { Controller, useForm } from "react-hook-form";
 import { UrbanLivingAndActivitySpace } from "shared";
 
 import { getLabelForLivingAndActivitySpace } from "@/features/create-project/domain/urbanProject";
-import {
-  formatSurfaceArea,
-  SQUARE_METERS_HTML_SYMBOL,
-} from "@/shared/services/format-number/formatNumber";
+import { sumObjectValues } from "@/shared/services/sum/sum";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
-import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
+import SurfaceAreaControlInput from "@/shared/views/components/form/SurfaceAreaControlInput/SurfaceAreaControlInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
@@ -20,11 +17,6 @@ type Props = {
 };
 
 export type FormValues = Record<UrbanLivingAndActivitySpace, number>;
-
-const getTotalSurface = (surfaceAreaDistribution: FormValues) =>
-  Object.values(surfaceAreaDistribution)
-    .filter(Number)
-    .reduce((total, surface) => total + surface, 0);
 
 function LivingAndActivitySpacesDistribution({
   livingAndActivitySpaces,
@@ -37,7 +29,7 @@ function LivingAndActivitySpacesDistribution({
 
   const surfaceAreas = watch();
 
-  const totalAllocatedSurface = useMemo(() => getTotalSurface(surfaceAreas), [surfaceAreas]);
+  const totalAllocatedSurface = useMemo(() => sumObjectValues(surfaceAreas), [surfaceAreas]);
 
   const remainder = totalSurfaceArea - totalAllocatedSurface;
   const isValid = remainder === 0;
@@ -73,24 +65,10 @@ function LivingAndActivitySpacesDistribution({
             }}
           />
         ))}
-
-        <RowNumericInput
-          className="tw-pb-5"
-          label="Total des espaces de vie et d'activité"
-          hintText={`en ${SQUARE_METERS_HTML_SYMBOL}`}
-          nativeInputProps={{
-            value: totalAllocatedSurface,
-            min: 0,
-            max: totalSurfaceArea,
-            type: "number",
-          }}
-          disabled
-          state={isValid ? "success" : "error"}
-          stateRelatedMessage={
-            isValid
-              ? "Le compte est bon !"
-              : `${formatSurfaceArea(Math.abs(remainder))} ${remainder > 0 ? "manquants" : "en trop"}`
-          }
+        <SurfaceAreaControlInput
+          label="Total de tous les espaces de vie et d'activité"
+          currentSurfaceArea={totalAllocatedSurface}
+          targetSurfaceArea={totalSurfaceArea}
         />
         <BackNextButtonsGroup onBack={onBack} disabled={!isValid} nextLabel="Valider" />
       </form>

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/surface-area-distribution/LivingAndActivitySpacesDistribution.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/surface-area-distribution/LivingAndActivitySpacesDistribution.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { UrbanLivingAndActivitySpace } from "shared";
+
+import { getLabelForLivingAndActivitySpace } from "@/features/create-project/domain/urbanProject";
+import {
+  formatSurfaceArea,
+  SQUARE_METERS_HTML_SYMBOL,
+} from "@/shared/services/format-number/formatNumber";
+import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
+import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
+import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
+import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
+
+type Props = {
+  totalSurfaceArea: number;
+  livingAndActivitySpaces: UrbanLivingAndActivitySpace[];
+  onSubmit: (data: FormValues) => void;
+  onBack: () => void;
+};
+
+export type FormValues = Record<UrbanLivingAndActivitySpace, number>;
+
+const getTotalSurface = (surfaceAreaDistribution: FormValues) =>
+  Object.values(surfaceAreaDistribution)
+    .filter(Number)
+    .reduce((total, surface) => total + surface, 0);
+
+function LivingAndActivitySpacesDistribution({
+  livingAndActivitySpaces,
+  totalSurfaceArea,
+  onSubmit,
+  onBack,
+}: Props) {
+  const { control, handleSubmit, watch } = useForm<FormValues>();
+  const _onSubmit = handleSubmit(onSubmit);
+
+  const surfaceAreas = watch();
+
+  const totalAllocatedSurface = useMemo(() => getTotalSurface(surfaceAreas), [surfaceAreas]);
+
+  const remainder = totalSurfaceArea - totalAllocatedSurface;
+  const isValid = remainder === 0;
+
+  return (
+    <WizardFormLayout title="Quelle est la part de chaque espace à aménager dans les lieux de vie et d'activité ?">
+      <form onSubmit={_onSubmit}>
+        {livingAndActivitySpaces.map((spaceCategory) => (
+          <Controller
+            name={spaceCategory}
+            control={control}
+            key={spaceCategory}
+            rules={{
+              min: {
+                value: 0,
+                message: "Veuillez sélectionner une superficie",
+              },
+              max: {
+                value: totalSurfaceArea,
+                message:
+                  "La superficie ne peut pas être supérieure à la superficie totale des espaces de vie et d'activité",
+              },
+            }}
+            render={(controller) => {
+              return (
+                <ControlledRowNumericInput
+                  {...controller}
+                  label={getLabelForLivingAndActivitySpace(spaceCategory)}
+                  hintInputText="en m²"
+                  imgSrc={undefined}
+                />
+              );
+            }}
+          />
+        ))}
+
+        <RowNumericInput
+          className="tw-pb-5"
+          label="Total des espaces de vie et d'activité"
+          hintText={`en ${SQUARE_METERS_HTML_SYMBOL}`}
+          nativeInputProps={{
+            value: totalAllocatedSurface,
+            min: 0,
+            max: totalSurfaceArea,
+            type: "number",
+          }}
+          disabled
+          state={isValid ? "success" : "error"}
+          stateRelatedMessage={
+            isValid
+              ? "Le compte est bon !"
+              : `${formatSurfaceArea(Math.abs(remainder))} ${remainder > 0 ? "manquants" : "en trop"}`
+          }
+        />
+        <BackNextButtonsGroup onBack={onBack} disabled={!isValid} nextLabel="Valider" />
+      </form>
+    </WizardFormLayout>
+  );
+}
+
+export default LivingAndActivitySpacesDistribution;

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/surface-area-distribution/index.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/living-and-activity-spaces/surface-area-distribution/index.tsx
@@ -1,0 +1,34 @@
+import {
+  livingAndActivitySpacesDistributionCompleted,
+  livingAndActivitySpacesDistributionReverted,
+} from "@/features/create-project/application/urban-project/urbanProject.actions";
+import {
+  selectLivingAndActivitySpaces,
+  selectSpaceCategorySurfaceArea,
+} from "@/features/create-project/application/urban-project/urbanProject.selectors";
+import { useAppDispatch, useAppSelector } from "@/shared/views/hooks/store.hooks";
+
+import LivingAndActivitySpacesDistribution, {
+  FormValues,
+} from "./LivingAndActivitySpacesDistribution";
+
+export default function LivingAndActivitySpacesDistributionContainer() {
+  const dispatch = useAppDispatch();
+  const livingAndActivitySpaces = useAppSelector(selectLivingAndActivitySpaces);
+  const livingAndActivitySpacesSurfaceArea = useAppSelector((state) =>
+    selectSpaceCategorySurfaceArea(state, "LIVING_AND_ACTIVITY_SPACES"),
+  );
+
+  return (
+    <LivingAndActivitySpacesDistribution
+      livingAndActivitySpaces={livingAndActivitySpaces}
+      totalSurfaceArea={livingAndActivitySpacesSurfaceArea}
+      onSubmit={(formData: FormValues) => {
+        dispatch(livingAndActivitySpacesDistributionCompleted(formData));
+      }}
+      onBack={() => {
+        dispatch(livingAndActivitySpacesDistributionReverted());
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/surface-area/SpacesCategoriesSurfaceAreaDistributionForm.tsx
+++ b/apps/web/src/features/create-project/views/urban-project/custom-forms/spaces/surface-area/SpacesCategoriesSurfaceAreaDistributionForm.tsx
@@ -7,13 +7,10 @@ import {
   getLabelForSpaceCategory,
   getPictogramForUrbanSpaceCategory,
 } from "@/features/create-project/domain/urbanProject";
-import {
-  formatSurfaceArea,
-  SQUARE_METERS_HTML_SYMBOL,
-} from "@/shared/services/format-number/formatNumber";
+import { sumObjectValues } from "@/shared/services/sum/sum";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
-import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
+import SurfaceAreaControlInput from "@/shared/views/components/form/SurfaceAreaControlInput/SurfaceAreaControlInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
@@ -24,11 +21,6 @@ type Props = {
 };
 
 export type FormValues = Record<UrbanSpaceCategory, number>;
-
-const getTotalSurface = (surfaceAreaDistribution: FormValues) =>
-  Object.values(surfaceAreaDistribution)
-    .filter(Number)
-    .reduce((total, surface) => total + surface, 0);
 
 function SpacesCategoriesSurfaceAreaDistributionForm({
   spacesCategories,
@@ -41,7 +33,7 @@ function SpacesCategoriesSurfaceAreaDistributionForm({
 
   const soilsValues = watch();
 
-  const totalAllocatedSurface = useMemo(() => getTotalSurface(soilsValues), [soilsValues]);
+  const totalAllocatedSurface = useMemo(() => sumObjectValues(soilsValues), [soilsValues]);
 
   const remainder = totalSurfaceArea - totalAllocatedSurface;
   const isValid = remainder === 0;
@@ -78,23 +70,10 @@ function SpacesCategoriesSurfaceAreaDistributionForm({
           />
         ))}
 
-        <RowNumericInput
-          className="tw-pb-5"
-          label="Total de toutes les surfaces"
-          hintText={`en ${SQUARE_METERS_HTML_SYMBOL}`}
-          nativeInputProps={{
-            value: totalAllocatedSurface,
-            min: 0,
-            max: totalSurfaceArea,
-            type: "number",
-          }}
-          disabled
-          state={isValid ? "success" : "error"}
-          stateRelatedMessage={
-            isValid
-              ? "Le compte est bon !"
-              : `${formatSurfaceArea(Math.abs(remainder))} ${remainder > 0 ? "manquants" : "en trop"}`
-          }
+        <SurfaceAreaControlInput
+          label="Total de tous les espaces"
+          currentSurfaceArea={totalAllocatedSurface}
+          targetSurfaceArea={totalSurfaceArea}
         />
         <BackNextButtonsGroup onBack={onBack} disabled={!isValid} nextLabel="Valider" />
       </form>

--- a/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-percentage/ByPercentageForm.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-percentage/ByPercentageForm.tsx
@@ -9,6 +9,7 @@ import {
   getLabelForSoilType,
   getPictogramForSoilType,
 } from "@/shared/services/label-mapping/soilTypeLabelMapping";
+import { sumObjectValues } from "@/shared/services/sum/sum";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import SurfaceAreaPieChart from "@/shared/views/components/Charts/SurfaceAreaPieChart";
 import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
@@ -23,11 +24,6 @@ type Props = {
 
 export type FormValues = Record<SoilType, number>;
 
-const getTotalAllocated = (distribution: FormValues) =>
-  Object.values(distribution)
-    .filter(Number)
-    .reduce((total, percent) => total + percent, 0);
-
 const SLIDER_PROPS = {
   tooltip: {
     formatter: (value?: number) => value && `${formatNumberFr(value)} %`,
@@ -40,7 +36,7 @@ function SiteSoilsDistributionByPercentageForm({ soils, onSubmit, onBack }: Prop
 
   const soilsValues = watch();
 
-  const totalAllocated = useMemo(() => getTotalAllocated(soilsValues), [soilsValues]);
+  const totalAllocated = useMemo(() => sumObjectValues(soilsValues), [soilsValues]);
 
   const remainder = 100 - totalAllocated;
 

--- a/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
+++ b/apps/web/src/features/create-site/views/custom/soils/soils-distribution/distribution/by-square-meters/BySquareMeters.tsx
@@ -3,18 +3,15 @@ import { Controller, useForm } from "react-hook-form";
 import { SoilType } from "shared";
 
 import {
-  formatSurfaceArea,
-  SQUARE_METERS_HTML_SYMBOL,
-} from "@/shared/services/format-number/formatNumber";
-import {
   getDescriptionForSoilType,
   getLabelForSoilType,
   getPictogramForSoilType,
 } from "@/shared/services/label-mapping/soilTypeLabelMapping";
+import { sumObjectValues } from "@/shared/services/sum/sum";
 import BackNextButtonsGroup from "@/shared/views/components/BackNextButtons/BackNextButtons";
 import SurfaceAreaPieChart from "@/shared/views/components/Charts/SurfaceAreaPieChart";
 import ControlledRowNumericInput from "@/shared/views/components/form/NumericInput/ControlledRowNumericInput";
-import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
+import SurfaceAreaControlInput from "@/shared/views/components/form/SurfaceAreaControlInput/SurfaceAreaControlInput";
 import WizardFormLayout from "@/shared/views/layout/WizardFormLayout/WizardFormLayout";
 
 type Props = {
@@ -25,11 +22,6 @@ type Props = {
 };
 
 export type FormValues = Record<SoilType, number>;
-
-const getTotalSurface = (soilsDistribution: FormValues) =>
-  Object.values(soilsDistribution)
-    .filter(Number)
-    .reduce((total, surface) => total + surface, 0);
 
 function SiteSoilsDistributionBySquareMetersForm({
   soils,
@@ -42,7 +34,7 @@ function SiteSoilsDistributionBySquareMetersForm({
 
   const soilsValues = watch();
 
-  const totalAllocatedSurface = useMemo(() => getTotalSurface(soilsValues), [soilsValues]);
+  const totalAllocatedSurface = useMemo(() => sumObjectValues(soilsValues), [soilsValues]);
 
   const remainder = totalSurfaceArea - totalAllocatedSurface;
   const isValid = remainder === 0;
@@ -84,24 +76,10 @@ function SiteSoilsDistributionBySquareMetersForm({
             }}
           />
         ))}
-
-        <RowNumericInput
-          className="tw-pb-5"
+        <SurfaceAreaControlInput
           label="Total de toutes les surfaces"
-          hintText={`en ${SQUARE_METERS_HTML_SYMBOL}`}
-          nativeInputProps={{
-            value: totalAllocatedSurface,
-            min: 0,
-            max: totalSurfaceArea,
-            type: "number",
-          }}
-          disabled
-          state={isValid ? "success" : "error"}
-          stateRelatedMessage={
-            isValid
-              ? "Le compte est bon !"
-              : `${formatSurfaceArea(Math.abs(remainder))} ${remainder > 0 ? "manquants" : "en trop"}`
-          }
+          currentSurfaceArea={totalAllocatedSurface}
+          targetSurfaceArea={totalSurfaceArea}
         />
         <BackNextButtonsGroup onBack={onBack} disabled={!isValid} nextLabel="Valider" />
       </form>

--- a/apps/web/src/shared/views/components/form/SurfaceAreaControlInput/SurfaceAreaControlInput.tsx
+++ b/apps/web/src/shared/views/components/form/SurfaceAreaControlInput/SurfaceAreaControlInput.tsx
@@ -1,0 +1,39 @@
+import {
+  formatSurfaceArea,
+  SQUARE_METERS_HTML_SYMBOL,
+} from "@/shared/services/format-number/formatNumber";
+import RowNumericInput from "@/shared/views/components/form/NumericInput/RowNumericInput";
+
+type Props = {
+  label: string;
+  targetSurfaceArea: number;
+  currentSurfaceArea: number;
+};
+
+function SurfaceAreaControlInput({ label, targetSurfaceArea, currentSurfaceArea }: Props) {
+  const remainder = targetSurfaceArea - currentSurfaceArea;
+  const isValid = remainder === 0;
+
+  return (
+    <RowNumericInput
+      className="tw-pb-5"
+      label={label}
+      hintText={`en ${SQUARE_METERS_HTML_SYMBOL}`}
+      nativeInputProps={{
+        value: currentSurfaceArea,
+        min: 0,
+        max: targetSurfaceArea,
+        type: "number",
+      }}
+      disabled
+      state={isValid ? "success" : "error"}
+      stateRelatedMessage={
+        isValid
+          ? "Le compte est bon !"
+          : `${formatSurfaceArea(Math.abs(remainder))} ${remainder > 0 ? "manquants" : "en trop"}`
+      }
+    />
+  );
+}
+
+export default SurfaceAreaControlInput;

--- a/packages/shared/src/reconversion-projects/index.ts
+++ b/packages/shared/src/reconversion-projects/index.ts
@@ -55,3 +55,4 @@ export * from "./photovoltaicPowerStation";
 export * from "./reinstatementCosts";
 export * from "./reinstatementFullTimeJobs";
 export * from "./green-spaces/urbanGreenSpaces";
+export * from "./living-and-activity-spaces/urbanLivingAndActivitySpaces";

--- a/packages/shared/src/reconversion-projects/living-and-activity-spaces/urbanLivingAndActivitySpaces.ts
+++ b/packages/shared/src/reconversion-projects/living-and-activity-spaces/urbanLivingAndActivitySpaces.ts
@@ -1,0 +1,11 @@
+import z from "zod";
+
+export const livingAndActivitySpace = z.enum([
+  "BUILDINGS",
+  "PAVED_ALLEY_OR_PARKING_LOT",
+  "GRAVEL_ALLEY_OR_PARKING_LOT",
+  "GARDEN_AND_GRASS_ALLEYS",
+  "TREE_FILLED_GARDEN_OR_ALLEY",
+]);
+
+export type UrbanLivingAndActivitySpace = z.infer<typeof livingAndActivitySpace>;


### PR DESCRIPTION
Pas de pictos non plus 😅 

Le code se répète pas mal sur les formulaires de sélection/attribution des surfaces, je vais voir si ça vaut le coup de créer des composants génériques genre `<SpaceSelectionForm/>` et `<SpaceSurfaceAreaDistributionForm/>`, peut-être même généralisable sur les formulaires sols.