### PR TITLE
fix(ci): add concurrency controls to prevent parallel CI/deploy races

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -3,6 +3,10 @@ name: "Continuous Delivery"
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 # Run when push occurs on main branch
 on:
   push:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,10 @@ name: "Deploy production"
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 # Run when push occurs on main branch
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,6 +3,10 @@ name: "Deploy staging"
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/integration-checks.yml
+++ b/.github/workflows/integration-checks.yml
@@ -6,6 +6,10 @@ name: Integration checks
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
## Summary
- Add `concurrency` blocks to CI and deploy workflows
- Integration checks: cancel stale runs on the same branch (`cancel-in-progress: true`)
- Deploy workflows: queue deploys to prevent races (`cancel-in-progress: false`)

## Context
CI/CD review finding #10 — no concurrency controls existed, allowing parallel deploys and wasted CI minutes.

## Test plan
- [ ] Push two commits quickly to a branch and verify the first CI run is cancelled
- [ ] Verify staging deploy queues correctly on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)