### PR TITLE
fix(ci): add post-deploy health check to verify API is responding

### DIFF
--- a/.github/workflows/deploy-to-scalingo.yml
+++ b/.github/workflows/deploy-to-scalingo.yml
@@ -45,3 +45,9 @@ jobs:
           run: |
             echo "Deploying API on app ${{ vars.SCALINGO_API_APP_NAME }}"
             scalingo --region ${{vars.SCALINGO_APP_REGION}} --app ${{ vars.SCALINGO_API_APP_NAME }} deploy api-scalingo.tar.gz
+        - name: Wait for deployment to stabilize
+          run: sleep 30
+        - name: Verify API health
+          run: |
+            echo "Checking API health at https://${{ vars.SCALINGO_API_APP_NAME }}.osc-secnum-fr1.scalingo.io/api/health"
+            curl --retry 3 --retry-delay 10 --retry-all-errors -sf "https://${{ vars.SCALINGO_API_APP_NAME }}.osc-secnum-fr1.scalingo.io/api/health" || echo "::warning::API health check failed — deployment may need manual verification"

--- a/.github/workflows/deploy-to-scalingo.yml
+++ b/.github/workflows/deploy-to-scalingo.yml
@@ -49,5 +49,6 @@ jobs:
           run: sleep 30
         - name: Verify API health
           run: |
-            echo "Checking API health at https://${{ vars.SCALINGO_API_APP_NAME }}.osc-secnum-fr1.scalingo.io/api/health"
-            curl --retry 3 --retry-delay 10 --retry-all-errors -sf "https://${{ vars.SCALINGO_API_APP_NAME }}.osc-secnum-fr1.scalingo.io/api/health" || echo "::warning::API health check failed — deployment may need manual verification"
+            API_URL="https://${{ vars.SCALINGO_API_APP_NAME }}.${{ vars.SCALINGO_APP_REGION }}.scalingo.io"
+            echo "Checking API health at ${API_URL}/api/health"
+            curl --retry 3 --retry-delay 10 --retry-all-errors -sf "${API_URL}/api/health" || echo "::warning::API health check failed — deployment may need manual verification"


### PR DESCRIPTION
## Summary
- Add health check step after Scalingo deployment
- Waits 30s for container restart, then curls API health endpoint with 3 retries
- Uses \`::warning::\` annotation on failure (does not block the workflow)

## Context
CI/CD review finding #14 — deployments had no verification that the app actually started correctly.

## Test plan
- [ ] Trigger a staging deploy and verify the health check step appears and passes
- [ ] Verify a failed health check produces a warning annotation (not a failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)