### PR TITLE
fix(infra): parameterize dev database credentials in docker-compose.db.yml

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -7,9 +7,9 @@ services:
     ports:
       - '${DATABASE_PORT}:5432'
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: secret
-      POSTGRES_DB: benefriches_db
+      POSTGRES_USER: ${DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-secret}
+      POSTGRES_DB: ${DATABASE_DB_NAME:-benefriches_db}
     volumes:
       - benefriches_pg_data:/var/lib/postgresql/data
   mailcatcher:


### PR DESCRIPTION
## Summary
- Replace hardcoded Postgres credentials with environment variable references
- Defaults preserve existing values (\`postgres\`/\`secret\`/\`benefriches_db\`) — no breaking change
- Variable names align with \`docker-compose.e2e.yml\` (\`DATABASE_USER\`, \`DATABASE_PASSWORD\`, \`DATABASE_DB_NAME\`)

## Context
CI/CD review finding #19 — dev compose had hardcoded credentials while e2e compose correctly used env vars.

## Test plan
- [ ] \`docker compose -f docker-compose.db.yml up\` works without any \`.env\` file (uses defaults)
- [ ] Setting \`DATABASE_PASSWORD=custom\` overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)