### PR TITLE
fix(web): route HeadlessUI Combobox wiring to the real native input in Autocomplete

### DIFF
--- a/apps/e2e-tests/pages/SiteCreationPage.ts
+++ b/apps/e2e-tests/pages/SiteCreationPage.ts
@@ -113,12 +113,13 @@ export class SiteCreationPage {
   }
 
   async fillAddress(municipality: string): Promise<void> {
-    const searchInput = this.page.getByRole("searchbox", {
+    // Accessible role is "combobox" (HeadlessUI's Combobox pattern), not "searchbox" — even
+    // though the underlying native input is type="search".
+    const searchInput = this.page.getByRole("combobox", {
       name: /Commune ou code postal|Adresse/i,
     });
-    // Use pressSequentially instead of fill() because HeadlessUI's ComboboxInput
-    // tries to call setSelectionRange() on the DSFR Input wrapper instead of
-    // the native input element, causing "setSelectionRange is not a function" error
+    // Use pressSequentially instead of fill() to match how a real user types (fill() sets the
+    // value in one go, bypassing the per-keystroke debounced search).
     await searchInput.pressSequentially(municipality, { delay: 50 });
 
     // Wait for autocomplete suggestions to appear and select the first option

--- a/apps/e2e-tests/tests/site-creation/agricultural-operation/create-custom-agricultural-operation.spec.ts-snapshots/agricultural-operation-custom-address-step.aria.yml
+++ b/apps/e2e-tests/tests/site-creation/agricultural-operation/create-custom-agricultural-operation.spec.ts-snapshots/agricultural-operation-custom-address-step.aria.yml
@@ -1,8 +1,7 @@
 - main:
   - heading "Où est située l'exploitation agricole ?" [level=2]
-  - combobox:
-    - text: Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète
-    - searchbox "Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète"
+  - text: Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète
+  - combobox "Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète"
   - list:
     - listitem:
       - button "Précédent"

--- a/apps/e2e-tests/tests/site-creation/agricultural-operation/create-express-agricultural-operation.spec.ts-snapshots/agricultural-operation-express-address-step.aria.yml
+++ b/apps/e2e-tests/tests/site-creation/agricultural-operation/create-express-agricultural-operation.spec.ts-snapshots/agricultural-operation-express-address-step.aria.yml
@@ -1,8 +1,7 @@
 - main:
   - heading "Où est située l'exploitation agricole ?" [level=2]
-  - combobox:
-    - text: Commune ou code postal *
-    - searchbox "Commune ou code postal *"
+  - text: Commune ou code postal *
+  - combobox "Commune ou code postal *"
   - list:
     - listitem:
       - button "Précédent"

--- a/apps/e2e-tests/tests/site-creation/friche/create-custom-friche.spec.ts-snapshots/friche-custom-address-step.aria.yml
+++ b/apps/e2e-tests/tests/site-creation/friche/create-custom-friche.spec.ts-snapshots/friche-custom-address-step.aria.yml
@@ -1,8 +1,7 @@
 - main:
   - heading "Où est située la friche ?" [level=2]
-  - combobox:
-    - text: Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète
-    - searchbox "Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète"
+  - text: Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète
+  - combobox "Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète"
   - list:
     - listitem:
       - button "Précédent"

--- a/apps/e2e-tests/tests/site-creation/friche/create-express-friche.spec.ts-snapshots/friche-express-address-step.aria.yml
+++ b/apps/e2e-tests/tests/site-creation/friche/create-express-friche.spec.ts-snapshots/friche-express-address-step.aria.yml
@@ -1,8 +1,7 @@
 - main:
   - heading "Où est située la friche ?" [level=2]
-  - combobox:
-    - text: Commune ou code postal *
-    - searchbox "Commune ou code postal *"
+  - text: Commune ou code postal *
+  - combobox "Commune ou code postal *"
   - list:
     - listitem:
       - button "Précédent"

--- a/apps/e2e-tests/tests/site-creation/natural-area/create-custom-natural-area.spec.ts-snapshots/natural-area-custom-address-step.aria.yml
+++ b/apps/e2e-tests/tests/site-creation/natural-area/create-custom-natural-area.spec.ts-snapshots/natural-area-custom-address-step.aria.yml
@@ -1,8 +1,7 @@
 - main:
   - heading "Où est situé l'espace naturel ?" [level=2]
-  - combobox:
-    - text: Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète
-    - searchbox "Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète"
+  - text: Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète
+  - combobox "Adresse * Entrez le nom de la commune, le code postal ou l'adresse complète"
   - list:
     - listitem:
       - button "Précédent"

--- a/apps/e2e-tests/tests/site-creation/natural-area/create-express-natural-area.spec.ts-snapshots/natural-area-express-address-step.aria.yml
+++ b/apps/e2e-tests/tests/site-creation/natural-area/create-express-natural-area.spec.ts-snapshots/natural-area-express-address-step.aria.yml
@@ -1,8 +1,7 @@
 - main:
   - heading "Où est situé l'espace naturel ?" [level=2]
-  - combobox:
-    - text: Commune ou code postal *
-    - searchbox "Commune ou code postal *"
+  - text: Commune ou code postal *
+  - combobox "Commune ou code postal *"
   - list:
     - listitem:
       - button "Précédent"

--- a/apps/web/src/features/onboarding/views/pages/identity/CreateUserForm/CreateUserStructureForm.tsx
+++ b/apps/web/src/features/onboarding/views/pages/identity/CreateUserForm/CreateUserStructureForm.tsx
@@ -190,16 +190,13 @@ function UserStructureForm({ administrativeDivisionService, formContext }: Props
               setValue("selectedStructureMunicipality", value, { shouldValidate: true });
               setValue("structureMunicipalityText", municipalities[value]?.label);
             }}
-          >
-            <Input
-              label={<RequiredLabel label="Commune ou code postal" />}
-              state={formState.errors.selectedStructureMunicipality ? "error" : "default"}
-              stateRelatedMessage={
-                formState.errors.selectedStructureMunicipality
-                  ? formState.errors.selectedStructureMunicipality.message
-                  : undefined
-              }
-              nativeInputProps={{
+            inputProps={{
+              label: <RequiredLabel label="Commune ou code postal" />,
+              state: formState.errors.selectedStructureMunicipality ? "error" : "default",
+              stateRelatedMessage: formState.errors.selectedStructureMunicipality
+                ? formState.errors.selectedStructureMunicipality.message
+                : undefined,
+              nativeInputProps: {
                 placeholder: "38000, Angers...",
                 value: structureMunicipalityText ?? "",
                 onChange: (e: ChangeEvent<HTMLInputElement>) => {
@@ -207,9 +204,9 @@ function UserStructureForm({ administrativeDivisionService, formContext }: Props
                   setValue("selectedStructureMunicipality", undefined);
                   void onSearch(e.target.value);
                 },
-              }}
-            />
-          </Autocomplete>
+              },
+            }}
+          />
           {selectedStructureMunicipality && (
             <Select
               options={

--- a/apps/web/src/shared/views/components/Autocomplete/Autocomplete.tsx
+++ b/apps/web/src/shared/views/components/Autocomplete/Autocomplete.tsx
@@ -1,6 +1,7 @@
 import { fr } from "@codegouvfr/react-dsfr";
+import Input, { InputProps } from "@codegouvfr/react-dsfr/Input";
 import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from "@headlessui/react";
-import { Fragment, ReactNode } from "react";
+import { ComponentPropsWithRef, Fragment } from "react";
 
 import classNames, { ClassValue } from "../../clsx";
 
@@ -9,7 +10,7 @@ type Props = {
   value?: string;
   onSelect: (value: string) => void;
   className?: ClassValue;
-  children: ReactNode;
+  inputProps: InputProps.RegularInput;
 };
 
 const SCROLLBAR_CLASSES = [
@@ -21,7 +22,42 @@ const SCROLLBAR_CLASSES = [
   "dark:[&::-webkit-scrollbar-thumb]:bg-neutral-500",
 ];
 
-function Autocomplete({ options, value, onSelect, className, children }: Props) {
+type ComboboxNativeInputProps = Omit<ComponentPropsWithRef<"input">, "defaultValue"> & {
+  defaultValue?: string;
+  dsfrInputProps: Omit<InputProps.RegularInput, "nativeInputProps">;
+};
+
+/**
+ * HeadlessUI's <ComboboxInput> renders whatever it's given as `as` and injects its own DOM
+ * wiring (ref, onChange/onKeyDown/onFocus/onBlur, role="combobox", aria-*) directly onto it,
+ * expecting that element to forward all of it straight to a real native <input>. DSFR's <Input>
+ * instead forwards its own `ref` (and any unrecognised props) to its OUTER wrapping <div> — so
+ * used directly, HeadlessUI's wiring would land on that div instead of the actual input: broken
+ * aria attributes, and a crash the moment HeadlessUI's own effects call
+ * `inputRef.current.setSelectionRange(...)`, since a <div> has no such method (hit both via
+ * Playwright's `fill()` and via the browser's native "clear" (×) button on `type="search"`
+ * fields, which mutates the DOM value directly the same way).
+ *
+ * This adapter is what HeadlessUI actually clones/injects into, and routes everything —
+ * including `ref` — into `nativeInputProps`, which DSFR's <Input> spreads directly onto the
+ * real <input> element.
+ */
+function ComboboxNativeInput({
+  ref,
+  dsfrInputProps,
+  ...nativeInputProps
+}: ComboboxNativeInputProps) {
+  return <Input {...dsfrInputProps} nativeInputProps={{ ...nativeInputProps, ref }} />;
+}
+
+function Autocomplete({ options, value, onSelect, className, inputProps }: Props) {
+  const { nativeInputProps, ...dsfrInputProps } = inputProps;
+  // `defaultValue` is typed as `string | number | readonly string[]` on nativeInputProps (the
+  // generic HTML input attributes shape) but ComboboxInput narrows it to `string`; this field is
+  // unused by every current caller of Autocomplete, so drop it rather than widen the adapter.
+  const { defaultValue: _unusedDefaultValue, ...nativeInputPropsWithoutDefaultValue } =
+    nativeInputProps ?? {};
+
   return (
     <div className={classNames(className)}>
       <Combobox
@@ -32,7 +68,18 @@ function Autocomplete({ options, value, onSelect, className, children }: Props) 
           }
         }}
       >
-        <ComboboxInput as={Fragment}>{children}</ComboboxInput>
+        <ComboboxInput
+          as={ComboboxNativeInput}
+          dsfrInputProps={dsfrInputProps}
+          // Keeps HeadlessUI's own DOM-value restoration (it writes to the input's value
+          // outside of React whenever the combobox's selected value changes) consistent with
+          // the label the consumer already displays for that same value, instead of falling
+          // back to the raw option value (e.g. a BAN id) once no `displayValue` is given.
+          displayValue={(optionValue: string) =>
+            options.find((option) => option.value === optionValue)?.label ?? ""
+          }
+          {...nativeInputPropsWithoutDefaultValue}
+        />
         <ComboboxOptions anchor="bottom start">
           <ul
             className={classNames(

--- a/apps/web/src/shared/views/components/form/Address/SearchAddressAutocompleteInput.spec.tsx
+++ b/apps/web/src/shared/views/components/form/Address/SearchAddressAutocompleteInput.spec.tsx
@@ -1,42 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AddressWithBanId } from "@/shared/core/gateways/AddressSearchGateway";
 
 import SearchAddressAutocompleteInput from "./SearchAddressAutocompleteInput";
-
-// Mock Autocomplete to avoid HeadlessUI Combobox jsdom incompatibilities
-// (ComboboxInput event handlers are disconnected from native input through DSFR Input wrapper).
-// This tests SearchAddressAutocompleteInput's logic without HeadlessUI internals.
-vi.mock("../../Autocomplete/Autocomplete", () => ({
-  default: ({
-    options,
-    onSelect,
-    children,
-  }: {
-    options: { label: string; value: string }[];
-    onSelect: (value: string) => void;
-    children: ReactNode;
-  }) => (
-    <div>
-      {children}
-      <ul role="listbox">
-        {options.map((opt) => (
-          <li
-            key={opt.value}
-            role="option"
-            onClick={() => {
-              onSelect(opt.value);
-            }}
-          >
-            {opt.label}
-          </li>
-        ))}
-      </ul>
-    </div>
-  ),
-}));
 
 const SEARCH_INPUT_LABEL = "Adresse";
 
@@ -63,6 +30,13 @@ const defaultProps = () => ({
 });
 
 const getSearchInput = () => screen.getByLabelText(SEARCH_INPUT_LABEL);
+
+// The options list only renders once the combobox is open; querying by role="option" beforehand
+// finds nothing even when suggestions were passed in. Arrow-down is a realistic way a user (or a
+// screen reader) opens it without typing.
+const openDropdown = () => {
+  fireEvent.keyDown(getSearchInput(), { key: "ArrowDown" });
+};
 
 describe("SearchAddressAutocompleteInput", () => {
   it("renders input with search text passed as prop", () => {
@@ -102,8 +76,11 @@ describe("SearchAddressAutocompleteInput", () => {
       />,
     );
 
+    openDropdown();
     const option = screen.getByRole("option", { name: /1 rue de la Paix/ });
-    fireEvent.click(option);
+    // HeadlessUI selects an option on mousedown (so the selection commits before the input's
+    // blur closes the dropdown), not on click.
+    fireEvent.mouseDown(option, { button: 0 });
 
     expect(onSearchTextChange).toHaveBeenCalledWith(address.value);
     expect(onSelectedAddressChange).toHaveBeenCalledWith(address);
@@ -124,6 +101,7 @@ describe("SearchAddressAutocompleteInput", () => {
       />,
     );
 
+    openDropdown();
     const option = screen.getByRole("option", { name: "Montrouge (92120)" });
     expect(option).toBeInTheDocument();
   });
@@ -136,6 +114,7 @@ describe("SearchAddressAutocompleteInput", () => {
 
     render(<SearchAddressAutocompleteInput {...defaultProps()} suggestions={addresses} />);
 
+    openDropdown();
     expect(screen.getByRole("option", { name: "1 rue de la Paix, Paris" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "2 avenue des Champs, Paris" })).toBeInTheDocument();
   });

--- a/apps/web/src/shared/views/components/form/Address/SearchAddressAutocompleteInput.tsx
+++ b/apps/web/src/shared/views/components/form/Address/SearchAddressAutocompleteInput.tsx
@@ -1,4 +1,4 @@
-import Input, { InputProps } from "@codegouvfr/react-dsfr/Input";
+import { InputProps } from "@codegouvfr/react-dsfr/Input";
 import { ChangeEvent } from "react";
 import type { Address } from "shared";
 
@@ -58,10 +58,9 @@ const SearchAddressAutocompleteInput = ({
       value={autocompleteValue}
       options={options}
       onSelect={handleSelect}
-    >
-      <Input
-        {...searchInputProps}
-        nativeInputProps={{
+      inputProps={{
+        ...searchInputProps,
+        nativeInputProps: {
           ...searchInputProps.nativeInputProps,
           value: searchText,
           type: "search",
@@ -69,9 +68,9 @@ const SearchAddressAutocompleteInput = ({
             onSearchTextChange(e.target.value);
             onSelectedAddressChange(undefined);
           },
-        }}
-      />
-    </Autocomplete>
+        },
+      }}
+    />
   );
 };
 

--- a/apps/web/src/test/setupTestEnv.ts
+++ b/apps/web/src/test/setupTestEnv.ts
@@ -11,3 +11,14 @@ vi.stubGlobal("CSS", {
     return true;
   }),
 });
+
+// jsdom doesn't implement ResizeObserver; HeadlessUI's Combobox uses it (via floating-ui) to
+// track its anchored options panel's size.
+vi.stubGlobal(
+  "ResizeObserver",
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);


### PR DESCRIPTION
## Summary
- DSFR's `<Input>` forwards its `ref` to its outer wrapping `<div>`, not the actual `<input>`. `Autocomplete.tsx` rendered `<ComboboxInput as={Fragment}>` around a full `<Input>`, so HeadlessUI's injected ref, `onChange`, and ARIA wiring (`role="combobox"`, `aria-expanded`, etc.) silently landed on that div instead of the real input.
- This broke combobox accessibility semantics and crashed the page (`setSelectionRange is not a function`) the moment HeadlessUI's own effects tried to manage input selection — reproduced both via Playwright's `fill()` in e2e tests and via a real user clicking the browser's native "×" clear button on `type="search"` fields (confirmed live in Chrome, no console errors after the fix).
- Introduces a small adapter component as `ComboboxInput`'s `as` target that routes everything HeadlessUI injects — `ref` included — into `nativeInputProps`, which DSFR's `<Input>` spreads directly onto the real input. Also supplies `displayValue` so HeadlessUI's own DOM-value restoration stays consistent with the label already shown for the selected option.
- Un-mocked `SearchAddressAutocompleteInput.spec.tsx` (previously mocked specifically to sidestep this integration) now that it passes for real, and added a `ResizeObserver` stub to the test setup (needed by HeadlessUI's floating-ui positioning, missing from jsdom).
- The address field's accessible role correctly changes from the browser's implicit `searchbox` (from `type="search"`) to the ARIA-correct `combobox` (a text input controlling a listbox popup) now that the role reaches the real input. Updated `SiteCreationPage.fillAddress()`'s locator and regenerated the 6 affected e2e aria-snapshot baselines accordingly (hand-reviewed — the only change in each is the wrapper/role restructuring).

## Test plan
- [x] `pnpm --filter web typecheck && pnpm --filter web lint && pnpm --filter web format:check`
- [x] `pnpm --filter web test` — 256 files / 1288 tests pass
- [x] `pnpm --filter e2e-tests typecheck && pnpm --filter e2e-tests lint && pnpm --filter e2e-tests format:check`
- [x] `pnpm --filter e2e-tests test:headless tests/site-creation/` — 9/9 pass
- [x] `pnpm --filter e2e-tests test:headless tests/onboarding/` — 3/3 pass
- [x] Live Chrome verification: typed a multi-word address, selected a suggestion, clicked the native "×" clear button — no crash, no console errors, field works normally afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)