### PR TITLE
fix(ci): set 1-day retention on build artifacts to reduce storage usage

### DIFF
--- a/.github/workflows/build-and-upload-api-artifact.yml
+++ b/.github/workflows/build-and-upload-api-artifact.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           name: api-scalingo-${{ inputs.tag }}
           path: api-scalingo.tar.gz
+          retention-days: 1

--- a/.github/workflows/build-and-upload-web-artifact.yml
+++ b/.github/workflows/build-and-upload-web-artifact.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           name: web-scalingo-${{ inputs.tag }}
           path: web-scalingo.tar.gz
+          retention-days: 1


### PR DESCRIPTION
## Summary
- Add \`retention-days: 1\` to API and web build artifact uploads
- These artifacts are consumed immediately by the deploy job, so 1 day is sufficient
- Reduces GitHub Actions storage usage (previously defaulted to 90 days)

## Context
CI/CD review finding #15 — build artifacts were using default 90-day retention unnecessarily.

## Test plan
- [ ] Verify staging deploy still works (artifacts are downloaded in the same run)
- [ ] Confirm artifacts are cleaned up after 1 day

🤖 Generated with [Claude Code](https://claude.com/claude-code)