### PR TITLE
fix(ci): scope secrets to only pass SCALINGO_API_TOKEN to deploy workflows

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -14,4 +14,5 @@ jobs:
     name: Build and deploy on staging
     # jobs are run in parallel by default, we want them to run sequentially
     uses: ./.github/workflows/deploy-staging.yml
-    secrets: inherit
+    secrets:
+      SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,4 +33,5 @@ jobs:
     with:
       tag: "v${{ github.run_number }}"
       environment: production
-    secrets: inherit
+    secrets:
+      SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,6 +6,9 @@ permissions:
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      SCALINGO_API_TOKEN:
+        required: true
 
 jobs:
   integration-checks:
@@ -33,4 +36,5 @@ jobs:
     with:
       tag: "v${{ github.run_number }}"
       environment: staging
-    secrets: inherit
+    secrets:
+      SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` with explicit `SCALINGO_API_TOKEN` passing in all deploy workflow chains
- `deploy-staging.yml` now declares `SCALINGO_API_TOKEN` as a required `workflow_call` secret
- Follows least-privilege principle: reusable workflows only receive the secrets they need

## Context
CI/CD review finding #9 — `secrets: inherit` was passing all repository secrets to reusable workflows unnecessarily.

## Test plan
- [ ] Trigger a staging deploy (push to main) and verify it succeeds
- [ ] Trigger a production deploy (workflow_dispatch) and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)